### PR TITLE
fix: release.sh can cut a first release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **`release.sh` can cut a first release.** The script (and `scripts/prepare-release-changelog.php`)
+  were derived from Verdict's, which assumed a release history: a previous tag, a release section
+  after Unreleased, and an existing `[Unreleased]: …/compare/…` footer. A repository with none of
+  those — every freshly scaffolded package, including the coming `verdict-console-livewire` and
+  `-filament` — died at `A previous release tag is required`, which is why `0.1.0` here was
+  bootstrapped by hand. The script now follows the org script's semantics: with no tag it offers to
+  release the version already in `VERSION` with no bump, and the preparer accepts an empty previous
+  tag, an Unreleased-only changelog, and creates the link footer from `composer.json`'s `homepage`
+  (falling back to the `origin` remote). Pinned by a new `tests/Unit` suite that runs the real
+  `release.sh` against a throwaway repository with a bare origin and declines the push.
+
 ## [0.1.0] - 2026-08-24
 
 The headless approval round trip. A Verdict `require_confirmation` pause is ingested into the

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,9 @@
     backupStaticProperties="false"
 >
     <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>

--- a/release.sh
+++ b/release.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
-# release.sh — Verdict release script
+# release.sh — verdict-console release script (derived from Verdict's; adds first-release support)
 # Usage: bash release.sh [patch|minor|major]
 # Dependencies: git, php
+#
+# A repository with no tag yet releases the version already in VERSION, with no bump — the org
+# script's semantics. Verdict's variant required a previous tag because its changelog preparer
+# extended an existing link footer; the preparer here creates that footer on a first release.
 
 set -e
 
@@ -53,7 +57,6 @@ fi
 
 current=$(cat VERSION)
 last_tag=$(git describe --tags --abbrev=0 2>/dev/null || printf '')
-[[ -n "$last_tag" ]] || die "A previous release tag is required"
 
 printf 'Current version : %s\n' "$current"
 printf 'Last tag        : %s\n' "${last_tag:-none}"
@@ -93,9 +96,22 @@ else
 fi
 printf '\n'
 
+# --- first release: an untagged VERSION is itself unreleased ---
+
+first_release=0
+if [[ -z "$last_tag" ]]; then
+    printf 'No previous tag exists, so %s in VERSION is itself unreleased.\n' "$current"
+    if confirm "Release ${current} as the first release (no bump)?"; then
+        first_release=1
+    fi
+    printf '\n'
+fi
+
 # --- determine bump type ---
 
-if [[ -n "$1" ]]; then
+if [[ $first_release -eq 1 ]]; then
+    bump="none"
+elif [[ -n "$1" ]]; then
     bump="$1"
 else
     # Suggest bump from conventional commit types
@@ -118,7 +134,7 @@ EOF
 fi
 
 case "$bump" in
-    patch|minor|major) ;;
+    none|patch|minor|major) ;;
     *) die "Unknown bump type: '$bump' — use patch, minor, or major" ;;
 esac
 
@@ -126,6 +142,7 @@ esac
 
 IFS='.' read -r major minor patch <<< "$current"
 case "$bump" in
+    none)  ;;
     major) major=$((major + 1)); minor=0; patch=0 ;;
     minor) minor=$((minor + 1)); patch=0 ;;
     patch) patch=$((patch + 1)) ;;
@@ -139,8 +156,16 @@ confirm "Proceed?" || { printf 'Aborted.\n'; exit 0; }
 
 # --- update files ---
 
+# The repository URL is only consumed on a first release, to create the changelog's link footer.
+# Prefer composer.json's homepage; fall back to the origin remote, normalised to a browsable URL.
+repo_url=$(php -r 'echo json_decode(file_get_contents("composer.json"), true)["homepage"] ?? "";' 2>/dev/null || printf '')
+if [[ -z "$repo_url" ]]; then
+    repo_url=$(git remote get-url origin 2>/dev/null \
+        | sed -E 's#^git@([^:]+):#https://\1/#; s#^ssh://git@#https://#; s#\.git$##' || printf '')
+fi
+
 php scripts/prepare-release-changelog.php \
