### PR TITLE
feat: console-owned operational state for notifications and resume attempts

### DIFF
--- a/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub
+++ b/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Console-owned operational state (VC-9, design §6.2).
+ *
+ * **A second migration, not an amendment to the first.** `v0.1.0` shipped the create migration, and
+ * it publishes to a fixed dated filename — so an adopter on 0.1.0 has already run it and would never
+ * receive a column added there. Amending a published migration divides adopters into those whose
+ * schema matches the code and those whose does not, silently. The `unresumable_reason` column was
+ * amended in place precisely because that stub was still unreleased; that licence expired at v0.1.0.
+ *
+ * What lands here is only what the console *does*, never what Verdict *decides*. Receipt status and
+ * expiry remain live Verdict reads (design §5).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('verdict_console_pending_approvals', function (Blueprint $table): void {
+            // How many times recovery has tried to drive this row. Console work, not receipt state:
+            // a receipt that is still valid can have been resumed unsuccessfully several times, and
+            // reconciliation (VC-10) needs to tell "never attempted" from "attempted and failed".
+            $table->unsignedInteger('resume_attempts')->default(0);
+
+            // When the most recent attempt began. Null until one does. Kept beside the counter
+            // because "three attempts" and "three attempts, the last an hour ago" call for different
+            // operator action, and the counter alone cannot say which.
+            $table->timestamp('last_resume_attempt_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('verdict_console_pending_approvals', function (Blueprint $table): void {
+            $table->dropColumn(['resume_attempts', 'last_resume_attempt_at']);
+        });
+    }
+};

--- a/database/migrations/create_verdict_console_approval_notifications_table.php.stub
+++ b/database/migrations/create_verdict_console_approval_notifications_table.php.stub
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Notification idempotency and delivery state (VC-9, design §6.2).
+ *
+ * **A table rather than a column, because the cardinality is one-to-many.** One paused approval can
+ * be notified several times — a reviewer assigned, a reminder, an escalation — each with its own
+ * delivery outcome. Folding that into a JSON column on the approval row would mean reading the whole
+ * value, mutating it in PHP, and writing it back; two concurrent claims for *different* notifications
+ * would both pass a guard on their own key and the second write would discard the first.
+ *
+ * **Idempotency is the unique index, not a check.** `(pending_approval_id, notification_key)` is
+ * unique, so "has this already been sent" is answered by whether the insert succeeded. The same
+ * reasoning the pause ingest uses: delegating the decision to the database closes the check-then-act
+ * window entirely, because there is no window.
+ *
+ * Nothing here mirrors Verdict. A notification records that *this console* told somebody something.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('verdict_console_approval_notifications', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+
+            $table->uuid('pending_approval_id');
+            $table->foreign('pending_approval_id')
+                ->references('id')
+                ->on('verdict_console_pending_approvals')
+                ->cascadeOnDelete();
+
+            // The host's name for *what* was sent — 'assigned', 'reminder-1', 'escalation'. Opaque to
+            // this package: it never parses or orders these, it only refuses to repeat one.
+            $table->string('notification_key', 64);
+
+            // Delivery outcome, recorded once known. Both null means claimed and still in flight.
+            $table->timestamp('delivered_at')->nullable();
+            $table->timestamp('failed_at')->nullable();
+
+            // The failure's shape, for an operator deciding whether to retry. Never the recipient's
+            // address or the message body — this table is an audit of console work, not a mail log.
+            $table->string('failure_reason', 255)->nullable();
+
+            $table->timestamps();
+
+            // The whole idempotency mechanism.
+            $table->unique(['pending_approval_id', 'notification_key']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('verdict_console_approval_notifications');
+    }
+};

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -148,6 +148,13 @@ notification idempotency + delivery-failure state; assignment / SLA timers; agen
 version; resume-attempt state; and **reconciliation of "receipt approved but resume failed"** (else
 retries duplicate notices or strand approved actions).
 
