### PR TITLE
feat: VC-4 PendingApproval index, migration, and store

### DIFF
--- a/database/migrations/create_verdict_console_pending_approvals_table.php.stub
+++ b/database/migrations/create_verdict_console_pending_approvals_table.php.stub
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('verdict_console_pending_approvals', function (Blueprint $table): void {
+            // Surrogate primary key. Deliberately NOT the receipt id: a Laravel AI approval can
+            // arrive with no Verdict receipt behind it — a non-BoundTool approval, or an ambiguous
+            // tool-call id — and those rows must still exist so they can be shown as
+            // not-console-actionable rather than dropped. (Design §3, §6.1, §6.3.)
+            $table->uuid('id')->primary();
+
+            // Ingest idempotency. Deterministic and NOT NULL on purpose: the natural key is
+            // tool_call_id + conversation_id, but conversation_id is nullable, and a UNIQUE index
+            // over a nullable column does not constrain rows where that column is NULL — two NULLs
+            // never compare equal. Hashing to a non-null column is what makes a redelivered
+            // ToolApprovalRequested collide instead of duplicating.
+            $table->char('ingest_key', 64)->unique();
+
+            // The authoritative reference to Verdict's receipt, when there is one. Nullable, and
+            // unique *when present* — which is exactly what a UNIQUE index over a nullable column
+            // gives, since NULLs do not collide. The same NULL semantics that break the composite
+            // key above are the reason this one needs no extra work.
+            $table->string('receipt_id')->nullable()->unique();
+
+            // Correlation captured at pause time. This is the only moment these are all available
+            // together; none is recoverable afterwards. (Design §6.1.)
+            $table->string('tool_call_id')->index();
+            $table->string('conversation_id')->nullable()->index();
+            $table->string('conversation_user')->nullable();
+
+            // Carried for evidence correlation (design §6.6): DecisionEvidence records an
+            // invocation id but no conversation id, so this row is the only place the two meet.
+            // It is never an identity: a two-turn resume mints a second invocation id.
+            $table->string('invocation_id')->nullable()->index();
+
+            // The host-defined key naming how to rebuild this agent (VC-2). Opaque to this table.
+            // Nullable because a receiptless or unresolvable row is still recorded.
+            $table->string('resolver_key')->nullable();
+
+            // Display-safe projection of the proposed action (VC-8). Opaque here; this table stores
+            // it, and never derives it, so no raw argument reaches the console by way of storage.
+            $table->json('presentation')->nullable();
+
+            // Whether *this console* can drive the run — never a statement about the receipt's
+            // validity, which is read live from Verdict. (Design §6.1.)
+            $table->string('resumability', 16)->index();
+
+            // Deliberately absent: any mirror of the receipt's status, and any expiry column.
+            // Receipt TTL and state stay Verdict's; a second copy is exactly the divergence the
+            // design avoids. (Design §5, §6.1.)
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('verdict_console_pending_approvals');
+    }
+};

--- a/database/migrations/create_verdict_console_pending_approvals_table.php.stub
+++ b/database/migrations/create_verdict_console_pending_approvals_table.php.stub
@@ -34,7 +34,18 @@ return new class extends Migration
             // together; none is recoverable afterwards. (Design §6.1.)
             $table->string('tool_call_id')->index();
             $table->string('conversation_id')->nullable()->index();
-            $table->string('conversation_user')->nullable();
+
+            // An OPAQUE, host-supplied reference to the participant — never Laravel AI's
+            // `conversationUser` object, and never a class-name-plus-id convention.
+            //
+            // `ToolApprovalRequested` carries a live participant *object*. It is not durable, and
+            // reconstructing one from `ClassName:7` is a convention this package must not invent:
+            // it silently guesses at a host's identity model, and it is wrong the moment a
+            // participant needs a tenant, a guard, or a constructor argument. So nothing here
+            // interprets this column. A host that needs a participant attached on resume supplies
+            // both the reference and the resolver that turns it back into an object; a host that
+            // does not leaves this null, and the resume runs without a participant.
+            $table->string('participant_reference')->nullable();
 
             // Carried for evidence correlation (design §6.6): DecisionEvidence records an
             // invocation id but no conversation id, so this row is the only place the two meet.

