### PR TITLE
test: VC-1 hermetic end-to-end approval round trip

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,6 +19,9 @@
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>
+        <testsuite name="EndToEnd">
+            <directory>tests/EndToEnd</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/tests/EndToEnd/ApprovalRoundTripTest.php
+++ b/tests/EndToEnd/ApprovalRoundTripTest.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Actions\ActionContext;
+use Fissible\Verdict\Actions\ActionEnvelope;
+use Fissible\Verdict\Actions\AuthorizedAction;
+use Fissible\Verdict\Capabilities\Capability;
+use Fissible\Verdict\Capabilities\CapabilityRegistry;
+use Fissible\Verdict\Contracts\CapabilityAuthorizer;
+use Fissible\Verdict\Decisions\Decision;
+use Fissible\Verdict\LaravelAi\VerdictApprovalMiddleware;
+use Fissible\Verdict\Targets\ExecutionTargetPolicy;
+use Fissible\Verdict\VerdictManager;
+use Fissible\VerdictConsole\Tests\EndToEndTestCase;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Approvals\Decision as AiDecision;
+use Laravel\Ai\Approvals\Decisions;
+use Laravel\Ai\Concerns\RemembersConversations as RemembersConversationsTrait;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasMiddleware;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Contracts\RemembersConversations as RemembersConversationsContract;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Tools\Request;
+
+const TOOL_CALL_ID = 'call_round_trip';
+const ORDER_ID = 1001;
+
+/** Counts executions across a whole test. The one number the round trip is really about. */
+final class RoundTripLedger
+{
+    public int $executions = 0;
+}
+
+final readonly class RoundTripOrder
+{
+    public function __construct(public int $id) {}
+}
+
+final readonly class RoundTripCustomer
+{
+    public function __construct(public int $id) {}
+}
+
+final class CancelOrderTool implements Tool
+{
+    public function description(): Stringable|string
+    {
+        return 'Cancel an order by id.';
+    }
+
+    public function handle(Request $request): Stringable|string
+    {
+        return 'The Verdict-bound tool handles this.';
+    }
+
+    /** @return array<string, Type> */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}
+
+/**
+ * Builds the bound tool, registering the capability once per container.
+ *
+ * The capability declares an execution-target policy deliberately: `requiresConfirmation()` without
+ * one makes `VerdictManager::requestConfirmation()` return null, so the run never pauses, no
+ * approval is ever requested, and this whole test would pass vacuously (design §12, verdict#230).
+ */
+function roundTripTool(): Tool
+{
+    $verdict = app(VerdictManager::class);
+
+    if (! app(CapabilityRegistry::class)->has('orders.cancel')) {
+        $verdict->capability(
+            Capability::usingPolicy(
+                name: 'orders.cancel',
+                ability: 'update',
+                resolveTarget: fn (ActionEnvelope $e): RoundTripOrder => new RoundTripOrder(
+                    (int) $e->proposal->arguments['order_id'],
+                ),
+            )
+                ->executionTarget(ExecutionTargetPolicy::acceptStaleSnapshot(
+                    name: 'round-trip-target',
+                    // Identity is the order id, not spl_object_id: the proposal and the execution
+                    // resolve two different PHP objects for the same order.
+                    identityUsing: fn (ActionEnvelope $e, RoundTripOrder $t): array => ['id' => $t->id],
+                ))
+                ->requiresConfirmation(fn (ActionEnvelope $e, RoundTripOrder $t): array => ['order_id' => $t->id])
+                ->executeUsing(function (AuthorizedAction $a): string {
+                    app(RoundTripLedger::class)->executions++;
+
+                    return 'Order cancelled.';
+                }),
+        );
+    }
+
+    return $verdict->bound(new CancelOrderTool, 'orders.cancel', new ActionContext('customer-7'));
+}
+
+/**
+ * The agent under test.
+ *
+ * Three declarations here are load-bearing, and each fails differently when omitted (design §3, §12):
+ *
+ * - `RemembersConversationsContract` extends `Conversational`, which is what
+ *   `throwIfNotResumable()` checks. Without it the run raises `ApprovalNotResumableException` the
+ *   moment it would pause — a **loud** failure.
+ * - The `RemembersConversations` *trait* plus a conversation store is what makes the paused turn
+ *   durable. Without it the resume silently records nothing — the **quiet** failure, and the one a
+ *   cross-process console would actually hit.
+ * - `VerdictApprovalMiddleware` is **not** auto-registered. Without it
+ *   `ApprovalExecutionContext::allows()` is false for every call and an approved receipt fails
+ *   proposal-validation with `invalid_state`.
+ */
+final class RoundTripAgent implements Agent, HasMiddleware, HasTools, RemembersConversationsContract
+{
+    use Promptable;
+    use RemembersConversationsTrait;
+
+    public function instructions(): Stringable|string
+    {
+        return 'Cancel orders when asked.';
+    }
+
+    /**
+     * Built here rather than injected: the bound tool closes over VerdictManager, and an agent
+     * holding one as a property cannot be serialized onto a queue later.
+     *
+     * @return array<int, Tool>
+     */
+    public function tools(): array
+    {
+        return [roundTripTool()];
+    }
+
+    /** @return array<int, object> */
+    public function middleware(): array
+    {
+        return [app(VerdictApprovalMiddleware::class)];
+    }
+
+    public function provider(): string
+    {
+        return EndToEndTestCase::PROVIDER;
+    }
+
+    public function maxSteps(): int
+    {
+        return 3;
+    }
+}
+
+beforeEach(function (): void {
+    $this->migrateRoundTripTables();
+
+    $this->app->instance(RoundTripLedger::class, new RoundTripLedger);
+
+    // A stub authorizer keeps this test about the approval round trip rather than about policy
+    // resolution. Every permit below is the authorizer's, never a Verdict default.
+    $this->app->instance(CapabilityAuthorizer::class, new class implements CapabilityAuthorizer
+    {
+        public function decide(Capability $capability, ActionEnvelope $envelope, mixed $target): Decision
+        {
+            return Decision::permit('test');
+        }
+    });
+});
+
+/** Pause the run and return the tool call id Verdict issued a receipt for. */
+function pauseForApproval(RoundTripAgent $agent): string
+{
+    $paused = $agent->prompt('Please cancel order '.ORDER_ID.'.');
+
+    expect($paused->hasPendingApprovals())->toBeTrue('A confirmation-gated capability must pause the run.')
+        ->and(app(RoundTripLedger::class)->executions)->toBe(0, 'The executor must not run before a human decides.');
+
+    return $paused->pendingApprovals->first()->id;
+}
+
+/**
+ * The round trip this package exists to automate, driven end to end with no network.
+ *
+ * VC-1's job is to force every design §12 hazard into the open before any of the runtime is built,
+ * because this is the path where the design can be *wrong* rather than merely late.
+ */
+it('executes a confirmation-gated capability exactly once across a pause, an approval, and a resume', function (): void {
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->toolCallResponse(TOOL_CALL_ID, 'CancelOrderTool', ['order_id' => ORDER_ID]))
+            ->push($this->textResponse('Order cancelled.')),
+    ]);
+
+    $agent = (new RoundTripAgent)->forParticipant(new RoundTripCustomer(7));
+
+    $toolCallId = pauseForApproval($agent);
+
+    // The human decision happens in Verdict, through its own authenticated flow. The agent
+    // framework's decision below is not a substitute for it — approving only there leaves the
+    // receipt unapproved and the resume denies at execution.
+    $approvals = app(VerdictManager::class)->approvals();
+    $challenge = $approvals->challengeForToolCall($toolCallId);
+
+    expect($challenge)->not->toBeNull('A pending receipt must yield a challenge for the approver to read.');
+
+    $approvals->approve($challenge->receiptId, $challenge->toolCallId, 'operator-1');
+
+    // A decision keyed by this exact tool call. `Decision::approveAll()` yields a wildcard that
+    // `ApprovalExecutionContext::push()` deliberately skips, so a blanket approval from the agent
+    // loop cannot authorize a specific consequential action.
+    $agent->prompt(Decisions::from([$toolCallId => AiDecision::approve()]));
+
+    expect(app(RoundTripLedger::class)->executions)->toBe(1, 'An approved, specifically-decided resume must execute exactly once.');
+
+    Http::assertSentCount(2);
+});
+
+/**
+ * The other half of "never hangs": a denial has to end the run cleanly rather than leave the agent
+ * waiting on a decision that already happened.
+ */
+it('returns a clean refusal without executing when the human denies', function (): void {
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->toolCallResponse(TOOL_CALL_ID, 'CancelOrderTool', ['order_id' => ORDER_ID]))
+            ->push($this->textResponse('I did not cancel the order.')),
+    ]);
+
+    $agent = (new RoundTripAgent)->forParticipant(new RoundTripCustomer(7));
+
+    $toolCallId = pauseForApproval($agent);
+
+    $approvals = app(VerdictManager::class)->approvals();
+    $challenge = $approvals->challengeForToolCall($toolCallId);
+    $approvals->reject($challenge->receiptId, $challenge->toolCallId, 'operator-1');
+
+    $resumed = $agent->prompt(Decisions::from([$toolCallId => AiDecision::reject()]));
+
+    expect($resumed)->not->toBeNull('A denied resume must return, not hang.')
+        ->and($resumed->hasPendingApprovals())->toBeFalse('A decided call must not still be pending.')
+        ->and(app(RoundTripLedger::class)->executions)->toBe(0, 'A denial must not execute the capability.');
+});
+
+/**
+ * The trap that makes every other assertion here vacuous, asserted directly so it cannot rot: a
+ * capability that asks for confirmation without an execution-target policy never pauses at all.
+ */
+it('never pauses when a confirmation-gated capability has no execution-target policy', function (): void {
+    app(VerdictManager::class)->capability(
+        Capability::usingPolicy(
+            name: 'orders.cancel-no-target',
+            ability: 'update',
+            resolveTarget: fn (ActionEnvelope $e): RoundTripOrder => new RoundTripOrder((int) $e->proposal->arguments['order_id']),
+        )
+            ->requiresConfirmation(fn (ActionEnvelope $e, RoundTripOrder $t): array => ['order_id' => $t->id])
+            ->executeUsing(fn (AuthorizedAction $a): string => 'Order cancelled.'),
+    );
+
+    $tool = app(VerdictManager::class)->bound(new CancelOrderTool, 'orders.cancel-no-target', new ActionContext('customer-7'));
+
+    expect($tool->shouldRequestApproval(new Request(['order_id' => ORDER_ID], 'no-target-call')))->toBeNull(
+        'A confirmation gate with no execution target never asks Laravel AI to pause, so it never reaches this package. '
+        .'The preflight doctor (VC-3) exists to catch this before it reaches a deployment.',
+    );
+});