+**Not all of it lands at once, and one item cannot land yet.** VC-9 ships notification idempotency,
+delivery state, and resume attempts; assignment and SLA timers wait for the first operator surface
+(v0.4). The **agent-reconstruction version has no producer**: `ResumableAgents` reports no such value,
+so recording one would mean this package inventing a version on the host's behalf — the same mistake
+as reconstructing a participant from a class name and an id. It is deferred until that contract gains
+a way to report it (#51), and the column and its consumer are separately scheduled after that.
+
 ### 6.3 Disposition bridge (Laravel AI → runtime)
 Listener on `ToolApprovalRequested`. For each pending item, call
 **`ApprovalManager::challengeForToolCall($toolCallId)`** — not the store's `findForToolCall()`, which

--- a/docs/planning/ISSUES.md
+++ b/docs/planning/ISSUES.md
@@ -193,11 +193,32 @@ sensitive args are not persisted verbatim under the default); the contract is do
 ## Milestone v0.2.0 — Production-grade workflow
 
 ### VC-9 · Operational state: notification idempotency + resume-attempt · M · `type:feature` `area:runtime`
-**Deps:** VC-4. **Scope:** console-owned operational columns (design §6.2) — notification
-idempotency/delivery state and a resume-attempt counter/agent-reconstruction version. **No second
-authorization state**; status still read from Verdict. (Assignment/SLA are deferred to the first
-operator-surface milestone, v0.4.)
-**Acceptance:** transitions tested; no column duplicates Verdict receipt status/expiry.
+**Deps:** VC-4. **Scope:** console-owned operational state (design §6.2) — notification
+idempotency/delivery state and a resume-attempt counter. **No second authorization state**; status
+still read from Verdict. (Assignment/SLA are deferred to the first operator-surface milestone, v0.4.)
+
+**Notification idempotency is a table, not a column on the row.** One approval is notified many times
+— assigned, reminder, escalation — each with its own outcome, so the cardinality is one-to-many and a
+JSON column would force a read-modify-write whose concurrent claims for *different* keys overwrite
+each other. Uniqueness on `(pending_approval_id, notification_key)` makes the database the arbiter,
+the same mechanism VC-4's ingest uses. A claim is written **before** the send is attempted: recording
+only successes makes "died mid-send" indistinguishable from "never started", and the retry duplicates.
+
+**Anything added after v0.1.0 is a new migration, never an amendment.** A published migration has
+already run for every adopter of the release that shipped it, so editing it reaches new installs only
+and silently divides the two. `unresumable_reason` was amended in place because that stub was still
+unreleased; v0.1.0 ended that licence.
+
+**`agent_reconstruction_version` is deferred — scoped out, not overlooked.** Nothing can write it:
+`ResumableAgents` exposes `keyFor`/`resolve`/`keys` and reports no reconstruction version, so shipping
+the column would add a field with no producer — the defect `participant_reference` had before VC-5
+supplied its seam. It needs an explicit `ResumableAgents` contract change, owned and justified as
+VC-2 work (VC-2 is closed, so that is a new issue: **#51**). Whatever consumes it — VC-10 deciding whether a
+row's resolver key predates a redeploy — must wait for that contract, not infer a version here.
+
+**Acceptance:** transitions tested; no column duplicates Verdict receipt status/expiry; the released
+create migration is asserted *not* to carry the new columns; published migrations sort in an order
+that can run on a fresh install.
 **Refs:** design §6.2.
 
 ### VC-10 · Resume-failure reconciliation (phase-specific) · M · `type:feature` `area:runtime`

--- a/release.sh
+++ b/release.sh
@@ -164,8 +164,11 @@ if [[ -z "$repo_url" ]]; then
         | sed -E 's#^git@([^:]+):#https://\1/#; s#^ssh://git@#https://#; s#\.git$##' || printf '')
 fi
 
+# UTC, not local time. The annotated tag and the GitHub Release are both stamped in UTC, so a local
+# date makes the changelog disagree with them for anyone west of Greenwich cutting a release in the
+# evening -- and makes the same commit produce different changelog dates depending on who ran it.
 php scripts/prepare-release-changelog.php \
-    CHANGELOG.md "$new_version" "$last_tag" "$new_tag" "$(date +%F)" "$repo_url"
+    CHANGELOG.md "$new_version" "$last_tag" "$new_tag" "$(date -u +%F)" "$repo_url"
 printf '%s\n' "$new_version" > VERSION
 
 # --- update package.json if present ---