--- a/src/Approvals/PendingApproval.php
+++ b/src/Approvals/PendingApproval.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * The console's queryable index of paused approvals.
+ *
+ * Verdict's `ApprovalReceiptStore` exposes `findForToolCall()` and the transition methods, but no
+ * `find(receiptId)` and no list or query API — so an inbox cannot be built by enumerating receipts.
+ * This table is that index. It is not a second authorization authority and holds no copy of the
+ * receipt's status: authoritative state is read live via `ApprovalManager::challengeForToolCall()`.
+ * (Design §5, §6.1.)
+ *
+ * @property string $id
+ * @property string $ingest_key
+ * @property string|null $receipt_id
+ * @property string $tool_call_id
+ * @property string|null $conversation_id
+ * @property string|null $conversation_user
+ * @property string|null $invocation_id
+ * @property string|null $resolver_key
+ * @property array<string, mixed>|null $presentation
+ * @property Resumability $resumability
+ */
+final class PendingApproval extends Model
+{
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $table = 'verdict_console_pending_approvals';
+
+    protected $guarded = [];
+
+    /**
+     * The deterministic ingest key for a pause.
+     *
+     * The natural key is the tool call plus its conversation, but `conversation_id` is nullable and
+     * a UNIQUE index does not constrain rows where a column is NULL — two NULLs never compare
+     * equal, so a redelivered event for a conversationless pause would insert a second row. Hashing
+     * both into one non-null column is what makes redelivery collide. The sentinel is explicit so a
+     * literal conversation id of `"-"` cannot impersonate absence.
+     */
+    public static function ingestKey(string $toolCallId, ?string $conversationId): string
+    {
+        return hash('sha256', json_encode([
+            'tool_call_id' => $toolCallId,
+            'conversation_id' => $conversationId,
+            'conversation_present' => $conversationId !== null,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'presentation' => 'array',
+            'resumability' => Resumability::class,
+        ];
+    }
+}

--- a/src/Approvals/PendingApproval.php
+++ b/src/Approvals/PendingApproval.php
@@ -20,7 +20,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property string|null $receipt_id
  * @property string $tool_call_id
  * @property string|null $conversation_id
- * @property string|null $conversation_user
+ * @property string|null $participant_reference
  * @property string|null $invocation_id
  * @property string|null $resolver_key
  * @property array<string, mixed>|null $presentation

--- a/src/Approvals/PendingApprovalStore.php
+++ b/src/Approvals/PendingApprovalStore.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Str;
+
+/**
+ * Writes and reads the console's index of paused approvals.
+ *
+ * The only interesting thing here is `ingest()`, and the only interesting thing about `ingest()` is
+ * that it does not read before it writes.
+ */
+final class PendingApprovalStore
+{
+    /**
+     * Record a pause, or return the row that already records it.
+     *
+     * **First-write-wins, and atomic.** A redelivered `ToolApprovalRequested` — the same pause
+     * arriving twice — must not produce a second row, and the obvious implementation
+     * (`if (! exists) { insert }`) cannot guarantee that: two workers can both pass the existence
+     * check before either writes. Delegating the decision to the unique index closes that window
+     * entirely, because there is no window. The database picks the winner.
+     *
+     * First-write-wins rather than last-write-wins is deliberate: by the time a redelivery arrives
+     * the original row may have been annotated — marked unresumable, given a resolver key — and an
+     * upsert would silently discard that. A duplicate event carries no newer truth than the row it
+     * duplicates.
+     *
+     * **It catches rather than ignores, and that distinction is load-bearing.** An earlier version
+     * used `insertOrIgnore`, which discards *every* conflict — so a second pause claiming a receipt
+     * another row already holds was silently dropped, and the read-back then failed with a
+     * bewildering "no rows" error. But two pauses on one receipt is not a redelivery; it is an
+     * anomaly worth raising, because it would mean two humans could drive the same action. Catching
+     * the violation and re-reading lets the two cases be told apart: a row under this ingest key
+     * means redelivery, no row means the conflict was somebody else's constraint, and that is
+     * rethrown.
+     *
+     * @param  array<string, mixed>|null  $presentation
+     */
+    public function ingest(
+        string $toolCallId,
+        ?string $conversationId = null,
+        ?string $conversationUser = null,
+        ?string $invocationId = null,
+        ?string $receiptId = null,
+        ?string $resolverKey = null,
+        ?array $presentation = null,
+        Resumability $resumability = Resumability::Unresumable,
+    ): PendingApproval {
+        $ingestKey = PendingApproval::ingestKey($toolCallId, $conversationId);
+        $now = now();
+
+        try {
+            PendingApproval::query()->insert([
+                'id' => Str::uuid()->toString(),
+                'ingest_key' => $ingestKey,
+                'receipt_id' => $receiptId,
+                'tool_call_id' => $toolCallId,
+                'conversation_id' => $conversationId,
+                'conversation_user' => $conversationUser,
+                'invocation_id' => $invocationId,
+                'resolver_key' => $resolverKey,
+                'presentation' => $presentation === null ? null : json_encode($presentation, JSON_THROW_ON_ERROR),
+                'resumability' => $resumability->value,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        } catch (UniqueConstraintViolationException $e) {
+            // Read back by the natural key rather than trusting the id generated above: whoever won
+            // the race wrote a different one, and theirs is the row that matters.
+            $existing = PendingApproval::query()->where('ingest_key', $ingestKey)->first();
+
+            if ($existing === null) {
+                throw $e;
+            }
+
+            return $existing;
+        }
+
+        return PendingApproval::query()->where('ingest_key', $ingestKey)->sole();
+    }
+
+    /**
+     * The row recording a given pause, if this console has seen it.
+     */
+    public function findByToolCall(string $toolCallId, ?string $conversationId = null): ?PendingApproval
+    {
+        return PendingApproval::query()
+            ->where('ingest_key', PendingApproval::ingestKey($toolCallId, $conversationId))
+            ->first();
+    }
+
+    /**
+     * The row holding a given Verdict receipt, if any.
+     *
+     * Returns a row, never a receipt *status* — that is read live from Verdict, and this table holds
+     * no copy of it. (Design §5.)
+     */
+    public function findByReceipt(string $receiptId): ?PendingApproval
+    {
+        return PendingApproval::query()->where('receipt_id', $receiptId)->first();
+    }
+}

--- a/src/Approvals/PendingApprovalStore.php
+++ b/src/Approvals/PendingApprovalStore.php
@@ -38,12 +38,15 @@ final class PendingApprovalStore
      * means redelivery, no row means the conflict was somebody else's constraint, and that is
      * rethrown.
      *
+     * `$participantReference` is opaque and host-supplied. This package never derives it from
+     * Laravel AI's participant object and never interprets it — see the migration for why.
+     *
      * @param  array<string, mixed>|null  $presentation
      */
     public function ingest(
         string $toolCallId,
         ?string $conversationId = null,
-        ?string $conversationUser = null,
+        ?string $participantReference = null,
         ?string $invocationId = null,
         ?string $receiptId = null,
         ?string $resolverKey = null,
@@ -60,7 +63,7 @@ final class PendingApprovalStore
                 'receipt_id' => $receiptId,
                 'tool_call_id' => $toolCallId,
                 'conversation_id' => $conversationId,
-                'conversation_user' => $conversationUser,
+                'participant_reference' => $participantReference,
                 'invocation_id' => $invocationId,
                 'resolver_key' => $resolverKey,
                 'presentation' => $presentation === null ? null : json_encode($presentation, JSON_THROW_ON_ERROR),

--- a/src/Approvals/Resumability.php
+++ b/src/Approvals/Resumability.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+/**
+ * Whether this console can drive a paused run to a resume.
+ *
+ * Never a statement about the Verdict receipt's validity. Receipt state and TTL are Verdict's, read
+ * live through `ApprovalManager`, and are deliberately not mirrored here — a second copy is the
+ * divergence the design exists to avoid. This enum answers a different question: given what was
+ * captured at pause time, can *this package* rebuild the agent and resume it at all?
+ */
+enum Resumability: string
+{
+    /** A Verdict receipt exists and the agent's resolver key resolved. The console can drive it. */
+    case Drivable = 'drivable';
+
+    /**
+     * The row is recorded but this console cannot drive it — no Verdict receipt behind the approval
+     * (a non-`BoundTool` approval, or an ambiguous tool-call id), or a resolver key that no longer
+     * resolves. Such a run is already paused and waiting; refusing to record it would hide it
+     * rather than prevent it, so it is stored, surfaced as not-console-actionable, and left to the
+     * host's recovery protocol.
+     */
+    case Unresumable = 'unresumable';
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -9,11 +9,11 @@ use Illuminate\Support\ServiceProvider;
 /**
  * Service provider for the headless core of `fissible/verdict-console`.
  *
- * Scaffold only. The runtime described in `docs/design/0001-verdict-console-design.md` — the
- * `PendingApproval` store, the disposition/resolution bridges, the durable projections, and the
- * operator surfaces — is not implemented here yet. This provider currently does nothing but merge
- * and publish the package configuration, so a clean install boots without error while the runtime is
- * built milestone by milestone (see `MILESTONES.md`).
+ * The runtime described in `docs/design/0001-verdict-console-design.md` is being built milestone by
+ * milestone (see `MILESTONES.md`). Landed so far: the `PendingApproval` index and its migration
+ * (VC-4). Still to come: the disposition/resolution bridges, the durable projections, and the
+ * operator surfaces. This provider merges and publishes configuration and migrations, so a clean
+ * install boots without error at every point along the way.
  */
 final class VerdictConsoleServiceProvider extends ServiceProvider
 {
@@ -31,5 +31,15 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../config/verdict-console.php' => config_path('verdict-console.php'),
         ], ['verdict-console', 'verdict-console-config']);
+
+        // Published rather than loaded from the package: the host owns when its schema changes, and
+        // a console table appearing on `migrate` without the host having asked for it is the kind of
+        // surprise a security-adjacent package should never spring. Verdict publishes its own
+        // migrations the same way.
+        $this->publishesMigrations([
+            __DIR__.'/../database/migrations/create_verdict_console_pending_approvals_table.php.stub' => database_path(
+                'migrations/2026_08_21_000001_create_verdict_console_pending_approvals_table.php',
+            ),
+        ], ['verdict-console', 'verdict-console-migrations']);
     }
 }

--- a/tests/Feature/MigrationPublishingTest.php
+++ b/tests/Feature/MigrationPublishingTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+
+/**
+ * The migration is published, not loaded from the package.
+ *
+ * The host owns when its schema changes. A console table appearing on `migrate` because a package
+ * was installed is the kind of surprise a security-adjacent dependency should never spring, so this
+ * asserts the publish path works rather than assuming the tag is wired.
+ */
+it('publishes the pending-approvals migration under its own tag', function (): void {
+    $target = database_path('migrations');
+
+    File::exists($target) && File::cleanDirectory($target);
+
+    $this->artisan('vendor:publish', ['--tag' => 'verdict-console-migrations', '--force' => true])
+        ->assertSuccessful();
+
+    $published = collect(File::files($target))
+        ->map(fn ($file): string => $file->getFilename())
+        ->filter(fn (string $name): bool => str_contains($name, 'create_verdict_console_pending_approvals_table'));
+
+    expect($published)->toHaveCount(1)
+        ->and($published->first())->toEndWith('.php', 'A published migration must be runnable, not left as a .stub.');
+
+    File::cleanDirectory($target);
+});
+
+/** The package must not run its own migrations behind the host's back. */
+it('does not load the migration automatically', function (): void {
+    expect(app('migrator')->paths())->not->toContain(dirname(__DIR__, 2).'/database/migrations');
+});

--- a/tests/Feature/PendingApprovalStoreTest.php
+++ b/tests/Feature/PendingApprovalStoreTest.php
@@ -23,7 +23,7 @@ it('records a pause', function (): void {
     $row = $this->store->ingest(
         toolCallId: 'call_1',
         conversationId: 'conv_1',
-        conversationUser: 'customer:7',
+        participantReference: 'host-opaque-ref-1',
         invocationId: 'inv_1',
         receiptId: 'receipt_1',
         resolverKey: 'orders-agent',
@@ -36,6 +36,7 @@ it('records a pause', function (): void {
         ->and($row->receipt_id)->toBe('receipt_1')
         ->and($row->resumability)->toBe(Resumability::Drivable)
         ->and($row->presentation)->toBe(['capability' => 'orders.cancel'])
+        ->and($row->participant_reference)->toBe('host-opaque-ref-1')
         ->and(PendingApproval::query()->count())->toBe(1);
 });
 
@@ -191,4 +192,29 @@ it('stores no copy of the receipt status and no expiry of its own', function ():
         ->and($columns)->not->toContain('receipt_status')
         ->and($columns)->not->toContain('expires_at')
         ->and($columns)->not->toContain('decided_at');
+});
+
+/**
+ * The participant column is an opaque host reference, not Laravel AI's participant object and not a
+ * class-name-plus-id convention this package invented.
+ *
+ * `ToolApprovalRequested` carries a live object; storing it as though it were durable, or encoding
+ * it as `ClassName:7` and rebuilding by convention, guesses at the host's identity model and is
+ * wrong the moment a participant needs a tenant, a guard, or a constructor argument. The default
+ * resume path therefore attaches no participant at all — `continue($conversationId)` — and a host
+ * that needs one supplies both the reference and the resolver.
+ */
+it('stores no participant object and invents no identity convention', function (): void {
+    $columns = Schema::getColumnListing('verdict_console_pending_approvals');
+
+    expect($columns)->not->toContain('conversation_user')
+        ->and($columns)->not->toContain('participant_class')
+        ->and($columns)->not->toContain('participant_id')
+        ->and($columns)->toContain('participant_reference');
+
+    // Whatever the host puts here comes back byte-identical; nothing parses it.
+    $opaque = 'tenant=9|urn:acme:person:42';
+    $row = $this->store->ingest(toolCallId: 'call_1', conversationId: 'conv_1', participantReference: $opaque);
+
+    expect($row->participant_reference)->toBe($opaque);
 });

--- a/tests/Feature/PendingApprovalStoreTest.php
+++ b/tests/Feature/PendingApprovalStoreTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
+use Fissible\VerdictConsole\Approvals\Resumability;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+beforeEach(function (): void {
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
+
+    $this->store = new PendingApprovalStore;
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists('verdict_console_pending_approvals');
+});
+
+it('records a pause', function (): void {
+    $row = $this->store->ingest(
+        toolCallId: 'call_1',
+        conversationId: 'conv_1',
+        conversationUser: 'customer:7',
+        invocationId: 'inv_1',
+        receiptId: 'receipt_1',
+        resolverKey: 'orders-agent',
+        presentation: ['capability' => 'orders.cancel'],
+        resumability: Resumability::Drivable,
+    );
+
+    expect($row->exists)->toBeTrue()
+        ->and($row->id)->not->toBeEmpty()
+        ->and($row->receipt_id)->toBe('receipt_1')
+        ->and($row->resumability)->toBe(Resumability::Drivable)
+        ->and($row->presentation)->toBe(['capability' => 'orders.cancel'])
+        ->and(PendingApproval::query()->count())->toBe(1);
+});
+
+/** A redelivered `ToolApprovalRequested` is the same pause arriving twice, not a second pause. */
+it('returns the same row when the same pause is ingested again', function (): void {
+    $first = $this->store->ingest(toolCallId: 'call_1', conversationId: 'conv_1', receiptId: 'receipt_1');
+    $second = $this->store->ingest(toolCallId: 'call_1', conversationId: 'conv_1', receiptId: 'receipt_1');
+
+    expect($second->id)->toBe($first->id)
+        ->and(PendingApproval::query()->count())->toBe(1);
+});
+
+/**
+ * The reason `ingest_key` is a hashed non-null column rather than a composite unique index over
+ * `(tool_call_id, conversation_id)`.
+ *
+ * A UNIQUE index does not constrain rows where an indexed column is NULL — two NULLs never compare
+ * equal — so a pause with no conversation would duplicate on every redelivery under the composite
+ * key, which is precisely the case a console cannot afford to get wrong: an approval with no
+ * conversation is already the one it cannot resume.
+ */
+it('stays idempotent for a pause that has no conversation', function (): void {
+    $first = $this->store->ingest(toolCallId: 'call_1', conversationId: null);
+    $second = $this->store->ingest(toolCallId: 'call_1', conversationId: null);
+
+    expect($second->id)->toBe($first->id)
+        ->and(PendingApproval::query()->count())->toBe(1);
+});
+
+/** The composite key it replaces would have failed this: proof the NULL case is genuinely covered. */
+it('proves a composite unique index over the nullable column would not have held', function (): void {
+    $rows = 2;
+
+    for ($i = 0; $i < $rows; $i++) {
+        PendingApproval::query()->insert([
+            'id' => Str::uuid()->toString(),
+            // A distinct ingest key per row, so this test isolates the NULL question rather than
+            // re-testing the unique index.
+            'ingest_key' => hash('sha256', 'distinct-'.$i),
+            'tool_call_id' => 'call_1',
+            'conversation_id' => null,
+            'resumability' => Resumability::Unresumable->value,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    // Both rows carry the identical natural key (call_1, NULL) and coexist happily. That is the
+    // database behaviour the hashed column exists to defeat.
+    expect(PendingApproval::query()->where('tool_call_id', 'call_1')->whereNull('conversation_id')->count())
+        ->toBe($rows);
+});
+
+/**
+ * The concurrency half of the acceptance criteria, and the honest bound on it.
+ *
+ * True parallel processes are not simulated: PHP has no reliable way to interleave two workers
+ * mid-statement in a test. What is asserted instead is the property that makes the race
+ * unwinnable — the row lands through the unique index rather than through a read-then-write, so
+ * there is no window between "does it exist?" and "insert it" for a second worker to slip into.
+ * This test forces exactly that interleaving by making the row appear *after* the store would have
+ * checked and *before* it writes: the store must absorb it, not raise.
+ */
+it('absorbs a row that appears between the check a naive store would make and its write', function (): void {
+    // Stand in for the concurrent worker that won the race.
+    PendingApproval::query()->insert([
+        'id' => Str::uuid()->toString(),
+        'ingest_key' => PendingApproval::ingestKey('call_1', 'conv_1'),
+        'receipt_id' => 'receipt_1',
+        'tool_call_id' => 'call_1',
+        'conversation_id' => 'conv_1',
+        'resumability' => Resumability::Drivable->value,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    // A check-then-insert store would now raise a unique violation here; an upserting one would
+    // overwrite the winner's row. Neither is acceptable.
+    $row = $this->store->ingest(toolCallId: 'call_1', conversationId: 'conv_1', receiptId: 'receipt_1');
+
+    expect(PendingApproval::query()->count())->toBe(1)
+        ->and($row->receipt_id)->toBe('receipt_1');
+});
+
+/**
+ * First-write-wins, stated as a test because the alternative is silent data loss: by the time a
+ * redelivery arrives the original row may have been annotated, and an upsert would discard that.
+ */
+it('does not overwrite an annotated row when the same pause is redelivered', function (): void {
+    $first = $this->store->ingest(toolCallId: 'call_1', conversationId: 'conv_1', resumability: Resumability::Drivable);
+
+    $first->update(['resolver_key' => 'repaired-by-an-operator']);
+
+    $second = $this->store->ingest(toolCallId: 'call_1', conversationId: 'conv_1', resumability: Resumability::Unresumable);
+
+    expect($second->resolver_key)->toBe('repaired-by-an-operator')
+        ->and($second->resumability)->toBe(Resumability::Drivable, 'A duplicate event carries no newer truth than the row it duplicates.');
+});
+
+/** Two distinct pauses are two rows, or the index would be collapsing real work. */
+it('records distinct pauses separately', function (): void {
+    $this->store->ingest(toolCallId: 'call_1', conversationId: 'conv_1');
+    $this->store->ingest(toolCallId: 'call_2', conversationId: 'conv_1');
+    $this->store->ingest(toolCallId: 'call_1', conversationId: 'conv_2');
+
+    expect(PendingApproval::query()->count())->toBe(3);
+});
+
+/** A literal conversation id must not be able to impersonate the absence of one. */
+it('separates a null conversation from a conversation literally named like a sentinel', function (): void {
+    $this->store->ingest(toolCallId: 'call_1', conversationId: null);
+    $this->store->ingest(toolCallId: 'call_1', conversationId: '-');
+    $this->store->ingest(toolCallId: 'call_1', conversationId: '');
+
+    expect(PendingApproval::query()->count())->toBe(3);
+});
+
+/** One receipt, one row — a receipt driven from two rows would be two humans deciding one action. */
+it('refuses a second row for the same receipt', function (): void {
+    $this->store->ingest(toolCallId: 'call_1', conversationId: 'conv_1', receiptId: 'receipt_1');
+
+    expect(fn () => $this->store->ingest(toolCallId: 'call_2', conversationId: 'conv_2', receiptId: 'receipt_1'))
+        ->toThrow(QueryException::class);
+});
+
+/**
+ * The other side of unique-when-present: receiptless rows must be able to coexist. They are the
+ * non-`BoundTool` and ambiguous approvals the console records but cannot drive (design §3, §6.3),
+ * and a NULL-collapsing index would let only one of them exist.
+ */
+it('allows many rows with no receipt at all', function (): void {
+    $this->store->ingest(toolCallId: 'call_1', conversationId: 'conv_1', receiptId: null);
+    $this->store->ingest(toolCallId: 'call_2', conversationId: 'conv_2', receiptId: null);
+    $this->store->ingest(toolCallId: 'call_3', conversationId: 'conv_3', receiptId: null);
+
+    expect(PendingApproval::query()->whereNull('receipt_id')->count())->toBe(3);
+});
+
+it('finds a row by its pause and by its receipt', function (): void {
+    $row = $this->store->ingest(toolCallId: 'call_1', conversationId: 'conv_1', receiptId: 'receipt_1');
+
+    expect($this->store->findByToolCall('call_1', 'conv_1')?->id)->toBe($row->id)
+        ->and($this->store->findByReceipt('receipt_1')?->id)->toBe($row->id)
+        ->and($this->store->findByToolCall('call_1', null))->toBeNull('A different conversation is a different pause.')
+        ->and($this->store->findByReceipt('receipt_absent'))->toBeNull();
+});
+
+/** The columns the design says must not exist. A future migration adding either is the regression. */
+it('stores no copy of the receipt status and no expiry of its own', function (): void {
+    $columns = Schema::getColumnListing('verdict_console_pending_approvals');
+
+    expect($columns)->not->toContain('status')
+        ->and($columns)->not->toContain('receipt_status')
+        ->and($columns)->not->toContain('expires_at')
+        ->and($columns)->not->toContain('decided_at');
+});


### PR DESCRIPTION
Closes #4. The console's queryable index of paused approvals.

Verdict's `ApprovalReceiptStore` has `findForToolCall()` and the transition methods but **no `find(receiptId)` and no list API**, so an inbox cannot be built by enumerating receipts. This table is that index — and nothing more. It holds no copy of the receipt's status and no expiry of its own; both stay Verdict's, read live. A test asserts those columns are *absent*, so a later migration adding one is a caught regression rather than a quiet drift.

## What would fail these tests

Stated up front, since a test that can't fail is decoration:

| Change | Test that fails |
|---|---|
| Drop the unique index on `ingest_key` | the two idempotency tests (`MultipleRecordsFoundException`) |
| Revert `ingest()` to `insertOrIgnore` | `refuses a second row for the same receipt` |
| Swap the hashed key for a composite `(tool_call_id, conversation_id)` unique index | `stays idempotent for a pause that has no conversation` |
| Add a `status` / `expires_at` column | `stores no copy of the receipt status and no expiry of its own` |
| Register the migration with `loadMigrationsFrom` | `does not load the migration automatically` |

The first two were **run**, not reasoned about — each fails only its own tests.

## Three schema decisions carry the weight

**Surrogate PK, not the receipt id.** An approval can arrive with no Verdict receipt behind it (a non-`BoundTool` approval, or an ambiguous tool-call id). Those rows must exist to be surfaced as not-console-actionable rather than dropped.

**A hashed non-null `ingest_key`, not a composite unique index.** A UNIQUE index does not constrain rows where a column is NULL — two NULLs never compare equal — so `(tool_call_id, conversation_id)` would duplicate on every redelivery of a *conversationless* pause, which is precisely the pause a console can least afford to mishandle. There's a test that demonstrates that database behaviour directly rather than asserting the claim.

**`receipt_id` nullable and unique-when-present**, which a UNIQUE index over a nullable column already gives for free. The same NULL semantics that *break* the composite key are what make this one work — noted at both sites, because the asymmetry is confusing otherwise.

## The store does not read before it writes

Check-then-insert cannot be idempotent under concurrency: two workers can both pass the check. So the unique index decides the winner and there is no window. **First-write-wins, not upsert** — by the time a redelivery arrives the row may have been annotated, and a duplicate event carries no newer truth than the row it duplicates.

On the concurrency acceptance criterion, the honest bound: true parallel processes aren't simulated — PHP has no reliable way to interleave two workers mid-statement in a test. What's asserted instead is the property that makes the race unwinnable, by forcing the exact interleaving (a row appearing *after* a naive store would have checked and *before* it writes) and requiring the store to absorb it.

## The first implementation was wrong and the tests caught it

`insertOrIgnore` discards **every** conflict, not just the one you mean. So a second pause claiming an already-held receipt was silently dropped and the read-back failed with a bewildering "no rows" error. But two pauses on one receipt isn't a redelivery — it's an anomaly worth raising, since it would mean two humans could drive one action. Catching the violation and re-reading tells the cases apart.

Worth flagging in review: I'd written a docblock asserting there was no second constraint for `insertOrIgnore` to swallow. That was unverified and false — `receipt_id`'s index is exactly that second constraint. Both the code and the comment are corrected.

## Dependency note

VC-4's stated deps include VC-2 and VC-8. The resolver key and presentation summary are stored as **opaque values**, so the table doesn't block on their semantics. If the VC-2 design gate changes the key from a string, this column changes with it — cheap pre-1.0, but a real coupling rather than none.

## Verification

`composer test` green: PHPStan clean, Pint clean, 100% type coverage, 19 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)