--- a/tests/EndToEndTestCase.php
+++ b/tests/EndToEndTestCase.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Tests;
+
+use Fissible\Verdict\VerdictServiceProvider;
+use Fissible\VerdictConsole\VerdictConsoleServiceProvider;
+use Illuminate\Foundation\Application;
+use Laravel\Ai\AiServiceProvider;
+use Orchestra\Testbench\TestCase as Orchestra;
+
+/**
+ * The heavy base case, for tests that must exercise the real Verdict + Laravel AI stack.
+ *
+ * {@see TestCase} deliberately boots only the console's provider so the unit suite stays fast and
+ * independent of Verdict's boot. That is the right default and is unchanged. This class is the
+ * explicit opposite: it boots all three providers because the approval round trip has no meaning
+ * without them — the pause comes from Laravel AI, the receipt from Verdict, and the tissue between
+ * them is what this package exists to be.
+ *
+ * Everything here is still hermetic. No network, no credentials: the provider is an
+ * `openai_compatible` driver pointed at a URL that only ever answers through `Http::fake()`.
+ */
+abstract class EndToEndTestCase extends Orchestra
+{
+    /**
+     * The provider name the end-to-end agents use.
+     */
+    public const string PROVIDER = 'console_e2e';
+
+    /**
+     * The model name that provider reports. Only ever echoed back by the faked transport.
+     */
+    public const string MODEL = 'console-e2e-model';
+
+    /**
+     * The base URL the faked transport answers for. Never resolved — `Http::fake()` intercepts
+     * before DNS, so this host does not exist and must not.
+     */
+    public const string BASE_URL = 'https://openai-compatible.invalid/v1';
+
+    /**
+     * @param  Application  $app
+     * @return array<int, class-string>
+     */
+    protected function getPackageProviders($app): array
+    {
+        return [
+            AiServiceProvider::class,
+            VerdictServiceProvider::class,
+            VerdictConsoleServiceProvider::class,
+        ];
+    }
+
+    /**
+     * @param  Application  $app
+     */
+    protected function defineEnvironment($app): void
+    {
+        // An OpenAI-compatible provider is the cheapest real gateway to drive over a faked
+        // transport: it posts to `chat/completions` through Laravel's HTTP client, which
+        // `Http::fake()` intercepts. A driver-specific provider would work equally well; this one
+        // needs no vendor-shaped envelope beyond the chat-completions body.
+        $app['config']->set('ai.providers.'.self::PROVIDER, [
+            'driver' => 'openai_compatible',
+            'key' => 'not-a-real-key',
+            'url' => self::BASE_URL,
+            'models' => ['text' => ['default' => self::MODEL]],
+        ]);
+
+        // Titling a conversation would spend a second faked response on a turn nothing asserts on.
+        $app['config']->set('ai.conversations.generate_title', false);
+    }
+
+    /**
+     * Create the tables the round trip genuinely needs.
+     *
+     * Verdict's shipped default approval store is the *database* one, and Laravel AI reconstructs a
+     * paused tool call from conversation history — so both sets of tables are preconditions of the
+     * round trip, not test scaffolding.
+     */
+    protected function migrateRoundTripTables(): void
+    {
+        $verdict = dirname(__DIR__).'/vendor/fissible/verdict/database/migrations';
+        $ai = dirname(__DIR__).'/vendor/laravel/ai/database/migrations';
+
+        (require $verdict.'/create_verdict_approval_receipts_table.php.stub')->up();
+        (require $verdict.'/add_proposal_provenance_to_verdict_approval_receipts_table.php.stub')->up();
+        (require $ai.'/2026_01_11_000001_create_agent_conversations_table.php')->up();
+    }
+
+    /**
+     * A chat-completions body carrying a single tool call.
+     *
+     * @param  array<string, mixed>  $arguments
+     * @return array<string, mixed>
+     */
+    protected function toolCallResponse(string $toolCallId, string $toolName, array $arguments): array
+    {
+        return [
+            'model' => self::MODEL,
+            'choices' => [[
+                'message' => [
+                    'content' => '',
+                    'tool_calls' => [[
+                        'id' => $toolCallId,
+                        'type' => 'function',
+                        'function' => ['name' => $toolName, 'arguments' => json_encode($arguments)],
+                    ]],
+                ],
+                'finish_reason' => 'tool_calls',
+            ]],
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+        ];
+    }
+
+    /**
+     * A chat-completions body carrying a final assistant message.
+     *
+     * @return array<string, mixed>
+     */
+    protected function textResponse(string $text): array
+    {
+        return [
+            'model' => self::MODEL,
+            'choices' => [[
+                'message' => ['content' => $text],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+        ];
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,6 +2,12 @@
 
 declare(strict_types=1);
 
+use Fissible\VerdictConsole\Tests\EndToEndTestCase;
 use Fissible\VerdictConsole\Tests\TestCase;
 
 uses(TestCase::class)->in('Feature');
+
+// The end-to-end suite boots Verdict and Laravel AI as well as this package. It is deliberately a
+// separate directory rather than a heavier default: the Feature suite must stay independent of
+// Verdict's boot, and this one cannot be.
+uses(EndToEndTestCase::class)->in('EndToEnd');


### PR DESCRIPTION
Closes #1. The walking skeleton: **pause → approve → resume → the tool executes exactly once**, plus the deny path, with no network and no credentials.

## Hermetic without faking the thing under test

VC-1 asks for a *real* gateway driven by `Http::fake()`, and that turns out to be viable for a specific reason worth recording: laravel/ai builds every provider client through Illuminate's HTTP client (`Gateway/Concerns/CreatesClient.php` → `Http::baseUrl(...)`), so `Http::fake()` intercepts it. The test therefore drives the genuine `openai_compatible` gateway, request builder, chat-completions response parser, generation loop, and resume path — only the transport is faked.

- `Agent::fake()` was not an option: it never resumes tools, so it cannot express this round trip at all.
- The base URL is an `.invalid` host that must never resolve.
- `Http::assertSentCount(2)` means the test cannot pass by never calling the provider.

## Every §12 hazard forced into the open

Each of these is silent-failure-shaped, and each is now load-bearing in a passing test rather than a line in a doc:

| Hazard | How the test pins it |
|---|---|
| `requiresConfirmation()` with no `executionTarget()` never pauses | capability declares one — **and a third test asserts the trap directly** |
| `VerdictApprovalMiddleware` is not auto-registered | agent declares it via `HasMiddleware` |
| Approving in the agent loop ≠ approving in Verdict | receipt approved through `ApprovalManager` |
| `approveAll()`'s wildcard is deliberately skipped | resume carries a decision keyed by the tool call |
| `Conversational` gates pause/resume — **loudly** | agent implements it (via `RemembersConversations`) |
| The `RemembersConversations` trait + store gates durability — **silently** | agent uses the trait; conversation tables migrated |

## Mutation-checked

Removing the Verdict-side `approve()`, and substituting `approveAll()`, **each fail the exactly-once assertion and no other test**. Without that, "executes once" is a number that could be right by accident.

## The third test earns its place

A confirmation gate with no execution-target policy never pauses, so it never reaches this package — which would make the other two assertions vacuous rather than false. That is precisely what VC-3's preflight doctor exists to catch before a deployment does, so it is pinned here now.

## Suite layout

`tests/TestCase.php` deliberately boots only this package, so the unit suite stays independent of Verdict's boot. That stays true. `EndToEndTestCase` is the explicit opposite — all three providers — in its own `tests/EndToEnd` directory with its own Pest binding and phpunit suite, rather than making the default heavier.

## Verification

`composer test` green: PHPStan clean, Pint clean, **100% type coverage**, 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)