--- a/src/Approvals/ApprovalNotification.php
+++ b/src/Approvals/ApprovalNotification.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/**
+ * One thing this console told somebody about one paused approval.
+ *
+ * A row exists because a notification was *claimed*, not because it arrived: `delivered_at` and
+ * `failed_at` are both null while it is in flight. That distinction is the point — an operator asking
+ * "was anyone told?" needs to tell "never attempted" from "attempted and lost", and a table that only
+ * recorded successes could answer neither. (Design §6.2.)
+ *
+ * @property string $id
+ * @property string $pending_approval_id
+ * @property string $notification_key
+ * @property Carbon|null $delivered_at
+ * @property Carbon|null $failed_at
+ * @property string|null $failure_reason
+ */
+final class ApprovalNotification extends Model
+{
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $table = 'verdict_console_approval_notifications';
+
+    protected $guarded = [];
+
+    /** Claimed, and neither delivered nor failed yet. */
+    public function isInFlight(): bool
+    {
+        return $this->delivered_at === null && $this->failed_at === null;
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'delivered_at' => 'datetime',
+            'failed_at' => 'datetime',
+        ];
+    }
+}

--- a/src/Approvals/ApprovalNotificationStore.php
+++ b/src/Approvals/ApprovalNotificationStore.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Str;
+
+/**
+ * Notification idempotency and delivery state for paused approvals (design §6.2).
+ *
+ * The console owns this because nothing else can: Verdict knows a receipt is pending, not whether a
+ * human was ever told about it. Without a durable record, a retried reconciliation pass re-notifies
+ * everybody it already notified.
+ */
+final class ApprovalNotificationStore
+{
+    /**
+     * Claim the right to send one notification, or find that somebody already has.
+     *
+     * **The unique index decides, not a read.** `claimed !== null` is the answer to "should I send
+     * this", and it is produced by attempting the insert rather than by checking first: two workers
+     * reconciling the same row concurrently both pass any `exists()` check before either writes.
+     * Delegating to `(pending_approval_id, notification_key)` closes that window because there is no
+     * window — the same reasoning `PendingApprovalStore::ingest()` uses for redelivery.
+     *
+     * A claim is deliberately not a delivery. The row is written *before* the send is attempted, so
+     * a process that dies mid-send leaves evidence that it tried; recording only on success would
+     * make a crash indistinguishable from never having started, and the retry would send twice.
+     *
+     * @return ApprovalNotification|null the claim, or null when this notification was already claimed
+     */
+    public function claim(PendingApproval $approval, string $notificationKey): ?ApprovalNotification
+    {
+        $now = now();
+
+        try {
+            ApprovalNotification::query()->insert([
+                'id' => Str::uuid()->toString(),
+                'pending_approval_id' => $approval->getKey(),
+                'notification_key' => $notificationKey,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        } catch (UniqueConstraintViolationException) {
+            return null;
+        }
+
+        return $this->find($approval, $notificationKey);
+    }
+
+    /** Record that the claimed notification reached its recipient. */
+    public function markDelivered(ApprovalNotification $notification): void
+    {
+        $notification->forceFill(['delivered_at' => now(), 'failed_at' => null, 'failure_reason' => null])->save();
+    }
+
+    /**
+     * Record that the claimed notification did not reach its recipient, and why.
+     *
+     * The reason is truncated rather than rejected: this is a diagnostic an operator reads while
+     * deciding whether to retry, and losing the whole record to a long exception message would cost
+     * more than losing the tail of one.
+     */
+    public function markFailed(ApprovalNotification $notification, string $reason): void
+    {
+        $notification->forceFill([
+            'failed_at' => now(),
+            'delivered_at' => null,
+            'failure_reason' => Str::limit($reason, 250),
+        ])->save();
+    }
+
+    /** The claim for one notification of one approval, if this console ever made it. */
+    public function find(PendingApproval $approval, string $notificationKey): ?ApprovalNotification
+    {
+        return ApprovalNotification::query()
+            ->where('pending_approval_id', $approval->getKey())
+            ->where('notification_key', $notificationKey)
+            ->first();
+    }
+
+    /**
+     * Every notification claimed for one approval, oldest first.
+     *
+     * @return Collection<int, ApprovalNotification>
+     */
+    public function forApproval(PendingApproval $approval): Collection
+    {
+        return ApprovalNotification::query()
+            ->where('pending_approval_id', $approval->getKey())
+            ->orderBy('created_at')
+            ->get();
+    }
+}

--- a/src/Approvals/PendingApproval.php
+++ b/src/Approvals/PendingApproval.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fissible\VerdictConsole\Approvals;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 
 /**
  * The console's queryable index of paused approvals.
@@ -26,6 +27,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property array<string, mixed>|null $presentation
  * @property Resumability $resumability
  * @property UnresumableReason|null $unresumable_reason
+ * @property int $resume_attempts
+ * @property Carbon|null $last_resume_attempt_at
  */
 final class PendingApproval extends Model
 {
@@ -62,6 +65,7 @@ final class PendingApproval extends Model
             'presentation' => 'array',
             'resumability' => Resumability::class,
             'unresumable_reason' => UnresumableReason::class,
+            'last_resume_attempt_at' => 'datetime',
         ];
     }
 }

