### PR TITLE
feat: VC-7 approver-authority contract

### DIFF
--- a/src/Approvals/GateApproverAuthority.php
+++ b/src/Approvals/GateApproverAuthority.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+use Fissible\VerdictConsole\Contracts\ApproverAuthority;
+use Fissible\VerdictConsole\Exceptions\ApproverNotIdentified;
+use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Config\Repository as Config;
+
+/**
+ * The shipped authority: a Laravel Gate ability, and the authenticated user's own identifier.
+ *
+ * **It denies until the host says otherwise, and that is the feature.** Laravel's Gate returns false
+ * for an ability nobody defined, so a fresh install approves nothing. An approval console whose
+ * default is "anyone may approve" would be worse than having no console at all, so the default here
+ * is the one that fails closed: define the ability, or nothing is approvable.
+ *
+ * The ability name comes from `verdict-console.approvals.gate`, and the whole class is replaceable
+ * through the container for hosts whose authority model is not a Gate.
+ */
+final readonly class GateApproverAuthority implements ApproverAuthority
+{
+    public function __construct(
+        private Gate $gate,
+        private Config $config,
+    ) {}
+
+    public function allows(PendingApproval $approval, ?Authenticatable $approver): bool
+    {
+        // An unauthenticated approver is refused before the Gate is consulted. Passing null through
+        // would let a host's `before()` callback or a permissive ability grant an *anonymous*
+        // approval, and no ability definition should be able to reach that outcome by accident.
+        if ($approver === null) {
+            return false;
+        }
+
+        return $this->gate->forUser($approver)->allows($this->ability(), $approval);
+    }
+
+    public function actorKeyFor(?Authenticatable $approver): string
+    {
+        if ($approver === null) {
+            throw ApproverNotIdentified::make();
+        }
+
+        $key = $approver->getAuthIdentifier();
+
+        // Deliberately the bare identifier, not `ClassName:7`. This package does not invent identity
+        // conventions on a host's behalf — the same rule that keeps it from reconstructing a
+        // participant from a class name and an id. A host whose identifiers are not unique across
+        // guards, or which wants a richer label in its audit trail, binds its own authority.
+        if ($key === null || (is_string($key) && trim($key) === '')) {
+            throw ApproverNotIdentified::make();
+        }
+
+        return (string) $key;
+    }
+
+    private function ability(): string
+    {
+        $ability = $this->config->get('verdict-console.approvals.gate');
+
+        return is_string($ability) && $ability !== '' ? $ability : 'approve-verdict-action';
+    }
+}

--- a/src/Contracts/ApproverAuthority.php
+++ b/src/Contracts/ApproverAuthority.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Contracts;
+
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Fissible\VerdictConsole\Exceptions\ApproverNotIdentified;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+/**
+ * Who may decide an approval, and what name that decision is recorded under.
+ *
+ * Both answers belong to the host. This package never hard-codes authority — an approval console
+ * that lets the wrong people approve is worse than no console — and it never invents an identity
+ * for the audit trail either.
+ *
+ * Tenancy and scoping are deliberately absent here; they are VC-12.
+ */
+interface ApproverAuthority
+{
+    /**
+     * Whether this approver may decide this approval.
+     *
+     * `$approver` is null when nobody is authenticated, which must never be permitted: an anonymous
+     * approval is the absence of the control, not a permissive case.
+     */
+    public function allows(PendingApproval $approval, ?Authenticatable $approver): bool;
+
+    /**
+     * The actor key recorded against the receipt as `approvedBy` / `rejectedBy`.
+     *
+     * This is an **audit label**, not an identity to reconstruct from. It answers "who decided
+     * this?" in the host's own records, months later, and nothing in this package parses it.
+     *
+     * @throws ApproverNotIdentified when there is no approver to name
+     */
+    public function actorKeyFor(?Authenticatable $approver): string;
+}

