### PR TITLE
feat: VC-2 resumable-agent contract

### DIFF
--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -236,6 +236,24 @@ Empirical, from #218/#234 and the two reviews. Each has cost real time before.
 - **`UnsafeOuterTransaction`** — resolution can't run inside a wrapping `DB::transaction`.
 - **`NullEvidenceRecorder` is the default** — evidence surfaces are blank until configured; say so.
 - **Anomaly events are once-per-process / ephemeral** — project them or lose them.
+- **Never resume with `continueLastConversation()`.** It selects the participant's *most recently
+  updated* conversation (`DatabaseConversationStore::latestConversationId()` orders by `updated_at
+  desc`), not the paused one. With one conversation per participant those coincide, which is why the
+  pattern looks correct in single-run tests; with two concurrent runs the approved decision lands on
+  the wrong one. Verdict's gates still hold — the receipt is bound to a tool call — so nothing fails
+  closed and nothing detects it. Resume with `continue($conversationId, $participantOrNull)` using
+  the id captured at pause time. Measured and filed as
+  [fissible/verdict#265](https://github.com/fissible/verdict/issues/265), which also fixes the
+  reference test that taught it.
+- **Laravel AI's participant is an object, and it is not durable.** Do not persist
+  `conversationUser`, and do not encode it as class-name-plus-id and rebuild by convention — that
+  invents an identity model on the host's behalf and breaks the moment a participant needs a tenant,
+  a guard, or a constructor argument. The default resume attaches no participant at all; a host that
+  needs one supplies an opaque reference *and* the resolver that rebuilds it (VC-4's
+  `participant_reference`).
+- **A conversationless pause cannot be resumed at all.** `continue()` requires a string conversation
+  id, and `PendingApproval.conversation_id` is nullable, so drivability is *receipt* **and** *resolver
+  key* **and** *conversation id* — not the first two alone.
 - **Agent reconstruction needs a host-supplied resolver key, not just class + participant** —
   class+participant can't rebuild an agent with runtime constructor args, tenant context, or a
   specific provider/model. Validate the resolver at ingestion, or an approval commits and becomes

--- a/src/Agents/AgentResolverRegistry.php
+++ b/src/Agents/AgentResolverRegistry.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Agents;
+
+use Closure;
+use Fissible\VerdictConsole\Contracts\ResumableAgents;
+use Fissible\VerdictConsole\Exceptions\UnkeyableAgent;
+use Fissible\VerdictConsole\Exceptions\UnresolvableAgentKey;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\RemembersConversations;
+use Throwable;
+
+/**
+ * The shipped {@see ResumableAgents} implementation: a registry of key → factory, plus a predicate
+ * per key saying which agents that key names.
+ *
+ * A host may bind its own implementation instead; this one exists so the common case is a few lines
+ * in a service provider rather than a class. It deliberately holds no state about *pauses* — it maps
+ * agents to keys and keys to agents, nothing more, and has no dependency on the console's tables.
+ *
+ * **Keys are opaque strings and versioning is a host convention.** Registering `orders@v1` and
+ * `orders@v2` side by side is how a deploy migrates agents without stranding live rows: new pauses
+ * key to v2, rows already holding v1 still resolve. Nothing here parses the `@v2`; the registry
+ * simply holds both. When v1 may be retired is an operational question about which rows still
+ * reference it, and deliberately not this class's business.
+ */
+final class AgentResolverRegistry implements ResumableAgents
+{
+    /** @var array<non-empty-string, Closure(): object> */
+    private array $factories = [];
+
+    /** @var array<non-empty-string, Closure(Agent): bool> */
+    private array $matchers = [];
+
+    /**
+     * Register how to rebuild one kind of agent, and how to recognise it.
+     *
+     * @param  non-empty-string  $key
+     * @param  Closure(): object  $factory  rebuilds the agent from nothing but this key
+     * @param  Closure(Agent): bool  $matches  whether a paused agent should be keyed to this key
+     */
+    public function register(string $key, Closure $factory, Closure $matches): self
+    {
+        if (trim($key) === '') {
+            throw new \InvalidArgumentException('A resumable-agent key must not be empty or whitespace.');
+        }
+
+        $this->factories[$key] = $factory;
+        $this->matchers[$key] = $matches;
+
+        return $this;
+    }
+
+    public function keyFor(Agent $agent): string
+    {
+        $matched = [];
+
+        foreach ($this->matchers as $key => $matches) {
+            if ($matches($agent)) {
+                $matched[] = $key;
+            }
+        }
+
+        // Ambiguity is refused rather than settled by registration order. The key chosen at pause
+        // time is what a resume depends on long afterwards, and "whichever was registered first"
+        // is not a property a host can reason about.
+        return match (count($matched)) {
+            1 => $matched[0],
+            0 => throw UnkeyableAgent::for($agent),
+            default => throw UnkeyableAgent::ambiguous($agent, $matched),
+        };
+    }
+
+    public function resolve(string $key): Agent&RemembersConversations
+    {
+        $factory = $this->factories[$key] ?? throw UnresolvableAgentKey::unknown($key);
+
+        try {
+            $agent = $factory();
+        } catch (Throwable $e) {
+            throw UnresolvableAgentKey::failed($key, $e);
+        }
+
+        // Checked rather than trusted to the type hint: the factory is host code, and a resolver
+        // returning the wrong shape should name its key rather than surface as a TypeError from
+        // inside this method.
+        if (! $agent instanceof Agent || ! $agent instanceof RemembersConversations) {
+            throw UnresolvableAgentKey::notConversational($key, $agent);
+        }
+
+        return $agent;
+    }
+
+    /** @return iterable<non-empty-string> */
+    public function keys(): iterable
+    {
+        return array_keys($this->factories);
+    }
+}

--- a/src/Contracts/ResumableAgents.php
+++ b/src/Contracts/ResumableAgents.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Contracts;
+
+use Fissible\VerdictConsole\Exceptions\UnkeyableAgent;
+use Fissible\VerdictConsole\Exceptions\UnresolvableAgentKey;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\RemembersConversations;
+
+/**
+ * How the host rebuilds an agent this console paused.
+ *
+ * `ToolApprovalRequested` hands over an `Agent` **instance**. Resuming happens later — a different
+ * request, often a different process — so the instance is gone and nothing in the event is durable
+ * enough to rebuild it from. Agent class plus participant is not enough for any agent that takes a
+ * provider/model choice, tenant context, or constructor input, which is most real ones.
+ *
+ * So the host owns reconstruction, and this contract is the seam. The package stores the key and
+ * hands it back; it never parses one.
+ */
+interface ResumableAgents
+{
+    /**
+     * The durable key naming how to rebuild this agent.
+     *
+     * Must be **pure and stable**: the same agent yields the same key across processes and deploys.
+     * A key derived from `spl_object_id()`, a timestamp, or a random seed breaks resumption only for
+     * runs that outlive the process that paused them — which is the only kind that needs resuming.
+     *
+     * @throws UnkeyableAgent when this agent is not one the host can rebuild
+     */
+    public function keyFor(Agent $agent): string;
+
+    /**
+     * Rebuild the agent a key names.
+     *
+     * Returns a **conversation-capable** agent, because a resume is meaningless without one: only
+     * `RemembersConversations` carries `continue()`, and `Conversational` is what Laravel AI checks
+     * before it will pause at all.
+     *
+     * Returns it **bare** — no conversation attached. Attaching is resumption's business, not
+     * reconstruction's, and the caller attaches by the conversation id captured at pause time.
+     *
+     * Must not require the pause to still exist. If rebuilding needs to read the console's own
+     * tables, the key is not carrying enough.
+     *
+     * @throws UnresolvableAgentKey when the key is unknown, or known and its factory fails
+     */
+    public function resolve(string $key): Agent&RemembersConversations;
+
+    /**
+     * Every key this host can currently resolve.
+     *
+     * Exists so startup preflight is expressible *through this interface* rather than by reaching
+     * into whatever registry a host happens to use. Without it, "every registered key resolves" is
+     * not a testable claim.
+     *
+     * @return iterable<non-empty-string>
+     */
+    public function keys(): iterable;
+}

--- a/src/Exceptions/ResumableAgentFailure.php
+++ b/src/Exceptions/ResumableAgentFailure.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Exceptions;
+
+use RuntimeException;
+
+/**
+ * The category the ingestion path catches.
+ *
+ * A pause that cannot be rebuilt is not an error to propagate — the run is already paused and
+ * waiting, so failing the listener would hide it rather than prevent it. The disposition bridge
+ * catches this base type, records the row as unresumable, and files an incident. Catching the
+ * category rather than each case is why the base exists.
+ */
+abstract class ResumableAgentFailure extends RuntimeException {}

--- a/src/Exceptions/UnkeyableAgent.php
+++ b/src/Exceptions/UnkeyableAgent.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Exceptions;
+
+use Laravel\Ai\Contracts\Agent;
+
+/**
+ * The host cannot name how to rebuild this agent.
+ *
+ * Thrown rather than returning `''` or the class name: a placeholder key would be stored, look
+ * resolvable, and fail only at resume — long after the information needed to diagnose it is gone.
+ */
+final class UnkeyableAgent extends ResumableAgentFailure
+{
+    public static function for(Agent $agent): self
+    {
+        return new self(sprintf(
+            'No resumable-agent key is registered for [%s]. Register one, or this agent\'s paused '
+            .'approvals cannot be resumed by the console.',
+            $agent::class,
+        ));
+    }
+
+    /** @param  list<non-empty-string>  $keys */
+    public static function ambiguous(Agent $agent, array $keys): self
+    {
+        return new self(sprintf(
+            'Agent [%s] matches more than one resumable-agent key [%s]. Ambiguity is refused rather '
+            .'than resolved by registration order, because the key chosen here is the one a resume '
+            .'depends on months later.',
+            $agent::class,
+            implode(', ', $keys),
+        ));
+    }
+}

--- a/src/Exceptions/UnresolvableAgentKey.php
+++ b/src/Exceptions/UnresolvableAgentKey.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Exceptions;
+
+use Throwable;
+
+/**
+ * A key that does not rebuild an agent — either unknown, or known and broken.
+ *
+ * The two are deliberately one type with different messages. To the ingestion path they mean the
+ * same thing (this row is not drivable); to an operator they read differently, and the message says
+ * which. A failing factory keeps its original throwable as `previous`, because "the resolver threw"
+ * without the cause is the least actionable possible incident.
+ */
+final class UnresolvableAgentKey extends ResumableAgentFailure
+{
+    public static function unknown(string $key): self
+    {
+        return new self(sprintf(
+            'No resumable-agent resolver is registered for key [%s]. If rows still reference it, the '
+            .'key was retired too early; if none do, the row predates a key migration.',
+            $key,
+        ));
+    }
+
+    public static function failed(string $key, Throwable $cause): self
+    {
+        return new self(
+            sprintf('The resumable-agent resolver for key [%s] failed: %s', $key, $cause->getMessage()),
+            previous: $cause,
+        );
+    }
+
+    public static function notConversational(string $key, object $produced): self
+    {
+        return new self(sprintf(
+            'The resolver for key [%s] produced [%s], which is not a conversational agent. A resume '
+            .'needs continue(), and Laravel AI will not pause an agent that is not Conversational at '
+            .'all — so an agent reaching here without it could never have produced this pause.',
+            $key,
+            $produced::class,
+        ));
+    }
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Fissible\VerdictConsole;
 
+use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
+use Fissible\VerdictConsole\Contracts\ResumableAgents;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -20,6 +22,11 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->mergeConfigFrom(__DIR__.'/../config/verdict-console.php', 'verdict-console');
+
+        // A singleton because registrations must survive resolution: a host registers its resolvers
+        // once at boot, and every later resolve() must see them. Bound to the shipped registry so
+        // the common case needs no class, and overridable because reconstruction is host knowledge.
+        $this->app->singleton(ResumableAgents::class, AgentResolverRegistry::class);
     }
 
     public function boot(): void

--- a/tests/Feature/ResumableAgentsTest.php
+++ b/tests/Feature/ResumableAgentsTest.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
+use Fissible\VerdictConsole\Contracts\ResumableAgents;
+use Fissible\VerdictConsole\Exceptions\ResumableAgentFailure;
+use Fissible\VerdictConsole\Exceptions\UnkeyableAgent;
+use Fissible\VerdictConsole\Exceptions\UnresolvableAgentKey;
+use Laravel\Ai\Concerns\RemembersConversations as RemembersConversationsTrait;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\RemembersConversations as RemembersConversationsContract;
+use Laravel\Ai\Promptable;
+
+/** An agent with runtime constructor input — the case class-plus-participant cannot rebuild. */
+final class TenantedOrdersAgent implements Agent, RemembersConversationsContract
+{
+    use Promptable;
+    use RemembersConversationsTrait;
+
+    public function __construct(public readonly string $tenant, public readonly string $model) {}
+
+    public function instructions(): Stringable|string
+    {
+        return 'Handle orders for tenant '.$this->tenant.'.';
+    }
+}
+
+/** Conversational, so it could pause — but nothing registers a key for it. */
+final class UnregisteredAgent implements Agent, RemembersConversationsContract
+{
+    use Promptable;
+    use RemembersConversationsTrait;
+
+    public function instructions(): Stringable|string
+    {
+        return 'nobody registered me';
+    }
+}
+
+/** Not conversational: a resolver returning this has produced something unusable. */
+final class NotConversationalAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): Stringable|string
+    {
+        return 'no conversation';
+    }
+}
+
+function ordersRegistry(string $tenant = 'acme'): AgentResolverRegistry
+{
+    return (new AgentResolverRegistry)->register(
+        'orders@v1',
+        fn (): TenantedOrdersAgent => new TenantedOrdersAgent($tenant, 'model-v1'),
+        fn (Agent $agent): bool => $agent instanceof TenantedOrdersAgent,
+    );
+}
+
+it('round-trips an agent through its key', function (): void {
+    $registry = ordersRegistry();
+    $paused = new TenantedOrdersAgent('acme', 'model-v1');
+
+    $rebuilt = $registry->resolve($registry->keyFor($paused));
+
+    // NOTE: this is a fixture-level proxy, not proof of equivalence. Two agent instances have no
+    // defined equality, and comparing a few properties would pass for an agent whose constructor
+    // took something the key dropped. Equivalence is host-defined by contract; what this asserts is
+    // that the shipped registry returns the thing it was told to, on a fixture simple enough for
+    // that to be checkable.
+    expect($rebuilt)->toBeInstanceOf(TenantedOrdersAgent::class)
+        ->and($rebuilt->tenant)->toBe('acme')
+        ->and($rebuilt->model)->toBe('model-v1')
+        ->and($rebuilt)->toBeInstanceOf(RemembersConversationsContract::class);
+});
+
+it('returns the agent bare, with no conversation attached', function (): void {
+    $registry = ordersRegistry();
+
+    // Attaching is resumption's business: the caller attaches the conversation captured at pause
+    // time. A registry that pre-attached would have to guess which conversation, and guessing is
+    // exactly the defect fissible/verdict#265 records.
+    expect($registry->resolve('orders@v1')->currentConversation())->toBeNull();
+});
+
+/**
+ * The property that makes a key durable rather than merely unique: it survives the process.
+ *
+ * A key derived from `spl_object_id()` or a random seed passes every same-process assertion and
+ * fails only for runs that outlive the process that paused them — which is every run this package
+ * exists to resume.
+ */
+it('derives the same key from a rebuilt registry in a fresh container', function (): void {
+    $keyAtPause = ordersRegistry()->keyFor(new TenantedOrdersAgent('acme', 'model-v1'));
+
+    // Stand in for a later request: nothing survives but the string.
+    $carried = json_decode(json_encode(['key' => $keyAtPause], JSON_THROW_ON_ERROR), true)['key'];
+
+    $this->refreshApplication();
+
+    expect(ordersRegistry()->keyFor(new TenantedOrdersAgent('acme', 'model-v1')))->toBe($carried)
+        ->and(ordersRegistry()->resolve($carried))->toBeInstanceOf(TenantedOrdersAgent::class);
+});
+
+it('refuses to key an agent nothing is registered for', function (): void {
+    expect(fn () => ordersRegistry()->keyFor(new UnregisteredAgent))
+        ->toThrow(UnkeyableAgent::class);
+
+    // Rather than returning a placeholder that stores cleanly and fails only at resume.
+    expect(fn () => ordersRegistry()->keyFor(new UnregisteredAgent))
+        ->toThrow(ResumableAgentFailure::class, 'No resumable-agent key is registered');
+});
+
+/** Registration order is not a property a host can reason about months later. */
+it('refuses to key an agent that two keys both claim', function (): void {
+    $registry = ordersRegistry()->register(
+        'orders@shadow',
+        fn (): TenantedOrdersAgent => new TenantedOrdersAgent('acme', 'model-v1'),
+        fn (Agent $agent): bool => $agent instanceof TenantedOrdersAgent,
+    );
+
+    expect(fn () => $registry->keyFor(new TenantedOrdersAgent('acme', 'model-v1')))
+        ->toThrow(UnkeyableAgent::class, 'matches more than one');
+});
+
+it('raises a catchable failure for an unknown key', function (): void {
+    expect(fn () => ordersRegistry()->resolve('orders@absent'))
+        ->toThrow(UnresolvableAgentKey::class)
+        ->and(fn () => ordersRegistry()->resolve('orders@absent'))
+        ->toThrow(ResumableAgentFailure::class);
+});
+
+/** "The resolver threw" without the cause is the least actionable possible incident. */
+it('preserves the original throwable when a registered resolver fails', function (): void {
+    $cause = new LogicException('the tenant connection is gone');
+
+    $registry = (new AgentResolverRegistry)->register(
+        'orders@broken',
+        fn (): object => throw $cause,
+        fn (Agent $agent): bool => true,
+    );
+
+    try {
+        $registry->resolve('orders@broken');
+        $this->fail('A failing resolver must not resolve.');
+    } catch (UnresolvableAgentKey $e) {
+        expect($e->getPrevious())->toBe($cause)
+            ->and($e->getMessage())->toContain('the tenant connection is gone');
+    }
+});
+
+it('rejects a resolver that produces a non-conversational agent', function (): void {
+    $registry = (new AgentResolverRegistry)->register(
+        'orders@wrong-shape',
+        fn (): NotConversationalAgent => new NotConversationalAgent,
+        fn (Agent $agent): bool => true,
+    );
+
+    expect(fn () => $registry->resolve('orders@wrong-shape'))
+        ->toThrow(UnresolvableAgentKey::class, 'not a conversational agent');
+});
+
+it('rejects an empty key at registration rather than at resume', function (): void {
+    expect(fn () => (new AgentResolverRegistry)->register('  ', fn (): object => new UnregisteredAgent, fn (): bool => true))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+/**
+ * Enumeration exists so startup preflight is expressible through the interface, rather than by
+ * reaching into whatever registry a host happens to use.
+ */
+it('enumerates its keys so a preflight can resolve every one', function (): void {
+    $registry = ordersRegistry()->register(
+        'orders@v2',
+        fn (): TenantedOrdersAgent => new TenantedOrdersAgent('acme', 'model-v2'),
+        fn (Agent $agent): bool => false,
+    );
+
+    expect(iterator_to_array((function () use ($registry): Generator {
+        yield from $registry->keys();
+    })()))->toBe(['orders@v1', 'orders@v2']);
+
+    // The preflight VC-3 will own, in the two lines it reduces to here.
+    foreach ($registry->keys() as $key) {
+        expect($registry->resolve($key))->toBeInstanceOf(Agent::class);
+    }
+});
+
+it('lets a preflight over keys() catch a resolver that would fail at resume', function (): void {
+    $registry = ordersRegistry()->register(
+        'orders@broken',
+        fn (): object => throw new RuntimeException('boom'),
+        fn (Agent $agent): bool => false,
+    );
+
+    $broken = [];
+
+    foreach ($registry->keys() as $key) {
+        try {
+            $registry->resolve($key);
+        } catch (ResumableAgentFailure) {
+            $broken[] = $key;
+        }
+    }
+
+    expect($broken)->toBe(['orders@broken']);
+});
+
+/**
+ * Versioned keys, which is how a deploy migrates agents without stranding rows that already hold the
+ * old key. New pauses key to v2; rows still holding v1 resolve for as long as v1 stays registered.
+ *
+ * When v1 may be *retired* is a different question — it depends on whether any live row still
+ * references it — and deliberately not this contract's business. It has no dependency on the
+ * console's tables, so it cannot answer it and must not pretend to.
+ */
+it('resolves a retired-generation key while new pauses key to the current one', function (): void {
+    $registry = (new AgentResolverRegistry)
+        ->register(
+            'orders@v1',
+            fn (): TenantedOrdersAgent => new TenantedOrdersAgent('acme', 'model-v1'),
+            // v1 no longer claims new agents: the deploy moved on.
+            fn (Agent $agent): bool => false,
+        )
+        ->register(
+            'orders@v2',
+            fn (): TenantedOrdersAgent => new TenantedOrdersAgent('acme', 'model-v2'),
+            fn (Agent $agent): bool => $agent instanceof TenantedOrdersAgent,
+        );
+
+    expect($registry->keyFor(new TenantedOrdersAgent('acme', 'model-v2')))->toBe('orders@v2')
+        ->and($registry->resolve('orders@v1')->model)->toBe('model-v1', 'A row paused before the migration must still resume.')
+        ->and($registry->resolve('orders@v2')->model)->toBe('model-v2');
+});
+
+it('is resolvable from the container as the contract', function (): void {
+    expect(app(ResumableAgents::class))->toBeInstanceOf(AgentResolverRegistry::class)
+        ->and(app(ResumableAgents::class))->toBe(app(ResumableAgents::class), 'Registrations must survive resolution.');
+});


### PR DESCRIPTION
Closes #2. The seam where the host owns agent reconstruction, built to the design gate's ruling.

`ToolApprovalRequested` hands over an `Agent` **instance**. Resuming happens later, in another process — the instance is gone, and class-plus-participant cannot rebuild an agent that takes a provider/model choice, tenant context, or constructor input.

```php
interface ResumableAgents
{
    public function keyFor(Agent $agent): string;                        // broad input: out-of-scope agents throw
    public function resolve(string $key): Agent&RemembersConversations;  // conversation-capable, returned bare
    /** @return iterable<non-empty-string> */
    public function keys(): iterable;                                    // makes preflight testable through the interface
}
```

## What would fail these tests

| Change | Test that fails |
|---|---|
| Settle key ambiguity by first-match instead of refusing | `refuses to key an agent that two keys both claim` |
| Drop the `previous` throwable on a failing resolver | `preserves the original throwable when a registered resolver fails` |
| Skip the conversational check in `resolve()` | `rejects a resolver that produces a non-conversational agent` |
| Return a conversation-attached agent | `returns the agent bare, with no conversation attached` |
| Key from `spl_object_id()` or a random seed | `derives the same key from a rebuilt registry in a fresh container` |
| Drop `keys()` | `enumerates its keys so a preflight can resolve every one` |

The first three were **run**. Each fails exactly one test.

## Two decisions worth reviewing

**Ambiguity is refused, not resolved.** If two keys both claim an agent, `keyFor()` throws rather than picking the first registration. The key chosen at pause time is what a resume depends on months later, and "whichever was registered first" is not a property a host can reason about — least of all after a deploy reorders a service provider.

**Versioned keys are a host convention this class does not parse.** Registering `orders@v1` and `orders@v2` side by side is how a deploy migrates agents without stranding rows already holding v1: new pauses key to v2, old rows still resolve. There's a test for exactly that. When v1 may be *retired* depends on whether any live row still references it — an operational question about a table this contract has no dependency on, so it doesn't pretend to answer it. That guard belongs in the reconciliation layer once VC-4 exists.

## The round-trip test is weaker than it reads, and says so

Two agent instances have no defined equality. Comparing class, provider and participant would pass for an agent whose constructor took a tenant the key dropped. So the test asserts a **fixture-level proxy** and states that in the test body — equivalence is host-defined by contract, and this must not be cited as proving it.

## Three hazards recorded, the first measured

- **`continueLastConversation()` resumes the wrong conversation** under concurrency — it selects the participant's *most recently updated* one. Reproduced and filed as [fissible/verdict#265](https://github.com/fissible/verdict/issues/265), which also fixes the reference test that taught the pattern.
- **Laravel AI's participant object is not durable** and must not be rebuilt from class-name-plus-id by convention.
- **A conversationless pause cannot be resumed at all** — `continue()` needs a string id — so drivability is *receipt* **and** *resolver key* **and** *conversation id*. That tightens VC-5's ingestion test beyond what its issue currently says.

## Rebase note

The hazards land in design §12; the pending documentation PR's four sites are §5 and §6.3 — **different hunks, so they merge cleanly**, but branch from current `main` rather than a stale checkout.

## Verification

`composer test` green: PHPStan clean, Pint clean, 100% type coverage, 18 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)