--- a/src/Approvals/PendingApprovalStore.php
+++ b/src/Approvals/PendingApprovalStore.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fissible\VerdictConsole\Approvals;
 
 use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 /**
@@ -142,6 +143,39 @@ final class PendingApprovalStore
         return PendingApproval::query()
             ->where('ingest_key', PendingApproval::ingestKey($toolCallId, $conversationId))
             ->first();
+    }
+
+    /**
+     * Record that a resume attempt is beginning, and say which attempt it is.
+     *
+     * **Locked rather than incremented-then-read.** `increment()` followed by a separate `value()`
+     * is two statements: a concurrent attempt can land between them, and the caller is handed a
+     * number that belongs to somebody else. That is fine for a metric and wrong for this, because
+     * VC-10 reconciliation decides what to do from *which* attempt this is — a first attempt and a
+     * fourth call for different action.
+     *
+     * The transaction is the console's own table only. It must not wrap a Verdict mutation:
+     * `SecurityStateTransaction` refuses an outer transaction, by design (design §12).
+     *
+     * @return int this caller's attempt number, counting from 1
+     */
+    public function beginResumeAttempt(PendingApproval $approval): int
+    {
+        return DB::transaction(function () use ($approval): int {
+            $locked = PendingApproval::query()
+                ->whereKey($approval->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $attempt = $locked->resume_attempts + 1;
+
+            $locked->forceFill([
+                'resume_attempts' => $attempt,
+                'last_resume_attempt_at' => now(),
+            ])->save();
+
+            return $attempt;
+        });
     }
 
     /**

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -73,9 +73,20 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         // a console table appearing on `migrate` without the host having asked for it is the kind of
         // surprise a security-adjacent package should never spring. Verdict publishes its own
         // migrations the same way.
+        // Dated filenames are fixed, and the ordering between them is load-bearing: the operational
+        // columns and the notifications table both require the pause table to exist. New migrations
+        // are *added* here, never folded into an earlier one — a published migration has already run
+        // for every adopter of the release that shipped it, so amending one changes new installs only
+        // and silently divides the two.
         $this->publishesMigrations([
             __DIR__.'/../database/migrations/create_verdict_console_pending_approvals_table.php.stub' => database_path(
                 'migrations/2026_08_21_000001_create_verdict_console_pending_approvals_table.php',
+            ),
+            __DIR__.'/../database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub' => database_path(
+                'migrations/2026_08_25_000001_add_operational_state_to_verdict_console_pending_approvals_table.php',
+            ),
+            __DIR__.'/../database/migrations/create_verdict_console_approval_notifications_table.php.stub' => database_path(
+                'migrations/2026_08_25_000002_create_verdict_console_approval_notifications_table.php',
             ),
         ], ['verdict-console', 'verdict-console-migrations']);
     }

--- a/tests/Feature/ApprovalNotificationStoreTest.php
+++ b/tests/Feature/ApprovalNotificationStoreTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\VerdictConsole\Approvals\ApprovalNotification;
+use Fissible\VerdictConsole\Approvals\ApprovalNotificationStore;
+use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function (): void {
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_approval_notifications_table.php.stub')->up();
+
+    $this->approvals = new PendingApprovalStore;
+    $this->notifications = new ApprovalNotificationStore;
+    $this->row = $this->approvals->ingest(toolCallId: 'call_1', conversationId: 'conv_1');
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists('verdict_console_approval_notifications');
+    Schema::dropIfExists('verdict_console_pending_approvals');
+});
+
+it('claims a notification once and refuses the second claim', function (): void {
+    $first = $this->notifications->claim($this->row, 'assigned');
+    $second = $this->notifications->claim($this->row, 'assigned');
+
+    expect($first)->toBeInstanceOf(ApprovalNotification::class)
+        ->and($second)->toBeNull('A second claim must not authorize a second send.')
+        ->and(ApprovalNotification::query()->count())->toBe(1);
+});
+
+/** Different notifications about the same approval are independent; only a repeat is refused. */
+it('claims distinct notifications for the same approval', function (): void {
+    expect($this->notifications->claim($this->row, 'assigned'))->not->toBeNull()
+        ->and($this->notifications->claim($this->row, 'reminder-1'))->not->toBeNull()
+        ->and($this->notifications->claim($this->row, 'escalation'))->not->toBeNull()
+        ->and(ApprovalNotification::query()->count())->toBe(3);
+});
+
+/**
+ * The same notification key for two different approvals is two different notifications.
+ *
+ * Uniqueness is on the pair. Keying on the notification alone would mean the first approval ever
+ * assigned silenced every later one.
+ */
+it('scopes idempotency to the approval, not the notification key alone', function (): void {
+    $other = $this->approvals->ingest(toolCallId: 'call_2', conversationId: 'conv_2');
+
+    expect($this->notifications->claim($this->row, 'assigned'))->not->toBeNull()
+        ->and($this->notifications->claim($other, 'assigned'))->not->toBeNull()
+        ->and(ApprovalNotification::query()->count())->toBe(2);
+});
+
+/**
+ * A claim is written before the send is attempted, so a crash mid-send leaves evidence.
+ *
+ * Recording only on success would make "died while sending" indistinguishable from "never started",
+ * and the retry would send a second time — the duplicate this table exists to prevent.
+ */
+it('records a claim as in flight until its outcome is known', function (): void {
+    $claim = $this->notifications->claim($this->row, 'assigned');
+
+    expect($claim->isInFlight())->toBeTrue()
+        ->and($claim->delivered_at)->toBeNull()
+        ->and($claim->failed_at)->toBeNull();
+});
+
+it('records delivery', function (): void {
+    $claim = $this->notifications->claim($this->row, 'assigned');
+    $this->notifications->markDelivered($claim);
+
+    $stored = ApprovalNotification::query()->sole();
+
+    expect($stored->delivered_at)->not->toBeNull()
+        ->and($stored->failed_at)->toBeNull()
+        ->and($stored->isInFlight())->toBeFalse();
+});
+
+it('records failure with its reason', function (): void {
+    $claim = $this->notifications->claim($this->row, 'assigned');
+    $this->notifications->markFailed($claim, 'SMTP 550 mailbox unavailable');
+
+    $stored = ApprovalNotification::query()->sole();
+
+    expect($stored->failed_at)->not->toBeNull()
+        ->and($stored->delivered_at)->toBeNull()
+        ->and($stored->failure_reason)->toBe('SMTP 550 mailbox unavailable');
+});
+
+/** A long exception message must cost the tail of a diagnostic, never the whole record. */
+it('truncates an overlong failure reason rather than losing the record', function (): void {
+    $claim = $this->notifications->claim($this->row, 'assigned');
+    $this->notifications->markFailed($claim, str_repeat('x', 5000));
+
+    $stored = ApprovalNotification::query()->sole();
+
+    expect($stored->failed_at)->not->toBeNull()
+        ->and(strlen((string) $stored->failure_reason))->toBeLessThanOrEqual(255);
+});
+
+/** A retry that succeeds must not leave the row claiming both outcomes. */
+it('replaces a failure with a delivery when a retry succeeds', function (): void {
+    $claim = $this->notifications->claim($this->row, 'assigned');
+    $this->notifications->markFailed($claim, 'timeout');
+    $this->notifications->markDelivered($claim);
+
+    $stored = ApprovalNotification::query()->sole();
+
+    expect($stored->delivered_at)->not->toBeNull()
+        ->and($stored->failed_at)->toBeNull()
+        ->and($stored->failure_reason)->toBeNull();
+});
+
+it('finds a claim and lists every notification for an approval', function (): void {
+    $this->notifications->claim($this->row, 'assigned');
+    $this->notifications->claim($this->row, 'reminder-1');
+
+    expect($this->notifications->find($this->row, 'assigned'))->not->toBeNull()
+        ->and($this->notifications->find($this->row, 'never-sent'))->toBeNull()
+        ->and($this->notifications->forApproval($this->row))->toHaveCount(2);
+});
+
+/**
+ * This table records console work, never Verdict's decision or the recipient's details.
+ *
+ * A `recipient` or `body` column would turn an audit of what the console did into a copy of the
+ * message itself, which is the host's to keep and ADR 0008's fingerprint rule to answer for.
+ */
+it('mirrors no Verdict state and stores no message content', function (): void {
+    $columns = Schema::getColumnListing('verdict_console_approval_notifications');
+
+    expect($columns)->not->toContain('receipt_id')
+        ->and($columns)->not->toContain('status')
+        ->and($columns)->not->toContain('expires_at')
+        ->and($columns)->not->toContain('recipient')
+        ->and($columns)->not->toContain('body');
+});

--- a/tests/Feature/MigrationPublishingTest.php
+++ b/tests/Feature/MigrationPublishingTest.php
@@ -29,6 +29,56 @@ it('publishes the pending-approvals migration under its own tag', function (): v
     File::cleanDirectory($target);
 });
 