-    CHANGELOG.md "$new_version" "$last_tag" "$new_tag" "$(date +%F)"
+    CHANGELOG.md "$new_version" "$last_tag" "$new_tag" "$(date +%F)" "$repo_url"
 printf '%s\n' "$new_version" > VERSION
 
 # --- update package.json if present ---

--- a/scripts/prepare-release-changelog.php
+++ b/scripts/prepare-release-changelog.php
@@ -3,13 +3,17 @@
 
 declare(strict_types=1);
 
-if ($argc !== 6) {
-    fwrite(STDERR, "Usage: prepare-release-changelog.php <path> <version> <previous-tag> <new-tag> <date>\n");
+// A first release has no previous tag: pass '' and supply the repository URL, which is what the
+// changelog's comparison links are built from when there is no existing footer to extend.
+if ($argc !== 6 && $argc !== 7) {
+    fwrite(STDERR, "Usage: prepare-release-changelog.php <path> <version> <previous-tag|''> <new-tag> <date> [repository-url]\n");
 
     exit(1);
 }
 
 [, $path, $version, $previousTag, $newTag, $date] = $argv;
+$repositoryUrl = rtrim((string) ($argv[6] ?? ''), '/');
+$firstRelease = $previousTag === '';
 
 if (preg_match('/^\d+\.\d+\.\d+$/', $version) !== 1) {
     fwrite(STDERR, "Version must use x.y.z format.\n");
@@ -23,7 +27,13 @@ if ($newTag !== 'v'.$version) {
     exit(1);
 }
 
-if (preg_match('/^v\d+\.\d+\.\d+$/', $previousTag) !== 1) {
+if ($firstRelease) {
+    if ($repositoryUrl === '') {
+        fwrite(STDERR, "A first release (no previous tag) needs the repository URL to build the changelog links.\n");
+
+        exit(1);
+    }
+} elseif (preg_match('/^v\d+\.\d+\.\d+$/', $previousTag) !== 1) {
     fwrite(STDERR, "Previous tag must use vx.y.z format.\n");
 
     exit(1);
@@ -49,12 +59,14 @@ if (str_contains($contents, "## [{$version}]")) {
     exit(1);
 }
 
-$unreleasedPattern = '/^## \[Unreleased\]\R(?<body>.*?)(?=^## \[)/ms';
+// The Unreleased section ends at the next release heading, at the link footer, or — on a first
+// release, where neither exists yet — at the end of the file.
+$unreleasedPattern = '/^## \[Unreleased\]\R(?<body>.*?)(?=^## \[|^\[Unreleased\]: |\z)/ms';
 $matches = [];
 $matchCount = preg_match_all($unreleasedPattern, $contents, $matches);
 
 if ($matchCount !== 1) {
-    fwrite(STDERR, "Changelog must contain exactly one Unreleased section followed by a release section.\n");
+    fwrite(STDERR, "Changelog must contain exactly one Unreleased section.\n");
 
     exit(1);
 }
@@ -76,24 +88,39 @@ if ($updated === null || $replaceCount !== 1) {
     exit(1);
 }
 
-$linkPattern = '/^\[Unreleased\]: (?<base>\S+\/compare\/)'.preg_quote($previousTag, '/').'\.\.\.HEAD$/m';
-$linkMatches = [];
-$linkCount = preg_match_all($linkPattern, $updated, $linkMatches);
+if ($firstRelease) {
+    // A footer with no previous tag is a contradiction for a human to resolve, not one to paper over.
+    if (preg_match('/^\[Unreleased\]: /m', $updated) === 1) {
+        fwrite(STDERR, "The changelog already carries an Unreleased comparison link, but there is no previous tag to compare from.\n");
 
-if ($linkCount !== 1) {
-    fwrite(STDERR, "Unreleased comparison link must target {$previousTag}...HEAD.\n");
+        exit(1);
+    }
 
-    exit(1);
-}
+    // Create the footer the next release will extend. The first version links to its release page
+    // rather than a comparison, because there is nothing earlier to compare against.
+    $updated = rtrim($updated, "\n")."\n\n"
+        ."[Unreleased]: {$repositoryUrl}/compare/{$newTag}...HEAD\n"
+        ."[{$version}]: {$repositoryUrl}/releases/tag/{$newTag}\n";
+} else {
+    $linkPattern = '/^\[Unreleased\]: (?<base>\S+\/compare\/)'.preg_quote($previousTag, '/').'\.\.\.HEAD$/m';
+    $linkMatches = [];
+    $linkCount = preg_match_all($linkPattern, $updated, $linkMatches);
 
-$base = (string) $linkMatches['base'][0];
-$releaseLinks = "[Unreleased]: {$base}{$newTag}...HEAD\n[{$version}]: {$base}{$previousTag}...{$newTag}";
-$updated = preg_replace($linkPattern, $releaseLinks, $updated, 1, $linkReplaceCount);
+    if ($linkCount !== 1) {
+        fwrite(STDERR, "Unreleased comparison link must target {$previousTag}...HEAD.\n");
 
-if ($updated === null || $linkReplaceCount !== 1) {
-    fwrite(STDERR, "Unable to update changelog comparison links.\n");
+        exit(1);
+    }
 
-    exit(1);
+    $base = (string) $linkMatches['base'][0];
+    $releaseLinks = "[Unreleased]: {$base}{$newTag}...HEAD\n[{$version}]: {$base}{$previousTag}...{$newTag}";
+    $updated = preg_replace($linkPattern, $releaseLinks, $updated, 1, $linkReplaceCount);
+
+    if ($updated === null || $linkReplaceCount !== 1) {
+        fwrite(STDERR, "Unable to update changelog comparison links.\n");
+
+        exit(1);
+    }
 }
 
 $directory = dirname($path);

--- a/tests/Unit/PrepareReleaseChangelogScriptTest.php
+++ b/tests/Unit/PrepareReleaseChangelogScriptTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Process\Process;
+
+/** @return array{string, string} */
+function releaseChangelogFixture(string $contents): array
+{
+    $directory = sys_get_temp_dir().'/verdict-console-release-'.bin2hex(random_bytes(8));
+
+    if (! mkdir($directory, 0700)) {
+        throw new RuntimeException('Unable to create the release-test directory.');
+    }
+
+    $path = $directory.'/CHANGELOG.md';
+    file_put_contents($path, $contents);
+
+    return [$directory, $path];
+}
+
+/** @param list<string> $arguments */
+function runReleaseChangelogScript(array $arguments): Process
+{
+    $process = new Process([
+        PHP_BINARY,
+        dirname(__DIR__, 2).'/scripts/prepare-release-changelog.php',
+        ...$arguments,
+    ]);
+    $process->run();
+
+    return $process;
+}
+
+function removeReleaseChangelogFixture(string $directory, string $path): void
+{
+    if (is_file($path)) {
+        unlink($path);
+    }
+
+    rmdir($directory);
+}
+
+it('promotes documentation-only notes without rewriting curated release history', function (): void {
+    $original = <<<'MARKDOWN'
+# Changelog
+
+## [Unreleased]
+
+- Replace private VCS instructions with the Packagist command.
+
+## [0.1.1] - 2026-08-02
+
+- Preserve this hand-written historical note exactly.
+
+[Unreleased]: https://github.com/fissible/verdict-console/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/fissible/verdict-console/compare/v0.1.0...v0.1.1
+MARKDOWN;
+    [$directory, $path] = releaseChangelogFixture($original);
+
+    try {
+        $process = runReleaseChangelogScript([$path, '0.1.2', 'v0.1.1', 'v0.1.2', '2026-08-03']);
+        $updated = (string) file_get_contents($path);
+
+        expect($process->isSuccessful())->toBeTrue($process->getErrorOutput())
+            ->and($updated)->toContain("## [Unreleased]\n\n## [0.1.2] - 2026-08-03")
+            ->and($updated)->toContain('- Replace private VCS instructions with the Packagist command.')
+            ->and($updated)->toContain('- Preserve this hand-written historical note exactly.')
+            ->and($updated)->toContain('[Unreleased]: https://github.com/fissible/verdict-console/compare/v0.1.2...HEAD')
+            ->and($updated)->toContain('[0.1.2]: https://github.com/fissible/verdict-console/compare/v0.1.1...v0.1.2');
+    } finally {
+        removeReleaseChangelogFixture($directory, $path);
+    }
+});
+
+it('refuses to prepare a release with no curated notes', function (): void {
+    $original = <<<'MARKDOWN'
+# Changelog
+
+## [Unreleased]
+
+## [0.1.1] - 2026-08-02
+
+- Existing release.
+
+[Unreleased]: https://github.com/fissible/verdict-console/compare/v0.1.1...HEAD
+MARKDOWN;
+    [$directory, $path] = releaseChangelogFixture($original);
+
+    try {
+        $process = runReleaseChangelogScript([$path, '0.1.2', 'v0.1.1', 'v0.1.2', '2026-08-03']);
+
+        expect($process->isSuccessful())->toBeFalse()
+            ->and($process->getErrorOutput())->toContain('Unreleased changelog section is empty.')
+            ->and(file_get_contents($path))->toBe($original);
+    } finally {
+        removeReleaseChangelogFixture($directory, $path);
+    }
+});
+
+// --- first release: no previous tag, no release section, no link footer -------------------------
+//
+// Verdict's variant of this script assumed a release history exists. A repository cutting its first
+// release has none of the three things it required, and that cost verdict-console a hand-bootstrapped
+// v0.1.0. An empty previous tag is the signal; the repository URL is what the footer is built from.
+
+it('prepares a first release from an Unreleased-only changelog and creates the link footer', function (): void {
+    $original = <<<'MARKDOWN'
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [Unreleased]
+
+- **Scaffolded the package.** The first thing worth releasing.
+MARKDOWN;
+    [$directory, $path] = releaseChangelogFixture($original);
+
+    try {
+        $process = runReleaseChangelogScript([
+            $path, '0.1.0', '', 'v0.1.0', '2026-08-24', 'https://github.com/fissible/example',
+        ]);
+        $updated = (string) file_get_contents($path);
+
+        expect($process->isSuccessful())->toBeTrue($process->getErrorOutput())
+            ->and($updated)->toContain("## [Unreleased]\n\n## [0.1.0] - 2026-08-24\n\n- **Scaffolded the package.** The first thing worth releasing.")
+            ->and($updated)->toContain('All notable changes to this package will be documented in this file.')
+            ->and($updated)->toEndWith(
+                "[Unreleased]: https://github.com/fissible/example/compare/v0.1.0...HEAD\n"
+                ."[0.1.0]: https://github.com/fissible/example/releases/tag/v0.1.0\n",
+            )
+            // The shape a *second* release then needs is exactly the one the first produced.
+            ->and(substr_count($updated, '[Unreleased]:'))->toBe(1);
+    } finally {
+        removeReleaseChangelogFixture($directory, $path);
+    }
+});
+
+it('refuses a first release when the changelog already carries an Unreleased comparison link', function (): void {
+    // A footer with no previous tag is a contradiction a human should resolve, not one the script
+    // should paper over by inventing or discarding a link.
+    $original = <<<'MARKDOWN'
+# Changelog
+
+## [Unreleased]
+
+- Something.
+
+[Unreleased]: https://github.com/fissible/example/compare/v0.0.9...HEAD
+MARKDOWN;
+    [$directory, $path] = releaseChangelogFixture($original);
+
+    try {
+        $process = runReleaseChangelogScript([
+            $path, '0.1.0', '', 'v0.1.0', '2026-08-24', 'https://github.com/fissible/example',
+        ]);
+
+        expect($process->isSuccessful())->toBeFalse()
+            ->and($process->getErrorOutput())->toContain('no previous tag')
+            ->and(file_get_contents($path))->toBe($original);
+    } finally {
+        removeReleaseChangelogFixture($directory, $path);
+    }
+});
+
+it('refuses a first release without a repository URL to build the footer from', function (): void {
+    $original = <<<'MARKDOWN'
+# Changelog
+
+## [Unreleased]
+
+- Something.
+MARKDOWN;
+    [$directory, $path] = releaseChangelogFixture($original);
+
+    try {
+        $process = runReleaseChangelogScript([$path, '0.1.0', '', 'v0.1.0', '2026-08-24']);
+
+        expect($process->isSuccessful())->toBeFalse()
+            ->and($process->getErrorOutput())->toContain('repository URL')
+            ->and(file_get_contents($path))->toBe($original);
+    } finally {
+        removeReleaseChangelogFixture($directory, $path);
+    }
+});

--- a/tests/Unit/ReleaseScriptFirstReleaseTest.php
+++ b/tests/Unit/ReleaseScriptFirstReleaseTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Runs the real `release.sh` against a throwaway repository with a bare `origin`, answering its
+ * prompts over stdin. Nothing leaves the temp directory: the push prompt is declined, and the bare
+ * repository is what `git fetch origin main` talks to.
+ *
+ * @return array{string, string} the work tree and the bare origin
+ */
+function scaffoldFirstReleaseRepository(): array
+{
+    $root = sys_get_temp_dir().'/verdict-console-release-sh-'.bin2hex(random_bytes(8));
+    $origin = $root.'/origin.git';
+    $work = $root.'/work';
+
+    foreach ([$root, $work, $work.'/scripts'] as $directory) {
+        if (! mkdir($directory, 0700, true)) {
+            throw new RuntimeException("Unable to create {$directory}.");
+        }
+    }
+
+    $repo = dirname(__DIR__, 2);
+    copy($repo.'/release.sh', $work.'/release.sh');
+    copy($repo.'/scripts/prepare-release-changelog.php', $work.'/scripts/prepare-release-changelog.php');
+
+    file_put_contents($work.'/VERSION', "0.1.0\n");
+    file_put_contents($work.'/composer.json', json_encode(['name' => 'fissible/example'], JSON_THROW_ON_ERROR)."\n");
+    file_put_contents($work.'/README.md', "# Example\n\n```bash\ncomposer require fissible/example:^0.0\n```\n");
+    file_put_contents($work.'/CHANGELOG.md', <<<'MARKDOWN'
+# Changelog
+
+## [Unreleased]
+
+- **Scaffolded the package.** The first thing worth releasing.
+
+MARKDOWN);
+
+    $git = static function (string $cwd, string ...$arguments): string {
+        $process = new Process(['git', ...$arguments], $cwd, [
+            'GIT_AUTHOR_NAME' => 'Test', 'GIT_AUTHOR_EMAIL' => 'test@example.com',
+            'GIT_COMMITTER_NAME' => 'Test', 'GIT_COMMITTER_EMAIL' => 'test@example.com',
+        ]);
+        $process->mustRun();
+
+        return trim($process->getOutput());
+    };
+
+    $git($root, 'init', '--quiet', '--bare', '--initial-branch=main', $origin);
+    $git($work, 'init', '--quiet', '--initial-branch=main');
+    $git($work, 'add', '-A');
+    $git($work, 'commit', '--quiet', '-m', 'feat: scaffold the package');
+    $git($work, 'remote', 'add', 'origin', $origin);
+    $git($work, 'push', '--quiet', '-u', 'origin', 'main');
+
+    return [$work, $origin];
+}
+
+function removeFirstReleaseRepository(string $work): void
+{
+    $root = dirname($work);
+    $process = new Process(['rm', '-rf', $root]);
+    $process->run();
+}
+
+/** @param list<string> $answers */
+function runReleaseScript(string $work, array $answers, string ...$arguments): Process
+{
+    $process = new Process(['bash', 'release.sh', ...$arguments], $work, [
+        'GIT_AUTHOR_NAME' => 'Test', 'GIT_AUTHOR_EMAIL' => 'test@example.com',
+        'GIT_COMMITTER_NAME' => 'Test', 'GIT_COMMITTER_EMAIL' => 'test@example.com',
+    ]);
+    $process->setInput(implode("\n", $answers)."\n");
+    $process->run();
+
+    return $process;
+}
+
+it('cuts a first release from an untagged repository without a bump', function (): void {
+    [$work, $origin] = scaffoldFirstReleaseRepository();
+
+    try {
+        // first release as-is? → y · Proceed? → y · Push to origin? → n
+        $process = runReleaseScript($work, ['y', 'y', 'n']);
+
+        $tags = (new Process(['git', 'tag', '--list'], $work))->mustRun()->getOutput();
+        $subject = (new Process(['git', 'log', '-1', '--format=%s'], $work))->mustRun()->getOutput();
+        $originTags = (new Process(['git', '--git-dir', $origin, 'tag', '--list'], $work))->mustRun()->getOutput();
+        $changelog = (string) file_get_contents($work.'/CHANGELOG.md');
+        $readme = (string) file_get_contents($work.'/README.md');
+
+        expect($process->isSuccessful())->toBeTrue($process->getOutput().$process->getErrorOutput())
+            ->and($process->getOutput())->toContain('No previous tag exists, so 0.1.0 in VERSION is itself unreleased.')
+            ->and(trim($tags))->toBe('v0.1.0')
+            ->and(trim($subject))->toBe('chore: release v0.1.0')
+            ->and(trim((string) file_get_contents($work.'/VERSION')))->toBe('0.1.0')
+            ->and($changelog)->toContain("## [Unreleased]\n\n## [0.1.0] - ".date('Y-m-d'))
+            ->and($changelog)->toContain('[Unreleased]: ')
+            ->and($changelog)->toContain('/compare/v0.1.0...HEAD')
+            ->and($changelog)->toContain('[0.1.0]: ')
+            ->and($changelog)->toContain('/releases/tag/v0.1.0')
+            ->and($readme)->toContain('composer require fissible/example:^0.1')
+            // The push prompt was declined: the bare origin must not have the tag.
+            ->and(trim($originTags))->toBe('');
+    } finally {
+        removeFirstReleaseRepository($work);
+    }
+})->skipOnWindows();
+
+it('still requires a bump once a previous tag exists', function (): void {
+    [$work] = scaffoldFirstReleaseRepository();
+
+    try {
+        (new Process(['git', 'tag', '-a', 'v0.1.0', '-m', 'v0.1.0'], $work, [
+            'GIT_COMMITTER_NAME' => 'Test', 'GIT_COMMITTER_EMAIL' => 'test@example.com',
+        ]))->mustRun();
+
+        // An explicit bump argument, then: Proceed? → n. The first-release prompt must not appear.
+        $process = runReleaseScript($work, ['n'], 'patch');
+
+        expect($process->getOutput())->not->toContain('No previous tag exists')
+            ->and($process->getOutput())->toContain('New version: 0.1.0 → 0.1.1');
+    } finally {
+        removeFirstReleaseRepository($work);
+    }
+})->skipOnWindows();


### PR DESCRIPTION
## Summary
- `release.sh` no longer dies with `A previous release tag is required`; with no tag it offers to release the version already in `VERSION` with no bump (the org script's semantics).
- `scripts/prepare-release-changelog.php` accepts an empty previous tag, an Unreleased-only changelog, and **creates** the link footer from `composer.json`'s `homepage` (fallback: normalised `origin` remote) instead of requiring one to extend.
- New `tests/Unit` suite pins both scripts, including a hermetic end-to-end run of the real `release.sh`.

## Why
The release tooling was copied from Verdict's variant, which assumes a release history exists. A freshly scaffolded package trips four blockers in sequence (tag guard, preparer's tag format, preparer's footer/section requirement, README constraint guard). That is why `v0.1.0` here had to be bootstrapped by hand, and `verdict-console-livewire` / `-filament` will be scaffolded from this repo and would hit the identical wall. The README guard is deliberate and stays; the other three are fixed.

## Test plan
- [x] Unit tests pass (`composer test`: phpstan, pint, 100% type coverage, pest — 111 tests)
- [x] New behaviour has a test — `tests/Unit/PrepareReleaseChangelogScriptTest.php` (existing behaviour mirrored from Verdict's tests + three first-release paths) and `tests/Unit/ReleaseScriptFirstReleaseTest.php`, which runs the real script against a throwaway repo with a bare `origin`, answers `y / y / n` over stdin, and asserts the tag, commit, changelog shape, README constraint rewrite, and that nothing was pushed. Skipped on Windows.
- [x] Tested manually: watched the suite fail first (4 failures: the three preparer cases and the `release.sh` run died at the tag guard), then pass after the change.

## Notes
- A changelog that already carries an `[Unreleased]:` link but has no tag is **refused** as a contradiction rather than repaired — a human should decide which is wrong.
- Verdict's own copy of these scripts has the same latent gap; harmless there (it has tags), but worth knowing if another PHP repo is ever cut from Verdict rather than from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