--- a/src/Exceptions/ApproverNotIdentified.php
+++ b/src/Exceptions/ApproverNotIdentified.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Exceptions;
+
+use RuntimeException;
+
+/**
+ * There is no approver to name on the receipt.
+ *
+ * Thrown rather than falling back to `'unknown'`, `'system'`, or an empty string. Verdict records
+ * this value on the receipt and in the evidence trail, so a placeholder would produce an audit
+ * entry asserting that *somebody* approved a consequential action while naming nobody — worse than
+ * a failed approval, because it looks complete.
+ */
+final class ApproverNotIdentified extends RuntimeException
+{
+    public static function make(): self
+    {
+        return new self(
+            'No authenticated approver is available to record against this decision. An approval must '
+            .'name who made it; bind a custom ApproverAuthority if this application identifies '
+            .'approvers by something other than the authenticated user.',
+        );
+    }
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Fissible\VerdictConsole;
 
 use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
+use Fissible\VerdictConsole\Approvals\GateApproverAuthority;
 use Fissible\VerdictConsole\Console\Commands\DoctorCommand;
 use Fissible\VerdictConsole\Contracts\ApprovalPresenter;
+use Fissible\VerdictConsole\Contracts\ApproverAuthority;
 use Fissible\VerdictConsole\Contracts\ResumableAgents;
 use Fissible\VerdictConsole\Presentation\DefaultApprovalPresenter;
 use Illuminate\Support\ServiceProvider;
@@ -27,6 +29,10 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/verdict-console.php', 'verdict-console');
 
         $this->app->singleton(ApprovalPresenter::class, DefaultApprovalPresenter::class);
+
+        // Bound to the Gate-backed authority, which denies until the host defines the ability. A
+        // host whose authority model is not a Gate rebinds this contract.
+        $this->app->singleton(ApproverAuthority::class, GateApproverAuthority::class);
 
         // A singleton because registrations must survive resolution: a host registers its resolvers
         // once at boot, and every later resolve() must see them. Bound to the shipped registry so

--- a/tests/Feature/ApproverAuthorityTest.php
+++ b/tests/Feature/ApproverAuthorityTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\VerdictConsole\Approvals\GateApproverAuthority;
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Fissible\VerdictConsole\Approvals\Resumability;
+use Fissible\VerdictConsole\Contracts\ApproverAuthority;
+use Fissible\VerdictConsole\Exceptions\ApproverNotIdentified;
+use Illuminate\Auth\GenericUser;
+use Illuminate\Contracts\Auth\Access\Gate as Gateway;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\Gate;
+
+function approvalRow(): PendingApproval
+{
+    return new PendingApproval([
+        'id' => 'row-1',
+        'ingest_key' => str_repeat('a', 64),
+        'receipt_id' => 'receipt-1',
+        'tool_call_id' => 'call-1',
+        'conversation_id' => 'conv-1',
+        'resumability' => Resumability::Drivable->value,
+    ]);
+}
+
+function approver(int|string $id = 7): Authenticatable
+{
+    return new GenericUser(['id' => $id]);
+}
+
+/**
+ * The default that matters most: nothing is approvable until a host says who may approve.
+ *
+ * Laravel's Gate returns false for an ability nobody defined, so this is the shipped behaviour
+ * rather than a check this package performs — but it is asserted here because it is the single
+ * property that must never regress. An approval console whose out-of-the-box answer is "yes" is
+ * worse than no console.
+ */
+it('denies every approver until the host defines the ability', function (): void {
+    expect(app(ApproverAuthority::class)->allows(approvalRow(), approver()))->toBeFalse();
+});
+
+it('permits an approver the host gate allows', function (): void {
+    Gate::define('approve-verdict-action', fn (Authenticatable $user): bool => true);
+
+    expect(app(ApproverAuthority::class)->allows(approvalRow(), approver()))->toBeTrue();
+});
+
+it('refuses an approver the host gate denies', function (): void {
+    Gate::define('approve-verdict-action', fn (Authenticatable $user): bool => false);
+
+    expect(app(ApproverAuthority::class)->allows(approvalRow(), approver()))->toBeFalse();
+});
+
+/** The row is passed to the ability, so a host can decide per approval rather than per user. */
+it('passes the approval to the gate so authority can be per-row', function (): void {
+    Gate::define(
+        'approve-verdict-action',
+        fn (Authenticatable $user, PendingApproval $approval): bool => $approval->receipt_id === 'receipt-1',
+    );
+
+    $other = approvalRow();
+    $other->receipt_id = 'receipt-2';
+
+    expect(app(ApproverAuthority::class)->allows(approvalRow(), approver()))->toBeTrue()
+        ->and(app(ApproverAuthority::class)->allows($other, approver()))->toBeFalse();
+});
+
+/**
+ * An anonymous approval is the absence of the control, not a permissive case.
+ *
+ * **Tested against a permissive Gate double on purpose.** Laravel's real Gate already denies a null
+ * user — verified — so asserting this through the framework would pass whether or not this package
+ * guarded anything, which is a test that cannot fail for the reason it claims. Injecting a Gate that
+ * says yes to everything makes the guard the only thing that can produce a denial, so this now
+ * measures the package rather than the framework.
+ *
+ * The guard is kept rather than leaning on Laravel's behaviour because "nobody may approve
+ * anonymously" is a property this package owes its users, not one it should inherit from an
+ * undocumented framework detail that a future release could reasonably change.
+ */
+it('refuses an unauthenticated approver even when the gate would permit everything', function (): void {
+    $permissive = Mockery::mock(Gateway::class);
+    $permissive->shouldReceive('forUser')->andReturnSelf();
+    $permissive->shouldReceive('allows')->andReturnTrue();
+
+    $authority = new GateApproverAuthority($permissive, app('config'));
+
+    expect($authority->allows(approvalRow(), approver()))->toBeTrue('The double must permit an identified approver.')
+        ->and($authority->allows(approvalRow(), null))->toBeFalse('Only the null guard can deny here.');
+});
+
+/**
+ * The actor key is the audit label Verdict records on the receipt. It must name somebody.
+ *
+ * Falling back to 'unknown' or '' would produce an evidence entry asserting that a consequential
+ * action was approved while naming nobody — worse than a failed approval, because it looks complete.
+ */
+it('refuses to name an approver that does not exist', function (): void {
+    expect(fn () => app(ApproverAuthority::class)->actorKeyFor(null))
+        ->toThrow(ApproverNotIdentified::class);
+});
+
+it('refuses to name an approver whose identifier is empty', function (): void {
+    expect(fn () => app(ApproverAuthority::class)->actorKeyFor(new GenericUser(['id' => ''])))
+        ->toThrow(ApproverNotIdentified::class);
+});
+
+/** The bare identifier, not a ClassName:id convention this package would be inventing. */
+it('records the authenticated identifier as the actor key', function (): void {
+    expect(app(ApproverAuthority::class)->actorKeyFor(approver(7)))->toBe('7')
+        ->and(app(ApproverAuthority::class)->actorKeyFor(approver('operator-a')))->toBe('operator-a');
+});
+
+it('reads the ability name from configuration', function (): void {
+    config()->set('verdict-console.approvals.gate', 'approve-something-else');
+
+    Gate::define('approve-something-else', fn (Authenticatable $user): bool => true);
+    Gate::define('approve-verdict-action', fn (Authenticatable $user): bool => false);
+
+    expect(app(ApproverAuthority::class)->allows(approvalRow(), approver()))->toBeTrue();
+});
+
+it('falls back to the documented ability when configuration is blank', function (): void {
+    config()->set('verdict-console.approvals.gate', '');
+
+    Gate::define('approve-verdict-action', fn (Authenticatable $user): bool => true);
+
+    expect(app(ApproverAuthority::class)->allows(approvalRow(), approver()))->toBeTrue();
+});
+
+it('is resolvable from the container and replaceable by a host', function (): void {
+    expect(app(ApproverAuthority::class))->toBeInstanceOf(GateApproverAuthority::class);
+
+    app()->instance(ApproverAuthority::class, new class implements ApproverAuthority
+    {
+        public function allows(PendingApproval $approval, ?Authenticatable $approver): bool
+        {
+            return true;
+        }
+
+        public function actorKeyFor(?Authenticatable $approver): string
+        {
+            return 'host-defined';
+        }
+    });
+
+    // No Gate is defined, so the shipped authority would deny — proof the host's replaced it.
+    expect(app(ApproverAuthority::class)->allows(approvalRow(), null))->toBeTrue()
+        ->and(app(ApproverAuthority::class)->actorKeyFor(null))->toBe('host-defined');
+});


### PR DESCRIPTION
Closes #7. Stacked on #35 (which carries the naming-convention commit), so it retargets to `main` once that merges.

Who may approve, and what name the decision is recorded under, are both the host's answers. `ApproverAuthority` has two methods for those two questions; `GateApproverAuthority` is the shipped implementation, replaceable through the container. Tenancy stays deferred to VC-12.

## What would fail these tests

| Change | Test that fails |
|---|---|
| Remove the null-approver guard | `refuses an unauthenticated approver even when the gate would permit everything` |
| Return `'unknown'` instead of throwing | `refuses to name an approver that does not exist` |
| Permit when no ability is defined | `denies every approver…`, `refuses an approver the host gate denies`, `passes the approval to the gate…` |
| Ignore the configured ability name | `reads the ability name from configuration` |
| Stop passing the row to the ability | `passes the approval to the gate so authority can be per-row` |

The first three were **run**.

## It denies until the host says otherwise

Laravel's Gate returns false for an ability nobody defined, so a fresh install approves nothing. That's the shipped default and it's the feature — an approval console whose out-of-the-box answer is "yes" is worse than no console. Asserted, because it's the one property that must never regress.

## The actor key is a label, not an identity

The bare identifier, never `ClassName:id` — the same rule that keeps this package from reconstructing a participant by convention. It's what a host reads in its audit trail months later; nothing here parses it.

An absent or empty identifier **throws** rather than falling back to `'unknown'` or `''`. Verdict records this on the receipt and in the evidence trail, so a placeholder would assert that somebody approved a consequential action while naming nobody — worse than a failed approval, because it looks complete.

## One test was wrong, and it's the interesting part

I wrote the null-approver guard, then asserted it through Laravel's real Gate — and **removing the guard failed nothing.** Laravel already denies a null user even with a permissive `before()` callback (verified empirically), so the assertion passed whether or not this package guarded anything. It was measuring the framework.

It now runs against a Gate double that permits everything, which makes the guard the only thing that can produce a denial. And the guard stays rather than leaning on Laravel: *"nobody may approve anonymously"* is a property this package owes its users, not one to inherit from an undocumented framework detail a future release could reasonably change.

That's the third time on this project a check ran without a reachable false. It's becoming the first thing I look for rather than the last.

## Note for VC-6

`ApproverAuthority` is the seam VC-6 consumes: check `allows()`, then pass `actorKeyFor()` into `ApprovalManager::approve/reject`. This PR deliberately does not resolve an approval — that's VC-6, and it stays gated on the boundary correction.

## On #167

This pins that *this package* offers no path around the guarantee. The authoritative test — that a receipt cannot be **consumed** cross-actor — is Verdict's, and [#167](https://github.com/fissible/verdict/issues/167) should still close there. The console's test would pass even if Verdict's guarantee were broken, so it is not a substitute.

## Verification

`composer test` green: PHPStan clean, Pint clean, 100% type coverage, **62 passed / 144 assertions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)