### PR TITLE
feat: durable reconciliation for continuations that failed after a decision

### DIFF
--- a/database/migrations/create_verdict_console_approval_reconciliations_table.php.stub
+++ b/database/migrations/create_verdict_console_approval_reconciliations_table.php.stub
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Console-owned records of a decision that Verdict accepted but Laravel AI could not resume (VC-10).
+ *
+ * **One row per paused approval, enforced by the index rather than a pre-read.** Two handlers can
+ * observe the same `ApprovalResumeFailed`; checking first lets both create a reconciliation record.
+ * The unique key makes the database choose one and leaves the other handler to read that durable
+ * record back.
+ *
+ * This stores the console's failed continuation, never the human decision or an execution claim. A
+ * later retry needs Verdict's resolved-receipt read (#298), while claim correlation belongs to VC-16.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('verdict_console_approval_reconciliations', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+
+            $table->uuid('pending_approval_id');
+            $table->foreign('pending_approval_id')
+                ->references('id')
+                ->on('verdict_console_pending_approvals')
+                ->cascadeOnDelete();
+
+            // Definitely before prompt, or indeterminate once prompt itself threw. Nothing in the
+            // Laravel AI API lets the console honestly split the second state more finely.
+            $table->string('phase', 32);
+            $table->timestamp('detected_at');
+
+            // Null means an operator has not yet recorded that this stranded continuation is closed.
+            $table->timestamp('abandoned_at')->nullable();
+            $table->timestamps();
+
+            $table->unique('pending_approval_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('verdict_console_approval_reconciliations');
+    }
+};

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -155,6 +155,18 @@ so recording one would mean this package inventing a version on the host's behal
 as reconstructing a participant from a class name and an id. It is deferred until that contract gains
 a way to report it (#51), and the column and its consumer are separately scheduled after that.
 
+**Reconciliation detects and abandons; it does not retry, and it names two phases rather than three.**
+A retry after `approve()`/`reject()` needs the decision back, and there is no read for it:
+`challengeForToolCall()` is pending-only by construction and `ApprovalManager` publishes no resolved
+status. Persisting the decision so it could be re-sent would be a second copy of authorization state
+under another name — the one thing §5 forbids — so retry waits on
+[verdict#298](https://github.com/fissible/verdict/issues/298)'s per-receipt read (VC-45), and is not
+built here in the meantime. Likewise the phase: a failure raised *before* `prompt()` is definitely
+pre-execution, and one raised *by* it is **indeterminate**, because Laravel AI executes the approved
+tools inside `prompt()` before handing results to the recorder. Execution-claim status would settle it
+and is not reachable — the raw claim id goes only to the executor, the claim row has no `tool_call_id`,
+and evidence keeps only its fingerprint. That correlation is VC-16's.
+
 ### 6.3 Disposition bridge (Laravel AI → runtime)
 Listener on `ToolApprovalRequested`. For each pending item, call
 **`ApprovalManager::challengeForToolCall($toolCallId)`** — not the store's `findForToolCall()`, which

--- a/docs/planning/ISSUES.md
+++ b/docs/planning/ISSUES.md
@@ -224,10 +224,32 @@ that can run on a fresh install.
 ### VC-10 · Resume-failure reconciliation (phase-specific) · M · `type:feature` `area:runtime`
 **Deps:** VC-6, VC-9. **Context:** "receipt approved in Verdict but resume failed" must not strand or
 double-fire (design §6.2). At-most-once is **capability-policy dependent**, not universal.
-**Scope:** detect the divergence; expose reconcile (retry resume / mark abandoned), idempotent.
-**Acceptance:** assert outcomes **per phase** — failure *before* tool execution vs *after* tool-result
-persistence — rather than a blanket "no double-execute"; retry does not double-notify (VC-9).
-**Refs:** design §6.2, §12; verdict `src/ExecutionClaims/ExecutionClaimManager.php`.
+**Scope:** durable detection of the divergence, and idempotent **mark-abandoned**.
+
+**Durable retry is deferred, not descoped by preference.** After `approve()`/`reject()` the receipt is
+no longer `Pending`, so `challengeForToolCall()` returns null by construction, and `ApprovalManager`
+publishes no read-back of a resolved decision. A retry would therefore need the console to persist the
+human's decision so it could be re-sent — which is a second copy of authorization state under another
+name, whatever it is labelled. The read that makes retry possible is
+[verdict#298](https://github.com/fissible/verdict/issues/298) (per-receipt status), already filed from
+ADR 0001 F2 and already carrying a console adoption ticket in VC-45. Retry belongs to that follow-on,
+not here.
+
+**Two observable phases, not three.** `definitely_pre_execution` — the failure was raised before
+`prompt()`. `indeterminate` — it was raised *by* `prompt()`, which Laravel AI executes the approved
+tools inside before handing results to the recorder, so nothing in its API proves which side of
+execution the throw fell on. Execution-claim status would answer it, and **cannot be reached from
+here**: `ExecutionClaimManager::find()` takes the raw claim id, which Verdict passes only into the
+executor as `AuthorizedAction::executionIdentity()`; the claim row carries capability/policy/binding
+fingerprint and no `tool_call_id`, and evidence keeps only `sha256(claimId)`. Correlating the two is
+**VC-16**'s (execution-claim read-model), or an upstream issue raised from it — never inferred here.
+Verdict's own `verdict.execution.claim-indeterminate` sets the precedent: a status whose producing
+transition cannot be recovered is labelled as such, and the label does not pretend otherwise.
+
+**Acceptance:** the two phases above are asserted distinctly, and no third is claimed; mark-abandoned
+is idempotent; detection is durable across a restart; no path re-sends a decision and no path
+persists one.
+**Refs:** design §6.2, §12; verdict#298 (gates retry); VC-16 (gates claim correlation).
 
 ### VC-11 · Notifications · S · `type:feature` `area:notifications`
 **Deps:** VC-9. **Context:** Verdict emits **no** receipt-transition events (its only events are the

--- a/src/Approvals/ApprovalReconciliation.php
+++ b/src/Approvals/ApprovalReconciliation.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/** One durable record that the console could not finish a Verdict-approved continuation. */
+final class ApprovalReconciliation extends Model
+{
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $table = 'verdict_console_approval_reconciliations';
+
+    protected $guarded = [];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'phase' => ResumeFailurePhase::class,
+            'detected_at' => 'datetime',
+            'abandoned_at' => 'datetime',
+        ];
+    }
+
+    /** @property string $id */
+    /** @property string $pending_approval_id */
+    /** @property ResumeFailurePhase $phase */
+    /** @property Carbon $detected_at */
+    /** @property Carbon|null $abandoned_at */
+}

--- a/src/Approvals/ApprovalReconciliationStore.php
+++ b/src/Approvals/ApprovalReconciliationStore.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+use Fissible\VerdictConsole\Exceptions\ReconciliationRecordUnreadable;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Str;
+
+/** Durable detection and closure of continuations that failed after Verdict accepted a decision. */
+final class ApprovalReconciliationStore
+{
+    /**
+     * Persist a failed continuation once, or return the record that already captured it.
+     *
+     * The unique index is the idempotency decision: another worker can observe the same exception
+     * before this one returns, so an existence check would leave a duplicate-record race.
+     *
+     * **First detection wins, phase included.** A later call carrying a different phase returns the
+     * original record unchanged and its own phase is discarded. That is deliberate: the stored phase
+     * is an observation of what was seen at the moment continuation failed, and overwriting it would
+     * replace a fact with a later guess — the operator would be shown the most recent report rather
+     * than the first, with no way to tell which. If a row ever needs a second observation, it needs a
+     * second record and a schema that admits many, not a mutable field on one.
+     */
+    public function detect(PendingApproval $approval, ResumeFailurePhase $phase): ApprovalReconciliation
+    {
+        $now = now();
+
+        try {
+            ApprovalReconciliation::query()->insert([
+                'id' => Str::uuid()->toString(),
+                'pending_approval_id' => $approval->getKey(),
+                'phase' => $phase->value,
+                'detected_at' => $now,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        } catch (UniqueConstraintViolationException $e) {
+            $existing = $this->find($approval);
+
+            if ($existing === null) {
+                throw $e;
+            }
+
+            return $existing;
+        }
+
+        return $this->find($approval) ?? throw ReconciliationRecordUnreadable::forApproval((string) $approval->getKey());
+    }
+
+    /** The durable reconciliation record for one paused approval, if continuation failed. */
+    public function find(PendingApproval $approval): ?ApprovalReconciliation
+    {
+        return ApprovalReconciliation::query()
+            ->where('pending_approval_id', $approval->getKey())
+            ->first();
+    }
+
+    /**
+     * Record abandonment once and preserve the original operator-visible timestamp on repeats.
+     *
+     * The `whereNull` guard makes repeats no-ops at the database boundary, rather than trusting a
+     * stale in-memory model that two operators could both hold.
+     */
+    public function markAbandoned(ApprovalReconciliation $reconciliation): ApprovalReconciliation
+    {
+        $now = now();
+
+        ApprovalReconciliation::query()
+            ->whereKey($reconciliation->getKey())
+            ->whereNull('abandoned_at')
+            ->update([
+                'abandoned_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+        return ApprovalReconciliation::query()
+            ->whereKey($reconciliation->getKey())
+            ->firstOrFail();
+    }
+}

--- a/src/Approvals/ApprovalResolutionService.php
+++ b/src/Approvals/ApprovalResolutionService.php
@@ -26,6 +26,8 @@ final readonly class ApprovalResolutionService
         private ApproverAuthority $authority,
         private ResumableAgents $agents,
         private ConversationParticipants $participants,
+        private PendingApprovalStore $pendingApprovals,
+        private ApprovalReconciliationStore $reconciliations,
     ) {}
 
     /**
@@ -79,6 +81,10 @@ final readonly class ApprovalResolutionService
             return $transition;
         }
 
+        // This is console-owned operational state, deliberately outside Verdict's security-state
+        // transaction. It says a continuation was attempted, never that a receipt remains valid.
+        $this->pendingApprovals->beginResumeAttempt($approval);
+
         try {
             $participant = $approval->participant_reference === null
                 ? null
@@ -86,13 +92,22 @@ final readonly class ApprovalResolutionService
 
             $agent = $this->agents->resolve($approval->resolver_key)
                 ->continue($approval->conversation_id, $participant);
+        } catch (Throwable $e) {
+            // No prompt started, so Laravel AI could not have reached the approved tool.
+            $this->reconciliations->detect($approval, ResumeFailurePhase::DefinitelyPreExecution);
 
+            throw ApprovalResumeFailed::forApproval($approval, $e);
+        }
+
+        try {
             $agent->prompt(Decisions::from([
                 $approval->tool_call_id => $approve ? Decision::approve() : Decision::reject(),
             ]));
         } catch (Throwable $e) {
-            // Verdict has already recorded the decision. Do not guess a participant or retry the
-            // transition; VC-10 reconciliation owns this post-decision recovery path.
+            // prompt() runs the tool and writes its result internally; a throw gives no public
+            // observation of which side of that boundary it fell on, so it is indeterminate.
+            $this->reconciliations->detect($approval, ResumeFailurePhase::Indeterminate);
+
             throw ApprovalResumeFailed::forApproval($approval, $e);
         }
 

--- a/src/Approvals/ResumeFailurePhase.php
+++ b/src/Approvals/ResumeFailurePhase.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+/** The only resume-failure phases the current Laravel AI boundary can observe honestly. */
+enum ResumeFailurePhase: string
+{
+    case DefinitelyPreExecution = 'definitely_pre_execution';
+    case Indeterminate = 'indeterminate';
+}

--- a/src/Exceptions/ReconciliationRecordUnreadable.php
+++ b/src/Exceptions/ReconciliationRecordUnreadable.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Exceptions;
+
+use RuntimeException;
+
+/**
+ * A reconciliation row was written and could not be read back.
+ *
+ * Named rather than inline because of *when* it fires: the console has already recorded that a human
+ * decision was accepted and its continuation failed, so a caller catching this is holding the one
+ * situation reconciliation exists to make visible, and now cannot see it either. That deserves a type
+ * a host can match on, not a generic logic error indistinguishable from a programming mistake.
+ *
+ * Reaching it means the insert reported success and the row is absent — a storage-layer contradiction
+ * rather than anything a caller did wrong.
+ */
+final class ReconciliationRecordUnreadable extends RuntimeException
+{
+    public static function forApproval(string $pendingApprovalId): self
+    {
+        return new self(
+            'A reconciliation record was written for pending approval ['.$pendingApprovalId.'] and could not be read back.'
+        );
+    }
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -88,6 +88,9 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
             __DIR__.'/../database/migrations/create_verdict_console_approval_notifications_table.php.stub' => database_path(
                 'migrations/2026_08_25_000002_create_verdict_console_approval_notifications_table.php',
             ),
+            __DIR__.'/../database/migrations/create_verdict_console_approval_reconciliations_table.php.stub' => database_path(
+                'migrations/2026_08_25_000003_create_verdict_console_approval_reconciliations_table.php',
+            ),
         ], ['verdict-console', 'verdict-console-migrations']);
     }
 }

--- a/tests/EndToEnd/ApprovalRoundTripTest.php
+++ b/tests/EndToEnd/ApprovalRoundTripTest.php
@@ -19,9 +19,11 @@ use Fissible\Verdict\LaravelAi\VerdictApprovalMiddleware;
 use Fissible\Verdict\Targets\ExecutionTargetPolicy;
 use Fissible\Verdict\VerdictManager;
 use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
+use Fissible\VerdictConsole\Approvals\ApprovalReconciliation;
 use Fissible\VerdictConsole\Approvals\ApprovalResolutionService;
 use Fissible\VerdictConsole\Approvals\PendingApproval as StoredPendingApproval;
 use Fissible\VerdictConsole\Approvals\Resumability;
+use Fissible\VerdictConsole\Approvals\ResumeFailurePhase;
 use Fissible\VerdictConsole\Approvals\UnresumableReason;
 use Fissible\VerdictConsole\Contracts\ApprovalPresenter;
 use Fissible\VerdictConsole\Contracts\ConversationParticipants;
@@ -332,6 +334,8 @@ final class RoundTripAgent implements Agent, HasMiddleware, HasTools, RemembersC
 beforeEach(function (): void {
     $this->migrateRoundTripTables();
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_approval_reconciliations_table.php.stub')->up();
 
     $this->app->instance(RoundTripLedger::class, new RoundTripLedger);
     $this->app->instance(ConversationParticipants::class, new RoundTripParticipants);
@@ -983,7 +987,13 @@ it('approves through the console and resumes the captured participant-bound conv
     $transition = app(ApprovalResolutionService::class)->approve(StoredPendingApproval::query()->sole(), new GenericUser(['id' => 'operator-1']));
 
     expect($transition?->outcome->value)->toBe('approved')
-        ->and(app(RoundTripLedger::class)->executions)->toBe(1);
+        ->and(app(RoundTripLedger::class)->executions)->toBe(1)
+        // A resume attempt is a console *action*, not a failure count: it is recorded for the
+        // successful path too, so "attempts, no reconciliation record" reads as a clean resume rather
+        // than as silence. VC-10 asks which attempt this is; it never asks how many went wrong.
+        ->and(StoredPendingApproval::query()->sole()->resume_attempts)->toBe(1, 'A successful resume is still an attempt.')
+        ->and(StoredPendingApproval::query()->sole()->last_resume_attempt_at)->not->toBeNull()
+        ->and(ApprovalReconciliation::query()->count())->toBe(0, 'Nothing diverged, so there is nothing to reconcile.');
 });
 
 /**
@@ -1241,7 +1251,31 @@ it('wraps a participant mismatch raised by continuation after Verdict records ap
 
     expect(fn () => app(ApprovalResolutionService::class)->approve(StoredPendingApproval::query()->sole(), new GenericUser(['id' => 'operator-1'])))
         ->toThrow(ApprovalResumeFailed::class);
-    expect(app(RoundTripLedger::class)->executions)->toBe(1);
+    expect(app(RoundTripLedger::class)->executions)->toBe(1)
+        ->and(ApprovalReconciliation::query()->sole()->phase)->toBe(ResumeFailurePhase::Indeterminate)
+        ->and(StoredPendingApproval::query()->sole()->resume_attempts)->toBe(1);
+});
+
+it('records a resolver failure before prompt as definitely pre-execution', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    Http::fake(['*/chat/completions' => Http::sequence()->push($this->toolCallResponse(TOOL_CALL_ID, 'CancelOrderTool', ['order_id' => ORDER_ID]))]);
+
+    pauseForApproval((new RoundTripAgent)->forParticipant(new RoundTripCustomer(7)));
+
+    $broken = (new AgentResolverRegistry)->register(
+        'round-trip@v1',
+        fn (): object => throw new LogicException('host resolver failed before prompt'),
+        fn (Agent $agent): bool => $agent instanceof RoundTripAgent,
+    );
+    app()->instance(ResumableAgents::class, $broken);
+
+    expect(fn () => app(ApprovalResolutionService::class)->approve(StoredPendingApproval::query()->sole(), new GenericUser(['id' => 'operator-1'])))
+        ->toThrow(ApprovalResumeFailed::class);
+
+    expect(app(RoundTripLedger::class)->executions)->toBe(0)
+        ->and(ApprovalReconciliation::query()->sole()->phase)->toBe(ResumeFailurePhase::DefinitelyPreExecution)
+        ->and(StoredPendingApproval::query()->sole()->resume_attempts)->toBe(1)
+        ->and(StoredPendingApproval::query()->sole()->last_resume_attempt_at)->not->toBeNull();
 });
 
 it('propagates Verdicts outer transaction guard rather than replacing it', function (): void {

--- a/tests/Feature/ApprovalReconciliationStoreTest.php
+++ b/tests/Feature/ApprovalReconciliationStoreTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\VerdictConsole\Approvals\ApprovalReconciliation;
+use Fissible\VerdictConsole\Approvals\ApprovalReconciliationStore;
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
+use Fissible\VerdictConsole\Approvals\ResumeFailurePhase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function (): void {
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_approval_reconciliations_table.php.stub')->up();
+
+    $this->approvals = new PendingApprovalStore;
+    $this->reconciliations = new ApprovalReconciliationStore;
+    $this->approval = $this->approvals->ingest(toolCallId: 'call_1', conversationId: 'conv_1');
+});
+
+afterEach(function (): void {
+    Carbon::setTestNow();
+    Schema::dropIfExists('verdict_console_approval_reconciliations');
+    Schema::dropIfExists('verdict_console_pending_approvals');
+});
+
+it('durably distinguishes a failure before prompt from an indeterminate prompt failure', function (): void {
+    $preExecution = $this->reconciliations->detect($this->approval, ResumeFailurePhase::DefinitelyPreExecution);
+
+    $other = $this->approvals->ingest(toolCallId: 'call_2', conversationId: 'conv_2');
+    $indeterminate = $this->reconciliations->detect($other, ResumeFailurePhase::Indeterminate);
+
+    $stored = ApprovalReconciliation::query()->orderBy('created_at')->get();
+
+    expect($preExecution->phase)->toBe(ResumeFailurePhase::DefinitelyPreExecution)
+        ->and($indeterminate->phase)->toBe(ResumeFailurePhase::Indeterminate)
+        ->and($stored)->toHaveCount(2)
+        ->and($stored[0]->phase)->toBe(ResumeFailurePhase::DefinitelyPreExecution)
+        ->and($stored[1]->phase)->toBe(ResumeFailurePhase::Indeterminate);
+});
+
+it('records detection in the database rather than on a live approval object', function (): void {
+    $detected = $this->reconciliations->detect($this->approval, ResumeFailurePhase::DefinitelyPreExecution);
+
+    $reloaded = PendingApproval::query()->sole();
+    $stored = $this->reconciliations->find($reloaded);
+
+    expect($detected->exists)->toBeTrue()
+        ->and($stored)->not->toBeNull()
+        ->and($detected->id)->toBe($stored->id)
+        ->and($stored->pending_approval_id)->toBe($reloaded->id)
+        ->and($stored->phase)->toBe(ResumeFailurePhase::DefinitelyPreExecution)
+        ->and($stored->detected_at)->not->toBeNull();
+});
+
+it('detects the same failure once through its unique database key', function (): void {
+    $first = $this->reconciliations->detect($this->approval, ResumeFailurePhase::Indeterminate);
+    $second = $this->reconciliations->detect($this->approval, ResumeFailurePhase::Indeterminate);
+
+    expect($second->id)->toBe($first->id)
+        ->and(ApprovalReconciliation::query()->count())->toBe(1);
+});
+
+/**
+ * First detection wins, phase included — the stored phase is a fact, not the latest opinion.
+ *
+ * A second observation carrying a different phase is discarded rather than written over the first.
+ * Overwriting would show an operator the most recent report with no way to tell it from the original,
+ * and the original is the one taken at the moment continuation actually failed. A row needing two
+ * observations needs two records and a schema that admits them, not a mutable field on one.
+ */
+it('keeps the first observed phase when a later detection disagrees', function (): void {
+    $first = $this->reconciliations->detect($this->approval, ResumeFailurePhase::DefinitelyPreExecution);
+    $second = $this->reconciliations->detect($this->approval, ResumeFailurePhase::Indeterminate);
+
+    expect($second->id)->toBe($first->id, 'A second detection must not create a second record.')
+        ->and($second->phase)->toBe(ResumeFailurePhase::DefinitelyPreExecution)
+        ->and(ApprovalReconciliation::query()->sole()->phase)
+        ->toBe(ResumeFailurePhase::DefinitelyPreExecution, 'The stored observation is the first one, not the last.');
+});
+
+it('marks a detected reconciliation abandoned once', function (): void {
+    Carbon::setTestNow('2026-08-25 00:00:00');
+    $reconciliation = $this->reconciliations->detect($this->approval, ResumeFailurePhase::Indeterminate);
+
+    Carbon::setTestNow('2026-08-25 00:01:00');
+    $first = $this->reconciliations->markAbandoned($reconciliation);
+
+    Carbon::setTestNow('2026-08-25 00:02:00');
+    $second = $this->reconciliations->markAbandoned($reconciliation);
+
+    expect($first->abandoned_at?->toDateTimeString())->toBe('2026-08-25 00:01:00')
+        ->and($second->abandoned_at?->toDateTimeString())->toBe('2026-08-25 00:01:00')
+        ->and(ApprovalReconciliation::query()->sole()->abandoned_at?->toDateTimeString())->toBe('2026-08-25 00:01:00');
+});
+
+it('does not create a reconciliation field that replays a human decision or links an execution claim', function (): void {
+    $columns = Schema::getColumnListing('verdict_console_approval_reconciliations');
+
+    expect($columns)->not->toContain('decision')
+        ->and($columns)->not->toContain('approved')
+        ->and($columns)->not->toContain('rejected')
+        ->and($columns)->not->toContain('execution_claim_id')
+        ->and($columns)->not->toContain('execution_claim_fingerprint');
+});

--- a/tests/Feature/MigrationPublishingTest.php
+++ b/tests/Feature/MigrationPublishingTest.php
@@ -49,14 +49,16 @@ it('publishes every migration, in an order that can actually run', function (): 
         ->sort()
         ->values();
 
-    expect($published)->toHaveCount(3);
+    expect($published)->toHaveCount(4);
 
     $position = fn (string $fragment): int => $published->search(fn (string $name): bool => str_contains($name, $fragment));
 
     expect($position('create_verdict_console_pending_approvals_table'))
         ->toBeLessThan($position('add_operational_state_to_verdict_console_pending_approvals_table'), 'A column cannot be added to a table that does not exist yet.')
         ->and($position('create_verdict_console_pending_approvals_table'))
-        ->toBeLessThan($position('create_verdict_console_approval_notifications_table'), 'The notifications foreign key requires the pause table.');
+        ->toBeLessThan($position('create_verdict_console_approval_notifications_table'), 'The notifications foreign key requires the pause table.')
+        ->and($position('create_verdict_console_pending_approvals_table'))
+        ->toBeLessThan($position('create_verdict_console_approval_reconciliations_table'), 'The reconciliation foreign key requires the pause table.');
 
     File::cleanDirectory($target);
 });


### PR DESCRIPTION
Closes #10.

VC-6 raises `ApprovalResumeFailed` when a continuation fails after Verdict has already recorded the decision. Nothing yet made that durable. This does — and stops there, deliberately.

## Two phases, because two are all that can be told apart honestly

- **`definitely_pre_execution`** — raised *before* `prompt()`. Laravel AI was never asked to run anything.
- **`indeterminate`** — raised *by* `prompt()`. `TextGenerationLoop` executes the approved tools inside it and only then hands the results to the recorder, so a throw may fall on either side of execution and the API does not say which.

That is not caution about an unlikely case. VC-5's negative control measured it: the action ran, the receipt was spent, and the turn still awaited a human. The split is why `resolve()` now has two `try` blocks instead of one — the boundary between them *is* the phase.

Verdict's own `verdict.execution.claim-indeterminate` is the precedent: a status whose producing transition cannot be recovered is labelled as such, and the label does not pretend otherwise.

## What is deliberately absent, and why

**No retry.** After `approve()`/`reject()` the receipt is no longer `Pending`, so `challengeForToolCall()` returns null *by construction* (`ApprovalManager.php:73-77`), and the manager publishes no read-back of a resolved decision. A retry would need the console to persist the human's decision so it could be re-sent — a second copy of authorization state whatever it is labelled, indistinguishable from a decision mirror to anyone reading the column a year from now. The read that makes retry possible is [verdict#298](https://github.com/fissible/verdict/issues/298), already filed from ADR 0001 F2 with VC-45 as its adoption ticket. **A test asserts no such field exists.**

**No execution-claim correlation.** Claim status would settle the indeterminate case, and cannot be reached from here: `ExecutionClaimManager::find()` takes the raw claim id, Verdict passes that only into the executor as `AuthorizedAction::executionIdentity()`, the claim row carries `capability`/`policy`/`bindingFingerprint` and **no `tool_call_id`**, and evidence keeps only `sha256(claimId)`. Correlation is **VC-16**'s.

Both deferrals are recorded in design §6.2 and `ISSUES.md` as well as #10 — §6.2 especially, since it is the section a future reader would otherwise cite as licence to add reconciliation state neither contract can support. Those doc changes are folded into this PR rather than landing separately, because the reasoning and the code answer the same question.

## First detection wins, phase included

A later observation returns the original record and discards its own phase. The stored phase is what was seen when continuation failed; overwriting it would show an operator the most recent report with no way to tell it from the first. A row needing two observations needs **two records and a schema that admits them**, not a mutable field on one — that argument is in the store docblock, so the next person who wants to update a phase finds the reasoning rather than just the prohibition.

## A resume attempt is a console action, not a failure count

`beginResumeAttempt()` fires on the successful path too, so "attempts recorded, no reconciliation row" reads as a clean resume rather than as silence. The success-path test asserts all three — attempts, timestamp, and **zero** reconciliation rows — as a positive statement rather than an absence.

## Mutation checks

| Mutation | Fails |
|---|---|
| Collapse the two phases into one | `records a resolver failure before prompt as definitely pre-execution` |
| Drop mark-abandoned's `whereNull` guard | `marks a detected reconciliation abandoned once` |
| Detect without persisting | six tests, incl. `records detection in the database rather than on a live approval object` |
| A later detection overwrites the first phase | `keeps the first observed phase when a later detection disagrees` |
| No attempt on the success path | three tests, incl. `approves through the console and resumes…` |

One note on provenance: the durability probe was first written as a memo on the read side only, which left it permanently empty — a no-op that passed 132/132 and proved nothing until rewritten as "detect, then delete the row". A mutation that cannot fail misleads exactly as much as a test that cannot.

## Verification

Pint clean, PHPStan clean, 100% type coverage, **133 passed / 456 assertions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
