### PR TITLE
feat: VC-3 preflight doctor with a structured findings model

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,6 +19,9 @@
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>
+        <testsuite name="Integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
         <testsuite name="EndToEnd">
             <directory>tests/EndToEnd</directory>
         </testsuite>

--- a/src/Console/Commands/DoctorCommand.php
+++ b/src/Console/Commands/DoctorCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Console\Commands;
+
+use Fissible\VerdictConsole\Doctor\Doctor;
+use Fissible\VerdictConsole\Doctor\Finding;
+use Fissible\VerdictConsole\Doctor\Severity;
+use Illuminate\Console\Command;
+
+/**
+ * Renders {@see Doctor}'s findings. It derives none of them itself — the findings are data so a UI
+ * can render the same set later (VC-22) without parsing console output.
+ */
+final class DoctorCommand extends Command
+{
+    protected $signature = 'verdict-console:doctor {--strict : Treat warnings as failures}';
+
+    protected $description = 'Check that this application is wired to drive Verdict approvals through the console.';
+
+    public function handle(Doctor $doctor): int
+    {
+        $findings = $doctor->run();
+
+        if ($findings === []) {
+            $this->components->info('Every console precondition is satisfied.');
+
+            return self::SUCCESS;
+        }
+
+        foreach ($findings as $finding) {
+            $this->renderFinding($finding);
+        }
+
+        $errors = array_filter($findings, fn (Finding $f): bool => $f->severity === Severity::Error);
+        $warnings = count($findings) - count($errors);
+
+        $this->newLine();
+        $this->components->twoColumnDetail('Errors', (string) count($errors));
+        $this->components->twoColumnDetail('Warnings', (string) $warnings);
+
+        // Errors move the exit code; warnings need --strict. This mirrors verdict:validate, whose
+        // advisory findings deliberately do not fail a build on their own.
+        return $errors !== [] || ($warnings > 0 && $this->option('strict'))
+            ? self::FAILURE
+            : self::SUCCESS;
+    }
+
+    private function renderFinding(Finding $finding): void
+    {
+        $label = $finding->severity === Severity::Error ? 'ERROR' : 'WARN';
+
+        $this->newLine();
+        $this->components->twoColumnDetail(
+            sprintf('<fg=%s;options=bold>%s</> %s', $finding->severity === Severity::Error ? 'red' : 'yellow', $label, $finding->subject),
+            $finding->code->value,
+        );
+        $this->line('  '.$finding->summary);
+        $this->line('  <fg=gray>Fix:</> '.$finding->fix);
+    }
+}

