### PR TITLE
feat: one verb resolver every approval surface renders from

### DIFF
--- a/docs/planning/ISSUES.md
+++ b/docs/planning/ISSUES.md
@@ -279,12 +279,16 @@ resolver; the console is never the tenancy authority.
 ### VC-41 · Verb-set resolver + per-surface contract test · S · `type:contract` `type:test` `area:runtime`
 **Deps:** VC-6. **Context:** [ADR 0001](../adr/0001-approval-surface-contract.md) §2 — *a Deny is not
 approvable* — must be one function every surface renders from, not a convention each re-derives.
-**Scope:** a headless `ApprovalVerbs`-style resolver: `{approve, reject}` iff live challenge non-null
-**and** `Drivable`; `{close}` iff `Drivable`, null challenge, **and** VC-43 has shipped (else `{}`);
-`{}` otherwise — including every informational disposition, `Unresumable` rows, and any wildcard/bulk/
-edit shape. Plus a surface-contract test helper VC-19/21/24/25/28 must use.
-**Acceptance:** every resolver cell unit-tested; empty set asserted for every non-`RequireConfirmation`
-disposition; the helper is documented as mandatory for rendering issues.
+**Scope:** a headless `ApprovalVerbs` resolver over the only item current code can produce: a
+`PendingApproval`, which exists only for `RequireConfirmation`. It yields `{approve, reject}` iff the
+live challenge is non-null, belongs to that tool call, and the row is `Drivable`; `{close}` iff
+`Drivable`, null challenge, **and** VC-43 has shipped (else `{}`). Every `UnresumableReason` yields
+`{}`, and the typed vocabulary has no wildcard/bulk/edit verb. Informational dispositions have no
+`PendingApproval` producer; VC-13/42 own their evidence item/read model and must render `{}` there,
+never fabricate a disposition parameter here. `ApprovalSurfaceContract` is mandatory in the rendering
+tests for VC-19/21/24/25/28.
+**Acceptance:** every current resolver cell unit-tested; all `UnresumableReason` cases empty; the
+named helper and its mandatory consumers are documented.
 **Waiting on Verdict:** nothing.
 **Refs:** ADR 0001 §2, §3, Consequences. ([#41](https://github.com/fissible/verdict-console/issues/41))
 

--- a/src/Approvals/ApprovalSurfaceContract.php
+++ b/src/Approvals/ApprovalSurfaceContract.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+use Fissible\Verdict\Approvals\ApprovalChallenge;
+use Fissible\VerdictConsole\Exceptions\ApprovalSurfaceContractViolation;
+
+/**
+ * Test helper VC-19/21/24/25/28 must use to pin ADR 0001's verb invariant.
+ *
+ * A component test may prove its own markup and still accidentally render an override, bulk, or
+ * stale approve control. Comparing its extracted verb set here makes every surface answer to the
+ * same live-challenge rule instead of re-implementing authorization policy in presentation code.
+ */
+final readonly class ApprovalSurfaceContract
+{
+    public function __construct(private ApprovalVerbs $verbs) {}
+
+    /**
+     * @param  list<ApprovalVerb>  $rendered
+     */
+    public function assertRendered(array $rendered, PendingApproval $approval, ?ApprovalChallenge $challenge): void
+    {
+        $expected = $this->verbs->resolve($approval, $challenge);
+        $normalizedExpected = $this->normalized($expected);
+        $normalizedRendered = $this->normalized($rendered);
+
+        // Sorted value comparison, so a surface may order its controls however it likes and still
+        // answer to the same set. It also settles duplicates without a separate check: the resolver
+        // never returns one, so a repeated verb changes the length and fails this comparison. An
+        // explicit array_unique() guard here would be a branch that cannot reach its own false.
+        if ($normalizedRendered !== $normalizedExpected) {
+            throw new ApprovalSurfaceContractViolation($expected, $rendered);
+        }
+    }
+
+    /**
+     * @param  list<ApprovalVerb>  $verbs
+     * @return list<string>
+     */
+    private function normalized(array $verbs): array
+    {
+        $values = array_map(static fn (ApprovalVerb $verb): string => $verb->value, $verbs);
+        sort($values);
+
+        return $values;
+    }
+}

--- a/src/Approvals/ApprovalVerb.php
+++ b/src/Approvals/ApprovalVerb.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+/** The complete, deliberately small vocabulary a surface may offer for one approval item. */
+enum ApprovalVerb: string
+{
+    case Approve = 'approve';
+    case Reject = 'reject';
+    case Close = 'close';
+}

--- a/src/Approvals/ApprovalVerbs.php
+++ b/src/Approvals/ApprovalVerbs.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+use Fissible\Verdict\Approvals\ApprovalChallenge;
+
+/** Resolves the single verb set every approval surface must render from live Verdict state. */
+final class ApprovalVerbs
+{
+    /**
+     * Return the verbs a surface may offer for this item.
+     *
+     * A persisted row proves only that Laravel AI once paused; the live challenge proves Verdict
+     * still accepts a human decision. Requiring both keeps a lapsed, consumed, or otherwise
+     * non-pending receipt from acquiring an approve button through stale console state.
+     *
+     * @return list<ApprovalVerb>
+     */
+    public function resolve(PendingApproval $approval, ?ApprovalChallenge $challenge): array
+    {
+        if ($approval->resumability !== Resumability::Drivable
+            || $challenge === null
+            || $challenge->toolCallId !== $approval->tool_call_id) {
+            return [];
+        }
+
+        // VC-43 has not measured close against a non-pending turn, so emitting it now would make a
+        // surface promise an exit path the runtime has not proved it can carry out.
+        return [ApprovalVerb::Approve, ApprovalVerb::Reject];
+    }
+}

--- a/src/Exceptions/ApprovalSurfaceContractViolation.php
+++ b/src/Exceptions/ApprovalSurfaceContractViolation.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Exceptions;
+
+use Fissible\VerdictConsole\Approvals\ApprovalVerb;
+use LogicException;
+
+/** A rendering test offered controls other than the shared approval-verb contract permits. */
+final class ApprovalSurfaceContractViolation extends LogicException
+{
+    /**
+     * @param  list<ApprovalVerb>  $expected
+     * @param  list<ApprovalVerb>  $actual
+     */
+    public function __construct(
+        public readonly array $expected,
+        public readonly array $actual,
+    ) {
+        parent::__construct(sprintf(
+            'Approval surface verb contract violated: expected [%s], rendered [%s].',
+            implode(', ', array_map(static fn (ApprovalVerb $verb): string => $verb->value, $expected)),
+            implode(', ', array_map(static fn (ApprovalVerb $verb): string => $verb->value, $actual)),
+        ));
+    }
+}

--- a/tests/Feature/ApprovalVerbsTest.php
+++ b/tests/Feature/ApprovalVerbsTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Approvals\ApprovalChallenge;
+use Fissible\VerdictConsole\Approvals\ApprovalSurfaceContract;
+use Fissible\VerdictConsole\Approvals\ApprovalVerb;
+use Fissible\VerdictConsole\Approvals\ApprovalVerbs;
+use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
+use Fissible\VerdictConsole\Approvals\Resumability;
+use Fissible\VerdictConsole\Approvals\UnresumableReason;
+use Fissible\VerdictConsole\Exceptions\ApprovalSurfaceContractViolation;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function (): void {
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+
+    $this->approvals = new PendingApprovalStore;
+    $this->verbs = new ApprovalVerbs;
+    $this->challenge = new ApprovalChallenge(
+        receiptId: 'receipt_1',
+        toolCallId: 'call_1',
+        capability: 'orders.cancel',
+        reason: 'Cancelling an order needs confirmation.',
+        expiresAt: new DateTimeImmutable('+10 minutes'),
+    );
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists('verdict_console_pending_approvals');
+});
+
+it('offers approve and reject only for a drivable item with a live challenge', function (): void {
+    $approval = $this->approvals->ingest(
+        toolCallId: 'call_1',
+        conversationId: 'conv_1',
+        resumability: Resumability::Drivable,
+    );
+
+    expect($this->verbs->resolve($approval, $this->challenge))
+        ->toBe([ApprovalVerb::Approve, ApprovalVerb::Reject]);
+});
+
+it('offers no verb when a drivable confirmation row has no live challenge', function (): void {
+    $approval = $this->approvals->ingest(
+        toolCallId: 'call_1',
+        conversationId: 'conv_1',
+        resumability: Resumability::Drivable,
+    );
+
+    expect($this->verbs->resolve($approval, null))->toBe([]);
+});
+
+it('offers no verb when a live challenge belongs to another tool call', function (): void {
+    $approval = $this->approvals->ingest(
+        toolCallId: 'call_1',
+        conversationId: 'conv_1',
+        resumability: Resumability::Drivable,
+    );
+    $otherChallenge = new ApprovalChallenge(
+        receiptId: 'receipt_2',
+        toolCallId: 'call_2',
+        capability: 'orders.cancel',
+        reason: 'Cancelling an order needs confirmation.',
+        expiresAt: new DateTimeImmutable('+10 minutes'),
+    );
+
+    expect($this->verbs->resolve($approval, $otherChallenge))->toBe([]);
+});
+
+it('offers no verb for every unresumable reason even when a live challenge exists', function (UnresumableReason $reason): void {
+    $approval = $this->approvals->ingest(
+        toolCallId: 'call_1',
+        conversationId: 'conv_1',
+        resumability: Resumability::Unresumable,
+        unresumableReason: $reason,
+    );
+
+    expect($this->verbs->resolve($approval, $this->challenge))->toBe([]);
+})->with(UnresumableReason::cases());
+
+it('offers neither close nor a widened decision shape before VC-43 ships', function (): void {
+    $approval = $this->approvals->ingest(
+        toolCallId: 'call_1',
+        conversationId: 'conv_1',
+        resumability: Resumability::Drivable,
+    );
+
+    $verbs = $this->verbs->resolve($approval, null);
+
+    expect($verbs)->not->toContain(ApprovalVerb::Close)
+        ->and(ApprovalVerb::cases())->toBe([ApprovalVerb::Approve, ApprovalVerb::Reject, ApprovalVerb::Close]);
+});
+
+it('gives rendering surfaces one assertion against the shared verb rule', function (): void {
+    $approval = $this->approvals->ingest(
+        toolCallId: 'call_1',
+        conversationId: 'conv_1',
+        resumability: Resumability::Drivable,
+    );
+    $contract = new ApprovalSurfaceContract($this->verbs);
+
+    expect(fn () => $contract->assertRendered(
+        [ApprovalVerb::Reject, ApprovalVerb::Approve],
+        $approval,
+        $this->challenge,
+    ))->not->toThrow(ApprovalSurfaceContractViolation::class)
+        ->and(fn () => $contract->assertRendered(
+            [ApprovalVerb::Approve],
+            $approval,
+            $this->challenge,
+        ))->toThrow(ApprovalSurfaceContractViolation::class, 'expected [approve, reject], rendered [approve]')
+        ->and(fn () => $contract->assertRendered(
+            [ApprovalVerb::Approve, ApprovalVerb::Reject, ApprovalVerb::Approve],
+            $approval,
+            $this->challenge,
+        ))->toThrow(ApprovalSurfaceContractViolation::class, 'expected [approve, reject], rendered [approve, reject, approve]');
+});


### PR DESCRIPTION
Closes #41.

ADR 0001 §2: *a Deny is not approvable* — and the rule must be **one function every surface renders from**, not a convention each surface re-derives. Four rendering surfaces are scheduled for v0.4. This is the thing they render from, and the test that fails when someone adds "approve anyway".

## Three conditions, not one

`{approve, reject}` requires a drivable row **and** a live challenge **and** that challenge belonging to *this* tool call.

A persisted row proves only that Laravel AI once paused. The live challenge proves Verdict still accepts a human decision. Requiring both is what stops a lapsed or consumed receipt from acquiring an approve button out of stale console state — which is the whole failure mode ADR 0001 §3 is about.

## No disposition parameter, deliberately

An earlier draft took `Disposition` as its first argument. **Nothing in this package produces one** — `PendingApproval` has no such column, the presentation doesn't carry it, and no other file references it. A parameter every caller must fabricate is exactly how a field with no producer gets introduced, and this repo has been bitten twice: `participant_reference` between VC-4 and VC-5, `agent_reconstruction_version` in VC-9.

The resolver instead takes the only item current code can produce: a `PendingApproval`, which exists because `ToolApprovalRequested` fired and therefore only for `RequireConfirmation`. An informational disposition has neither a row nor a live challenge, so it yields `{}` **structurally rather than by inspection**. Evidence-derived items stay VC-13/VC-42's to model, and `ISSUES.md` now says so explicitly so nobody re-adds the parameter to satisfy a test.

## Unreachable by type, not by assertion

`ApprovalVerb` has three cases and no others, so `approveAll()` and `Decision::edit()` cannot be expressed in the resolver's output. That acceptance clause is satisfied by the type system rather than by a test that could be deleted.

## The surface helper

Comparison is on **sorted values**, so a surface may order its controls freely and still answer to the same set — otherwise every one of the four v0.4 surfaces hits the same false failure once.

That also settles duplicates without a separate guard: the resolver never returns one, so a repeated verb changes the length and fails the comparison. An explicit `array_unique()` check was in the first draft and **removed after mutation showed it could not reach its own false** — deleting it failed nothing, because the comparison had already caught every case it claimed to.

Failures raise a named `ApprovalSurfaceContractViolation` carrying expected and actual verbs. The person reading that message is usually the one who just added a control they shouldn't have, and *"does not match the contract"* doesn't tell them which.

## Coverage

The unresumable case is driven from `UnresumableReason::cases()`, so a fifth reason is covered the day it is added rather than the day someone remembers. The helper is tested for the reordered, short, and duplicated cases.

| Mutation | Fails |
|---|---|
| Drop the tool-call identity guard | `offers no verb when a live challenge belongs to another tool call` |
| Make the comparison order-sensitive | `gives rendering surfaces one assertion against the shared verb rule` |

## Verification

Pint clean, PHPStan clean, 100% type coverage, **142 passed / 470 assertions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