+/**
+ * Every migration publishes, and later ones sort after the table they alter.
+ *
+ * The second half is not cosmetic: Laravel runs published migrations in filename order, so an
+ * operational-state migration dated before the create migration would fail on a fresh install with a
+ * missing table — and pass forever on the developer's machine, where the table already exists.
+ */
+it('publishes every migration, in an order that can actually run', function (): void {
+    $target = database_path('migrations');
+
+    File::exists($target) && File::cleanDirectory($target);
+
+    $this->artisan('vendor:publish', ['--tag' => 'verdict-console-migrations', '--force' => true])
+        ->assertSuccessful();
+
+    $published = collect(File::files($target))
+        ->map(fn ($file): string => $file->getFilename())
+        ->sort()
+        ->values();
+
+    expect($published)->toHaveCount(3);
+
+    $position = fn (string $fragment): int => $published->search(fn (string $name): bool => str_contains($name, $fragment));
+
+    expect($position('create_verdict_console_pending_approvals_table'))
+        ->toBeLessThan($position('add_operational_state_to_verdict_console_pending_approvals_table'), 'A column cannot be added to a table that does not exist yet.')
+        ->and($position('create_verdict_console_pending_approvals_table'))
+        ->toBeLessThan($position('create_verdict_console_approval_notifications_table'), 'The notifications foreign key requires the pause table.');
+
+    File::cleanDirectory($target);
+});
+
+/**
+ * A published migration has already run for every adopter of the release that shipped it.
+ *
+ * Adding a column to the create migration therefore reaches new installs only, and silently divides
+ * adopters into those whose schema matches the code and those whose does not. `unresumable_reason`
+ * was amended in place because its stub was still unreleased; v0.1.0 ended that licence. This asserts
+ * the shipped create migration still describes v0.1.0's table and nothing later.
+ */
+it('leaves the released create migration alone and adds operational state separately', function (): void {
+    $create = file_get_contents(dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub');
+    $added = file_get_contents(dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub');
+
+    expect($create)->not->toContain('resume_attempts', 'v0.1.0 shipped without this column; adding it here reaches new installs only.')
+        ->and($create)->not->toContain('last_resume_attempt_at')
+        ->and($added)->toContain('resume_attempts')
+        ->and($added)->toContain('last_resume_attempt_at');
+});
+
 /** The package must not run its own migrations behind the host's back. */
 it('does not load the migration automatically', function (): void {
     expect(app('migrator')->paths())->not->toContain(dirname(__DIR__, 2).'/database/migrations');

--- a/tests/Feature/PendingApprovalStoreTest.php
+++ b/tests/Feature/PendingApprovalStoreTest.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Str;
 
 beforeEach(function (): void {
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
 
     $this->store = new PendingApprovalStore;
 });
@@ -193,6 +194,58 @@ it('stores no copy of the receipt status and no expiry of its own', function ():
         ->and($columns)->not->toContain('receipt_status')
         ->and($columns)->not->toContain('expires_at')
         ->and($columns)->not->toContain('decided_at');
+});
+
+/**
+ * VC-9's own acceptance clause, asserted against the schema rather than trusted to review.
+ *
+ * Operational state is what the *console* did — attempts it made, people it told. The temptation it
+ * guards against is a column like `approved_at` or `receipt_expires_at`, which reads as harmless
+ * caching and is exactly the divergence §5 forbids: the moment a second copy of authorization state
+ * exists, something will read the stale one.
+ */
+it('adds only console work to the row, never a second copy of Verdict state', function (): void {
+    $columns = Schema::getColumnListing('verdict_console_pending_approvals');
+
+    expect($columns)->toContain('resume_attempts')
+        ->and($columns)->toContain('last_resume_attempt_at')
+        ->and($columns)->not->toContain('approved_at')
+        ->and($columns)->not->toContain('rejected_at')
+        ->and($columns)->not->toContain('receipt_expires_at')
+        ->and($columns)->not->toContain('receipt_state');
+});
+
+/**
+ * The attempt number is this caller's, and that is the whole reason it is locked.
+ *
+ * VC-10 decides what to do from *which* attempt this is — a first attempt and a fourth call for
+ * different action — so an increment-then-read that can hand back a concurrent writer's number is
+ * not a weaker version of this, it is a wrong one.
+ *
+ * **What this test cannot prove.** Sequentially, increment-then-read returns the same numbers, so
+ * this passes against either implementation; only two writers racing tell them apart, and that is
+ * not reachable in-process against SQLite. The row's ingest race is testable because a unique index
+ * makes the database the arbiter and the loser gets an exception; a counter has no such witness.
+ * Read this as protecting the counting, not as evidence of the lock.
+ */
+it('counts each resume attempt once and reports the caller its own number', function (): void {
+    $row = $this->store->ingest(toolCallId: 'call_1', conversationId: 'conv_1');
+
+    expect($this->store->beginResumeAttempt($row))->toBe(1)
+        ->and($this->store->beginResumeAttempt($row))->toBe(2)
+        ->and($this->store->beginResumeAttempt($row))->toBe(3)
+        ->and(PendingApproval::query()->sole()->resume_attempts)->toBe(3);
+});
+
+/** A counter alone cannot tell "three attempts" from "three attempts, the last an hour ago". */
+it('records when the most recent resume attempt began', function (): void {
+    $row = $this->store->ingest(toolCallId: 'call_1', conversationId: 'conv_1');
+
+    expect(PendingApproval::query()->sole()->last_resume_attempt_at)->toBeNull('An unattempted row has no attempt time.');
+
+    $this->store->beginResumeAttempt($row);
+
+    expect(PendingApproval::query()->sole()->last_resume_attempt_at)->not->toBeNull();
 });
 
 /**

--- a/tests/Unit/ReleaseScriptFirstReleaseTest.php
+++ b/tests/Unit/ReleaseScriptFirstReleaseTest.php
@@ -97,7 +97,10 @@ it('cuts a first release from an untagged repository without a bump', function (
             ->and(trim($tags))->toBe('v0.1.0')
             ->and(trim($subject))->toBe('chore: release v0.1.0')
             ->and(trim((string) file_get_contents($work.'/VERSION')))->toBe('0.1.0')
-            ->and($changelog)->toContain("## [Unreleased]\n\n## [0.1.0] - ".date('Y-m-d'))
+            // gmdate, matching release.sh's `date -u`. `date()` follows PHP's configured timezone,
+            // which is UTC here and need not be anywhere else; pinning both sides to UTC explicitly
+            // is what stops this from passing 17 hours a day and failing the other 7.
+            ->and($changelog)->toContain("## [Unreleased]\n\n## [0.1.0] - ".gmdate('Y-m-d'))
             ->and($changelog)->toContain('[Unreleased]: ')
             ->and($changelog)->toContain('/compare/v0.1.0...HEAD')
             ->and($changelog)->toContain('[0.1.0]: ')


### PR DESCRIPTION
Closes #9.

> **Scope note — this PR bundles two independent changes.** `b2a18af` is VC-9. `a22b01e` is an
> unrelated **release-reliability fix**: a UTC/local date mismatch that made `ReleaseScriptFirstReleaseTest`
> fail every evening. It is included because it would otherwise have turned this PR red for reasons
> that have nothing to do with VC-9, and because leaving `main` failing seven hours a day was not
> worth a second branch. It touches only `release.sh` and its own test, shares no files with VC-9, and
> can be reverted independently. Details below.

The console owns what the console *did* — attempts it made, people it told. Verdict still owns what was decided; receipt status and expiry remain live reads.

## Two migrations, because v0.1.0 shipped

The create migration publishes to a fixed dated filename, so **an adopter on 0.1.0 has already run it**. A column added there reaches new installs only, and silently divides adopters into those whose schema matches the code and those whose does not. `unresumable_reason` was amended in place precisely because that stub was still unreleased — that licence expired at the release.

Two tests hold the line:

- the released create migration is asserted **not** to carry the new columns;
- published filenames must sort in an order that can actually run on a fresh install. That second one is invisible locally: a migration dated before the table it alters passes forever on a machine where the table already exists, and fails on the first real install.

## Notification idempotency is a table

One approval is notified many times — assigned, reminder, escalation — each with its own outcome, so the cardinality is one-to-many. A JSON column would also force a read-modify-write: two concurrent claims for *different* keys each pass a guard on their own key, and the second write discards the first.

Uniqueness on `(pending_approval_id, notification_key)` makes the database the arbiter instead — the same mechanism VC-4's ingest uses, for the same reason: delegating the decision closes the check-then-act window because there is no window.

**A claim is written before the send is attempted.** Recording only successes makes "died mid-send" indistinguishable from "never started", and the retry then sends twice — the duplicate this table exists to prevent. Both timestamps null means claimed and in flight, which is a state an operator needs to see.

## The resume counter reads back under a lock

`increment()` then a separate read is two statements, and a concurrent attempt landing between them hands the caller a number belonging to somebody else. VC-10 decides what to do from *which* attempt this is, so that is not a weaker version — it is a wrong one. The transaction covers this package's own table only; it must never wrap a Verdict mutation, which `SecurityStateTransaction` refuses by design.

**What the test does not prove, stated in the test.** Sequentially both implementations return the same numbers, and two writers racing is not reachable in-process against SQLite. The row's ingest race *is* testable because a unique index makes the database the arbiter and the loser gets an exception; a counter has no such witness. The mutation is caught, but incidentally — by the `last_resume_attempt_at` assertion, not the attempt-number one.

## `agent_reconstruction_version` is deferred, on purpose

Nothing can write it. `ResumableAgents` exposes `keyFor`/`resolve`/`keys` and reports no such value, so the column would be a field that reads as information and carries none — the defect `participant_reference` had between VC-4 and VC-5.

It needs an explicit contract change, filed as **#51**, scoped to the contract alone with storage and consumer excluded. The deferral is recorded in design §6.2, `ISSUES.md`, and #9, so this is a scoped decision rather than a silent acceptance gap. §6.2 mattered most: it still listed the value as console-owned state, and removing it from VC-9 alone would have left the design promising a field nothing produces.

## Bundled: a release-reliability fix (`a22b01e`)

Not VC-9. Included per the scope note above; independently revertable.

`ReleaseScriptFirstReleaseTest` failed every evening and passed every morning. `release.sh` stamped `$(date +%F)` in **system local** time while the test compared `date('Y-m-d')` in **UTC** — a seven-hour disagreement between 17:00 PDT and midnight UTC. The v0.1.0 CI run passed at 23:53 UTC: 16:53 PDT, seven minutes inside the window.

Fixed toward UTC, because the changelog date is part of a published artifact and the other two stamps for the same event are already UTC — the annotated tag and the GitHub Release. A local date makes the changelog disagree with both for anyone cutting a release in the evening west of Greenwich, and makes the same commit produce a different date depending on who ran the script. The test now uses `gmdate()` rather than relying on PHP's configured timezone happening to be UTC.

## Mutation checks

| Mutation | Fails |
|---|---|
| Claim reads before inserting instead of using the unique index | `claims a notification once and refuses the second claim` |
| `markDelivered` leaves the stale failure behind | `replaces a failure with a delivery when a retry succeeds` |
| `beginResumeAttempt` reverts to increment-then-read | `records when the most recent resume attempt began` |

## Verification

Pint clean, PHPStan clean, 100% type coverage, **126 passed / 419 assertions** — the whole suite, including `tests/Unit`, which the timezone fix restores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