--- a/src/Doctor/Doctor.php
+++ b/src/Doctor/Doctor.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Doctor;
+
+use Fissible\Verdict\Capabilities\CapabilityRegistry;
+use Fissible\Verdict\LaravelAi\BoundTool;
+use Fissible\Verdict\LaravelAi\VerdictApprovalMiddleware;
+use Fissible\VerdictConsole\Contracts\ResumableAgents;
+use Fissible\VerdictConsole\Exceptions\ResumableAgentFailure;
+use Illuminate\Contracts\Config\Repository as Config;
+use Illuminate\Database\Schema\Builder as SchemaBuilder;
+use Laravel\Ai\Concerns\RemembersConversations as RemembersConversationsTrait;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasMiddleware;
+use Laravel\Ai\Contracts\HasTools;
+
+/**
+ * Moves every silent precondition to boot time.
+ *
+ * Each check here corresponds to a design §12 trap that otherwise fails at the first pause — and
+ * several of them fail *silently* there, which is why they cost real time to diagnose. A dead
+ * confirmation gate simply never appears in the inbox; a missing middleware turns an approved
+ * receipt into `invalid_state`; a missing conversation trait makes the resume a no-op. None of those
+ * announces itself.
+ *
+ * **Class-level only.** Whether a *particular* paused run can be resumed depends on what was
+ * captured at pause time and is validated at ingestion (VC-5). This answers the different question:
+ * is this wiring capable of working at all?
+ */
+final readonly class Doctor
+{
+    public function __construct(
+        private ResumableAgents $agents,
+        private CapabilityRegistry $capabilities,
+        private SchemaBuilder $schema,
+        private Config $config,
+    ) {}
+
+    /**
+     * Every finding, worst first.
+     *
+     * @return list<Finding>
+     */
+    public function run(): array
+    {
+        $findings = [
+            ...$this->inspectPersistence(),
+            ...$this->inspectAgents(),
+            ...$this->inspectCapabilities(),
+        ];
+
+        usort($findings, fn (Finding $a, Finding $b): int => [$a->severity === Severity::Warning, $a->subject]
+            <=> [$b->severity === Severity::Warning, $b->subject]);
+
+        return $findings;
+    }
+
+    /**
+     * @return list<Finding>
+     *
+     * Checks the tables rather than the binding. `ConversationStore` is bound by Laravel AI's own
+     * service provider, which this package hard-depends on, so "is it bound" can never be false and
+     * would be a check that always passes. What actually breaks a host is publishing the package and
+     * never running its migrations: the binding resolves, the writes fail, and the paused turn is
+     * simply never persisted.
+     */
+    private function inspectPersistence(): array
+    {
+        $table = $this->config->get('ai.conversations.tables.conversations', 'agent_conversations');
+        $table = is_string($table) ? $table : 'agent_conversations';
+
+        if ($this->schema->hasTable($table)) {
+            return [];
+        }
+
+        return [new Finding(
+            code: FindingCode::ConversationTablesMissing,
+            severity: Severity::Error,
+            subject: $table,
+            summary: 'The conversation tables are not migrated, so a paused turn is never persisted and '
+                .'no resume can reconstruct the pending tool call.',
+            fix: 'Publish and run Laravel AI\'s conversation migrations.',
+        )];
+    }
+
+    /** @return list<Finding> */
+    private function inspectAgents(): array
+    {
+        $findings = [];
+
+        foreach ($this->agents->keys() as $key) {
+            try {
+                $agent = $this->agents->resolve($key);
+            } catch (ResumableAgentFailure $e) {
+                // The preventive stage of design §6.3: the only point at which an unresumable agent
+                // can be caught before a run is already paused and waiting on it.
+                $findings[] = new Finding(
+                    code: FindingCode::ResolverKeyUnresolvable,
+                    severity: Severity::Error,
+                    subject: $key,
+                    summary: 'This resolver key does not rebuild an agent, so any run it paused cannot '
+                        .'be resumed: '.$e->getMessage(),
+                    fix: 'Repair the resolver registered for this key, or retire the key once no pending '
+                        .'approval still references it.',
+                );
+
+                continue;
+            }
+
+            $findings = [...$findings, ...$this->inspectAgent($key, $agent)];
+        }
+
+        return $findings;
+    }
+
+    /** @return list<Finding> */
+    private function inspectAgent(string $key, Agent $agent): array
+    {
+        $findings = [];
+        $subject = $agent::class;
+
+        // Design §3 names two conversation preconditions. Only one of them is checked here, and the
+        // reason is worth stating: `ResumableAgents::resolve()` returns `Agent&RemembersConversations`,
+        // so a non-`Conversational` agent can never reach this method — VC-2 refuses it first, and it
+        // surfaces above as an unresolvable key whose message names the fix. Re-checking it here
+        // would be an unreachable branch pretending to be a safeguard.
+        //
+        // The *trait* is a different matter: an agent can satisfy the contract by hand and still lack
+        // the trait, which is the silent failure — durable recording no-ops and nothing raises.
+        if (! in_array(RemembersConversationsTrait::class, class_uses_recursive($agent), true)) {
+            $findings[] = new Finding(
+                code: FindingCode::AgentDoesNotRememberConversations,
+                severity: Severity::Error,
+                subject: $subject,
+                summary: 'Without the RemembersConversations trait the provider silently skips durable '
+                    .'approval recording, so a resume driven from another process has nothing to '
+                    .'reconstruct. Nothing raises; the resume simply does not happen.',
+                fix: 'Use the Laravel\Ai\Concerns\RemembersConversations trait on this agent.',
+            );
+        }
+
+        if (! $agent instanceof HasMiddleware || ! $this->declaresApprovalMiddleware($agent)) {
+            $findings[] = new Finding(
+                code: FindingCode::ApprovalMiddlewareMissing,
+                severity: Severity::Error,
+                subject: $subject,
+                summary: 'VerdictApprovalMiddleware is not auto-registered. Without it '
+                    .'ApprovalExecutionContext::allows() is false for every tool call, and an approved '
+                    .'receipt fails proposal-validation with invalid_state.',
+                fix: 'Implement Laravel\Ai\Contracts\HasMiddleware and return '
+                    .'app(VerdictApprovalMiddleware::class) from middleware().',
+            );
+        }
+
+        if (! $this->hasBoundTool($agent)) {
+            $findings[] = new Finding(
+                code: FindingCode::AgentHasNoBoundTool,
+                severity: Severity::Warning,
+                subject: $subject,
+                summary: 'This agent is registered as resumable but has no Verdict-bound tool, so it can '
+                    .'never raise a receipt-backed approval. Nothing breaks; the registration does '
+                    .'nothing.',
+                fix: 'Bind at least one tool through Verdict::bound(), or unregister the resolver key ['
+                    .$key.'].',
+            );
+        }
+
+        return $findings;
+    }
+
+    /** @return list<Finding> */
+    private function inspectCapabilities(): array
+    {
+        $findings = [];
+
+        foreach ($this->capabilities->all() as $capability) {
+            // The #230 dead gate. Checked over the whole registry rather than per agent, because a
+            // capability that can never pause is broken regardless of which agent reaches it.
+            if ($capability->confirmationRequired() && $capability->executionTargetPolicy() === null) {
+                $findings[] = new Finding(
+                    code: FindingCode::ConfirmationGateCannotPause,
+                    severity: Severity::Error,
+                    subject: $capability->name,
+                    summary: 'This capability asks for confirmation but declares no execution-target '
+                        .'policy, so requestConfirmation() returns null: it never pauses, never reaches '
+                        .'the approval inbox, and is denied at execution without a human being asked.',
+                    fix: 'Declare an executionTarget() policy on this capability, or remove '
+                        .'requiresConfirmation().',
+                );
+            }
+        }
+
+        return $findings;
+    }
+
+    private function declaresApprovalMiddleware(HasMiddleware $agent): bool
+    {
+        foreach ($agent->middleware() as $middleware) {
+            if ($middleware instanceof VerdictApprovalMiddleware) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasBoundTool(Agent $agent): bool
+    {
+        if (! $agent instanceof HasTools) {
+            return false;
+        }
+
+        foreach ($agent->tools() as $tool) {
+            if ($tool instanceof BoundTool) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Doctor/Doctor.php
+++ b/src/Doctor/Doctor.php
@@ -65,24 +65,44 @@ final readonly class Doctor
      * would be a check that always passes. What actually breaks a host is publishing the package and
      * never running its migrations: the binding resolves, the writes fail, and the paused turn is
      * simply never persisted.
+     *
+     * **Both tables, not just the conversations one.** Laravel AI's single migration creates two,
+     * and the *messages* table is the one that matters most here: it stores the paused assistant
+     * turn — its `tool_calls` and `approval_state` — and the approval results a resume records. A
+     * host with only the conversations table migrated would pass a one-table check and then fail at
+     * the moment of the pause, which is precisely the silent setup failure this command exists to
+     * catch.
      */
     private function inspectPersistence(): array
     {
-        $table = $this->config->get('ai.conversations.tables.conversations', 'agent_conversations');
-        $table = is_string($table) ? $table : 'agent_conversations';
+        $missing = array_values(array_filter(
+            [$this->conversationTable('conversations'), $this->conversationTable('messages')],
+            fn (string $table): bool => ! $this->schema->hasTable($table),
+        ));
 
-        if ($this->schema->hasTable($table)) {
+        if ($missing === []) {
             return [];
         }
 
         return [new Finding(
             code: FindingCode::ConversationTablesMissing,
             severity: Severity::Error,
-            subject: $table,
-            summary: 'The conversation tables are not migrated, so a paused turn is never persisted and '
-                .'no resume can reconstruct the pending tool call.',
-            fix: 'Publish and run Laravel AI\'s conversation migrations.',
+            subject: implode(', ', $missing),
+            summary: 'Laravel AI\'s conversation tables are not fully migrated, so a paused turn is never '
+                .'persisted and no resume can reconstruct the pending tool call. The messages table in '
+                .'particular holds the paused assistant turn and its approval state, so a run can pause '
+                .'and be lost even when the conversations table exists.',
+            fix: 'Publish and run Laravel AI\'s conversation migration, which creates both tables.',
         )];
+    }
+
+    /** @param  'conversations'|'messages'  $which */
+    private function conversationTable(string $which): string
+    {
+        $default = $which === 'conversations' ? 'agent_conversations' : 'agent_conversation_messages';
+        $configured = $this->config->get('ai.conversations.tables.'.$which, $default);
+
+        return is_string($configured) && $configured !== '' ? $configured : $default;
     }
 
     /** @return list<Finding> */

--- a/src/Doctor/Finding.php
+++ b/src/Doctor/Finding.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Doctor;
+
+/**
+ * One thing that is wrong, what it will do if left, and how to fix it.
+ *
+ * Returned as data rather than printed so a UI can render the same findings later (VC-22) without
+ * re-deriving them from console output.
+ */
+final readonly class Finding
+{
+    public function __construct(
+        public FindingCode $code,
+        public Severity $severity,
+        /** What the finding is about: an agent class, a resolver key, or a capability name. */
+        public string $subject,
+        /** What is wrong, and what it causes at runtime. */
+        public string $summary,
+        /** What to change. Never "check your configuration". */
+        public string $fix,
+    ) {}
+
+    /** @return array<string, string> */
+    public function toArray(): array
+    {
+        return [
+            'code' => $this->code->value,
+            'severity' => $this->severity->value,
+            'subject' => $this->subject,
+            'summary' => $this->summary,
+            'fix' => $this->fix,
+        ];
+    }
+}

--- a/src/Doctor/FindingCode.php
+++ b/src/Doctor/FindingCode.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Doctor;
+
+/**
+ * One code per precondition, because "your agent is misconfigured" is not an actionable finding.
+ *
+ * Every case here corresponds to a trap in design §12 that fails *silently or confusingly* at first
+ * pause. The whole point of the doctor is to move each one to boot time, where a person is looking.
+ */
+enum FindingCode: string
+{
+    /** A registered resolver key does not rebuild an agent. The preventive stage of design §6.3. */
+    case ResolverKeyUnresolvable = 'resolver_key_unresolvable';
+
+    /** Without the trait, durable recording silently no-ops and a cross-process resume cannot work. */
+    case AgentDoesNotRememberConversations = 'agent_does_not_remember_conversations';
+
+    /** The conversation tables are not migrated: nothing persists the paused turn. */
+    case ConversationTablesMissing = 'conversation_tables_missing';
+
+    /** Not auto-registered — without it `ApprovalExecutionContext::allows()` is false for every call. */
+    case ApprovalMiddlewareMissing = 'approval_middleware_missing';
+
+    /** A resumable agent with no Verdict-bound tool can never produce a receipt-backed approval. */
+    case AgentHasNoBoundTool = 'agent_has_no_bound_tool';
+
+    /** The #230 dead gate: asks for confirmation, declares no execution target, never pauses. */
+    case ConfirmationGateCannotPause = 'confirmation_gate_cannot_pause';
+}

--- a/src/Doctor/Severity.php
+++ b/src/Doctor/Severity.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Doctor;
+
+/**
+ * How badly a finding breaks the console.
+ *
+ * Deliberately only two levels. A preflight whose output needs triage is one nobody reads.
+ */
+enum Severity: string
+{
+    /** This agent or capability cannot be driven by the console at all. */
+    case Error = 'error';
+
+    /**
+     * Works, but is not doing what its registration implies — the shape of a mistake rather than a
+     * broken run.
+     */
+    case Warning = 'warning';
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fissible\VerdictConsole;
 
 use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
+use Fissible\VerdictConsole\Console\Commands\DoctorCommand;
 use Fissible\VerdictConsole\Contracts\ResumableAgents;
 use Illuminate\Support\ServiceProvider;
 
@@ -34,6 +35,8 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         if (! $this->app->runningInConsole()) {
             return;
         }
+
+        $this->commands([DoctorCommand::class]);
 
         $this->publishes([
             __DIR__.'/../config/verdict-console.php' => config_path('verdict-console.php'),

--- a/tests/EndToEndTestCase.php
+++ b/tests/EndToEndTestCase.php
@@ -4,11 +4,7 @@ declare(strict_types=1);
 
 namespace Fissible\VerdictConsole\Tests;
 
-use Fissible\Verdict\VerdictServiceProvider;
-use Fissible\VerdictConsole\VerdictConsoleServiceProvider;
 use Illuminate\Foundation\Application;
-use Laravel\Ai\AiServiceProvider;
-use Orchestra\Testbench\TestCase as Orchestra;
 
 /**
  * The heavy base case, for tests that must exercise the real Verdict + Laravel AI stack.
@@ -22,7 +18,7 @@ use Orchestra\Testbench\TestCase as Orchestra;
  * Everything here is still hermetic. No network, no credentials: the provider is an
  * `openai_compatible` driver pointed at a URL that only ever answers through `Http::fake()`.
  */
-abstract class EndToEndTestCase extends Orchestra
+abstract class EndToEndTestCase extends IntegrationTestCase
 {
     /**
      * The provider name the end-to-end agents use.
@@ -39,19 +35,6 @@ abstract class EndToEndTestCase extends Orchestra
      * before DNS, so this host does not exist and must not.
      */
     public const string BASE_URL = 'https://openai-compatible.invalid/v1';
-
-    /**
-     * @param  Application  $app
-     * @return array<int, class-string>
-     */
-    protected function getPackageProviders($app): array
-    {
-        return [
-            AiServiceProvider::class,
-            VerdictServiceProvider::class,
-            VerdictConsoleServiceProvider::class,
-        ];
-    }
 
     /**
      * @param  Application  $app

--- a/tests/Integration/DoctorTest.php
+++ b/tests/Integration/DoctorTest.php
@@ -329,7 +329,7 @@ it('warns rather than errors for a resumable agent that binds nothing', function
 });
 
 /**
- * Checked as a table rather than a container binding. `ConversationStore` is bound by Laravel AI's
+ * Checked as tables rather than a container binding. `ConversationStore` is bound by Laravel AI's
  * provider, which this package hard-depends on, so a binding check could never fail — what actually
  * breaks a host is publishing and never migrating.
  */
@@ -341,6 +341,40 @@ it('reports missing conversation tables once, not per agent', function (): void 
 
     expect($tables)->toHaveCount(1)
         ->and(current($tables)->severity)->toBe(Severity::Error);
+});
+
+/**
+ * The half a one-table check would miss, and the more dangerous half.
+ *
+ * Laravel AI's single migration creates both tables, so they are usually present together — but a
+ * host that migrated partially, renamed one, or restored a partial dump gets a doctor that says
+ * "clean" and a run that pauses into nothing. The messages table is where the paused assistant turn
+ * lives: `DatabaseConversationStore::storeAssistantMessage()` writes its `tool_calls` and
+ * `approval_state` there, and `getLatestConversationMessages()` reads them back to reconstruct the
+ * pending call on resume. Without it the conversation row exists and the pause is lost.
+ */
+it('reports the messages table missing even when the conversations table exists', function (): void {
+    Schema::drop('agent_conversation_messages');
+
+    $findings = doctorFor(['a' => new HealthyAgent])->run();
+    $finding = current(array_filter($findings, fn ($f) => $f->code === FindingCode::ConversationTablesMissing));
+
+    expect($finding)->not->toBeFalse('A half-migrated host must not pass preflight.')
+        ->and($finding->severity)->toBe(Severity::Error)
+        ->and($finding->subject)->toBe('agent_conversation_messages')
+        // The subject names only what is actually missing, so the fix is not a guess.
+        ->and($finding->subject)->not->toContain('agent_conversations,');
+});
+
+/** Both missing names both, so an operator sees the whole gap in one finding. */
+it('names both tables when neither is migrated', function (): void {
+    Schema::drop('agent_conversation_messages');
+    Schema::drop('agent_conversations');
+
+    $findings = doctorFor(['a' => new HealthyAgent])->run();
+    $finding = current(array_filter($findings, fn ($f) => $f->code === FindingCode::ConversationTablesMissing));
+
+    expect($finding->subject)->toBe('agent_conversations, agent_conversation_messages');
 });
 
 /** The #230 dead gate, checked over the registry: it is broken whichever agent reaches it. */

--- a/tests/Integration/DoctorTest.php
+++ b/tests/Integration/DoctorTest.php
@@ -1,0 +1,405 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Actions\ActionContext;
+use Fissible\Verdict\Actions\ActionEnvelope;
+use Fissible\Verdict\Actions\AuthorizedAction;
+use Fissible\Verdict\Approvals\ApprovalExecutionContext;
+use Fissible\Verdict\Capabilities\Capability;
+use Fissible\Verdict\Capabilities\CapabilityRegistry;
+use Fissible\Verdict\Contracts\CapabilityAuthorizer;
+use Fissible\Verdict\Decisions\Decision;
+use Fissible\Verdict\LaravelAi\VerdictApprovalMiddleware;
+use Fissible\Verdict\Targets\ExecutionTargetPolicy;
+use Fissible\Verdict\VerdictManager;
+use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
+use Fissible\VerdictConsole\Contracts\ResumableAgents;
+use Fissible\VerdictConsole\Doctor\Doctor;
+use Fissible\VerdictConsole\Doctor\FindingCode;
+use Fissible\VerdictConsole\Doctor\Severity;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Ai\Concerns\RemembersConversations as RemembersConversationsTrait;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasMiddleware;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Contracts\RemembersConversations as RemembersConversationsContract;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Tools\Request;
+
+final class DoctorSubjectTool implements Tool
+{
+    public function description(): Stringable|string
+    {
+        return 'A tool.';
+    }
+
+    public function handle(Request $request): Stringable|string
+    {
+        return 'ok';
+    }
+
+    /** @return array<string, Type> */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}
+
+/** Wired correctly: conversational, remembers, declares the middleware, binds a tool. */
+final class HealthyAgent implements Agent, HasMiddleware, HasTools, RemembersConversationsContract
+{
+    use Promptable;
+    use RemembersConversationsTrait;
+
+    public function instructions(): Stringable|string
+    {
+        return 'healthy';
+    }
+
+    /** @return array<int, Tool> */
+    public function tools(): array
+    {
+        return [doctorBoundTool()];
+    }
+
+    /** @return array<int, object> */
+    public function middleware(): array
+    {
+        return [new VerdictApprovalMiddleware(new ApprovalExecutionContext)];
+    }
+}
+
+/** Not `Conversational`: Laravel AI throws rather than pausing. */
+final class NotConversationalDoctorAgent implements Agent, HasMiddleware, HasTools
+{
+    use Promptable;
+
+    public function instructions(): Stringable|string
+    {
+        return 'not conversational';
+    }
+
+    /** @return array<int, Tool> */
+    public function tools(): array
+    {
+        return [doctorBoundTool()];
+    }
+
+    /** @return array<int, object> */
+    public function middleware(): array
+    {
+        return [new VerdictApprovalMiddleware(new ApprovalExecutionContext)];
+    }
+}
+
+/** Implements the contract but omits the trait: the silent half of the pair. */
+final class TraitlessAgent implements Agent, HasMiddleware, HasTools, RemembersConversationsContract
+{
+    use Promptable;
+
+    private ?string $conversationId = null;
+
+    public function instructions(): Stringable|string
+    {
+        return 'no trait';
+    }
+
+    /** @return array<int, Tool> */
+    public function tools(): array
+    {
+        return [doctorBoundTool()];
+    }
+
+    /** @return array<int, object> */
+    public function middleware(): array
+    {
+        return [new VerdictApprovalMiddleware(new ApprovalExecutionContext)];
+    }
+
+    public function forParticipant(object $participant): static
+    {
+        return $this;
+    }
+
+    public function forUser($user): static
+    {
+        return $this;
+    }
+
+    public function continue(string $conversationId, ?object $as = null): static
+    {
+        $this->conversationId = $conversationId;
+
+        return $this;
+    }
+
+    public function continueLastConversation(object $as): static
+    {
+        return $this;
+    }
+
+    public function messages(): iterable
+    {
+        return [];
+    }
+
+    public function currentConversation(): ?string
+    {
+        return $this->conversationId;
+    }
+
+    public function hasConversationParticipant(): bool
+    {
+        return false;
+    }
+
+    public function conversationParticipant(): ?object
+    {
+        return null;
+    }
+}
+
+/** Declares no middleware: an approved receipt fails as `invalid_state`. */
+final class MiddlewarelessAgent implements Agent, HasTools, RemembersConversationsContract
+{
+    use Promptable;
+    use RemembersConversationsTrait;
+
+    public function instructions(): Stringable|string
+    {
+        return 'no middleware';
+    }
+
+    /** @return array<int, Tool> */
+    public function tools(): array
+    {
+        return [doctorBoundTool()];
+    }
+}
+
+/** Registered as resumable but binds nothing through Verdict. */
+final class ToollessAgent implements Agent, HasMiddleware, RemembersConversationsContract
+{
+    use Promptable;
+    use RemembersConversationsTrait;
+
+    public function instructions(): Stringable|string
+    {
+        return 'no bound tool';
+    }
+
+    /** @return array<int, object> */
+    public function middleware(): array
+    {
+        return [new VerdictApprovalMiddleware(new ApprovalExecutionContext)];
+    }
+}
+
+function doctorBoundTool(): Tool
+{
+    $verdict = app(VerdictManager::class);
+
+    if (! app(CapabilityRegistry::class)->has('doctor.healthy')) {
+        $verdict->capability(
+            Capability::usingPolicy(
+                name: 'doctor.healthy',
+                ability: 'update',
+                resolveTarget: fn (ActionEnvelope $e): object => new stdClass,
+            )
+                ->executionTarget(ExecutionTargetPolicy::acceptStaleSnapshot(
+                    name: 'doctor-target',
+                    identityUsing: fn (ActionEnvelope $e, object $t): array => ['id' => 1],
+                ))
+                ->requiresConfirmation(fn (ActionEnvelope $e, object $t): array => ['id' => 1])
+                ->executeUsing(fn (AuthorizedAction $a): string => 'done'),
+        );
+    }
+
+    return $verdict->bound(new DoctorSubjectTool, 'doctor.healthy', new ActionContext('actor'));
+}
+
+/** @param  array<string, Agent>  $agents */
+function doctorFor(array $agents = []): Doctor
+{
+    $registry = new AgentResolverRegistry;
+
+    foreach ($agents as $key => $agent) {
+        $registry->register($key, fn (): Agent => $agent, fn (Agent $candidate): bool => $candidate === $agent);
+    }
+
+    app()->instance(ResumableAgents::class, $registry);
+
+    return app(Doctor::class);
+}
+
+beforeEach(function (): void {
+    // The conversation tables are a real precondition; migrate them so the default run is clean.
+    (require dirname(__DIR__, 2).'/vendor/laravel/ai/database/migrations/2026_01_11_000001_create_agent_conversations_table.php')->up();
+
+    // Verdict leaves the authorizer to the application, so nothing binds one by default and
+    // VerdictManager cannot build without it. The doctor never asks it to decide anything; this is
+    // here so the capabilities under inspection can be registered at all.
+    app()->instance(CapabilityAuthorizer::class, new class implements CapabilityAuthorizer
+    {
+        public function decide(Capability $capability, ActionEnvelope $envelope, mixed $target): Decision
+        {
+            return Decision::permit('doctor test');
+        }
+    });
+
+});
+
+it('reports nothing when every precondition is satisfied', function (): void {
+    expect(doctorFor(['healthy' => new HealthyAgent])->run())->toBe([]);
+});
+
+it('reports a resolver key that does not rebuild an agent', function (): void {
+    $registry = (new AgentResolverRegistry)->register(
+        'broken',
+        fn (): object => throw new RuntimeException('the tenant connection is gone'),
+        fn (Agent $agent): bool => false,
+    );
+
+    app()->instance(ResumableAgents::class, $registry);
+
+    $findings = app(Doctor::class)->run();
+
+    expect($findings)->toHaveCount(1)
+        ->and($findings[0]->code)->toBe(FindingCode::ResolverKeyUnresolvable)
+        ->and($findings[0]->severity)->toBe(Severity::Error)
+        ->and($findings[0]->subject)->toBe('broken')
+        // The cause is what makes the finding actionable; "the resolver threw" alone is not.
+        ->and($findings[0]->summary)->toContain('the tenant connection is gone');
+});
+
+/**
+ * A non-conversational agent never reaches the doctor's per-agent checks: `ResumableAgents::resolve()`
+ * returns `Agent&RemembersConversations`, so VC-2 refuses it first. The doctor's job here is to
+ * surface that refusal as something actionable rather than to re-check a shape it cannot receive.
+ */
+it('surfaces a non-conversational agent through the resolver rather than a per-agent check', function (): void {
+    $findings = doctorFor(['a' => new NotConversationalDoctorAgent])->run();
+
+    expect($findings)->toHaveCount(1)
+        ->and($findings[0]->code)->toBe(FindingCode::ResolverKeyUnresolvable)
+        ->and($findings[0]->summary)->toContain('not a conversational agent')
+        // The message must name why the shape matters, not just that it is wrong.
+        ->and($findings[0]->summary)->toContain('continue()');
+});
+
+/**
+ * The two conversation preconditions are separate findings on purpose. They fail in opposite ways —
+ * one throws loudly at pause, the other silently skips durable recording — so an agent that has the
+ * contract but not the trait must be told exactly that, not "your conversation setup is wrong".
+ */
+it('separates the loud conversation precondition from the silent one', function (): void {
+    $findings = doctorFor(['a' => new TraitlessAgent])->run();
+    $codes = array_map(fn ($f) => $f->code, $findings);
+
+    // This agent satisfies the contract by hand, so VC-2's resolve() accepts it — which is exactly
+    // why the trait check has to exist separately. The contract is the loud gate; the trait is the
+    // silent one, and only the silent one can get this far.
+    expect($codes)->toContain(FindingCode::AgentDoesNotRememberConversations)
+        ->and($codes)->not->toContain(FindingCode::ResolverKeyUnresolvable);
+
+    $silent = current(array_filter($findings, fn ($f) => $f->code === FindingCode::AgentDoesNotRememberConversations));
+
+    expect($silent->summary)->toContain('Nothing raises');
+});
+
+it('reports a missing approval middleware', function (): void {
+    $findings = doctorFor(['a' => new MiddlewarelessAgent])->run();
+
+    expect(array_map(fn ($f) => $f->code, $findings))->toContain(FindingCode::ApprovalMiddlewareMissing)
+        ->and(current(array_filter($findings, fn ($f) => $f->code === FindingCode::ApprovalMiddlewareMissing))->summary)
+        ->toContain('invalid_state');
+});
+
+it('warns rather than errors for a resumable agent that binds nothing', function (): void {
+    $findings = doctorFor(['pointless' => new ToollessAgent])->run();
+    $finding = current(array_filter($findings, fn ($f) => $f->code === FindingCode::AgentHasNoBoundTool));
+
+    expect($finding->severity)->toBe(Severity::Warning, 'Nothing is broken; the registration just does nothing.')
+        // The fix names the key to unregister, so it is actionable without a lookup.
+        ->and($finding->fix)->toContain('pointless');
+});
+
+/**
+ * Checked as a table rather than a container binding. `ConversationStore` is bound by Laravel AI's
+ * provider, which this package hard-depends on, so a binding check could never fail — what actually
+ * breaks a host is publishing and never migrating.
+ */
+it('reports missing conversation tables once, not per agent', function (): void {
+    Schema::drop('agent_conversations');
+
+    $findings = doctorFor(['a' => new HealthyAgent, 'b' => new HealthyAgent])->run();
+    $tables = array_filter($findings, fn ($f) => $f->code === FindingCode::ConversationTablesMissing);
+
+    expect($tables)->toHaveCount(1)
+        ->and(current($tables)->severity)->toBe(Severity::Error);
+});
+
+/** The #230 dead gate, checked over the registry: it is broken whichever agent reaches it. */
+it('reports a confirmation gate that can never pause', function (): void {
+    app(VerdictManager::class)->capability(
+        Capability::usingPolicy(
+            name: 'doctor.dead-gate',
+            ability: 'update',
+            resolveTarget: fn (ActionEnvelope $e): object => new stdClass,
+        )
+            ->requiresConfirmation(fn (ActionEnvelope $e, object $t): array => ['id' => 1])
+            ->executeUsing(fn (AuthorizedAction $a): string => 'done'),
+    );
+
+    $findings = doctorFor()->run();
+    $finding = current(array_filter($findings, fn ($f) => $f->code === FindingCode::ConfirmationGateCannotPause));
+
+    expect($finding->severity)->toBe(Severity::Error)
+        ->and($finding->subject)->toBe('doctor.dead-gate')
+        ->and($finding->summary)->toContain('never pauses');
+});
+
+/** A gate that declares a target is not reported — or the finding would be noise. */
+it('does not report a confirmation gate that declares an execution target', function (): void {
+    doctorBoundTool();
+
+    $codes = array_map(fn ($f) => $f->code, doctorFor()->run());
+
+    expect($codes)->not->toContain(FindingCode::ConfirmationGateCannotPause);
+});
+
+it('returns findings as data a UI can render', function (): void {
+    $findings = doctorFor(['a' => new MiddlewarelessAgent])->run();
+
+    expect($findings[0]->toArray())->toHaveKeys(['code', 'severity', 'subject', 'summary', 'fix'])
+        ->and($findings[0]->toArray()['code'])->toBeString();
+});
+
+it('orders errors before warnings', function (): void {
+    Schema::drop('agent_conversations');
+
+    $severities = array_map(fn ($f) => $f->severity, doctorFor(['pointless' => new ToollessAgent])->run());
+
+    expect($severities[0])->toBe(Severity::Error)
+        ->and(end($severities))->toBe(Severity::Warning);
+});
+
+it('fails the command for an error and passes for a clean run', function (): void {
+    doctorFor(['healthy' => new HealthyAgent]);
+    $this->artisan('verdict-console:doctor')->assertSuccessful();
+
+    doctorFor(['a' => new MiddlewarelessAgent]);
+    $this->artisan('verdict-console:doctor')->assertFailed();
+});
+
+/** Warnings alone do not fail a build; --strict is how a host opts into that. */
+it('fails a warning-only run only under --strict', function (): void {
+    doctorFor(['pointless' => new ToollessAgent]);
+
+    $this->artisan('verdict-console:doctor')->assertSuccessful();
+    $this->artisan('verdict-console:doctor', ['--strict' => true])->assertFailed();
+});

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Tests;
+
+use Fissible\Verdict\VerdictServiceProvider;
+use Fissible\VerdictConsole\VerdictConsoleServiceProvider;
+use Illuminate\Foundation\Application;
+use Laravel\Ai\AiServiceProvider;
+use Orchestra\Testbench\TestCase as Orchestra;
+
+/**
+ * The middle tier: Verdict and Laravel AI are booted, but nothing drives an agent.
+ *
+ * {@see TestCase} boots only this package, deliberately, so the unit suite stays independent of
+ * Verdict's boot. {@see EndToEndTestCase} adds a faked provider transport and drives a whole run.
+ * This sits between them, for code that inspects the real Verdict container — the doctor's checks
+ * are only meaningful against real capabilities and real bindings.
+ */
+abstract class IntegrationTestCase extends Orchestra
+{
+    /**
+     * @param  Application  $app
+     * @return array<int, class-string>
+     */
+    protected function getPackageProviders($app): array
+    {
+        return [
+            AiServiceProvider::class,
+            VerdictServiceProvider::class,
+            VerdictConsoleServiceProvider::class,
+        ];
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Fissible\VerdictConsole\Tests\EndToEndTestCase;
+use Fissible\VerdictConsole\Tests\IntegrationTestCase;
 use Fissible\VerdictConsole\Tests\TestCase;
 
 uses(TestCase::class)->in('Feature');
@@ -11,3 +12,7 @@ uses(TestCase::class)->in('Feature');
 // separate directory rather than a heavier default: the Feature suite must stay independent of
 // Verdict's boot, and this one cannot be.
 uses(EndToEndTestCase::class)->in('EndToEnd');
+
+// Boots Verdict and Laravel AI without driving an agent, for code whose checks are only meaningful
+// against the real container.
+uses(IntegrationTestCase::class)->in('Integration');


### PR DESCRIPTION
Closes #3. Moves every silent precondition to boot time, where somebody is looking.

Findings are **data** — `code`, `severity`, `subject`, `summary`, and a `fix` that names what to change — so VC-22 can render the same set without parsing console output. `verdict-console:doctor` renders them; errors move the exit code, warnings need `--strict`, mirroring `verdict:validate`.

Its input is VC-2's `keys()` + `resolve()`, which is why enumeration had to be on that contract: a key that no longer rebuilds an agent is caught here, at the one point design §6.3 calls *preventive*, rather than when a run is already paused and waiting on it.

## What would fail these tests

| Change | Test that fails |
|---|---|
| Remove the `RemembersConversations` trait check | `separates the loud conversation precondition from the silent one` |
| Remove the approval-middleware check | `reports a missing approval middleware` (+2 that use it as a fixture) |
| Remove the #230 dead-gate check | `reports a confirmation gate that can never pause` |
| Report the table check per agent instead of once | `reports missing conversation tables once, not per agent` |
| Make `AgentHasNoBoundTool` an error | `warns rather than errors for a resumable agent that binds nothing` |
| Fail a warning-only run without `--strict` | `fails a warning-only run only under --strict` |

The first three were **run**; each fails only the tests that name it.

## Two checks from the issue were wrong, and are changed rather than kept

**The per-agent `Conversational` check is unreachable.** `resolve()` returns `Agent&RemembersConversations`, so VC-2 refuses a non-conversational agent before the doctor can ever see one. The branch was an unreachable safeguard pretending to be a real one. Removed, with a test asserting the case surfaces *through the resolver*, carrying a message that names why the shape matters.

The trait check stays, and is genuinely a separate concern: an agent can satisfy the contract **by hand** and still lack the trait — that's the silent half of the §3 pair, and it's the half that can actually reach the doctor.

**Checking that a `ConversationStore` is bound is vacuous.** Laravel AI's provider binds it and this package hard-depends on that package, so the check could never fail. What actually breaks a host is publishing and never migrating: the binding resolves, the writes fail, the paused turn is never persisted. Now checked against the conversations **table**.

## A third test tier

`TestCase` boots only this package, deliberately. `EndToEndTestCase` drives a whole run over a faked transport. The doctor needs neither — it inspects the real Verdict container without driving anything — so `EndToEndTestCase` now extends a new `IntegrationTestCase` instead of repeating its providers.

## One gotcha worth passing on

**Pest's `toContain()` is variadic.** A second string argument is asserted as *another needle*, not treated as a failure message. Three assertions here were silently stricter than intended until they failed for a reason unrelated to the code. Worth knowing before it costs someone else an afternoon.

## Verification

`composer test` green: PHPStan clean, Pint clean, 100% type coverage, 46 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)