### PR TITLE
docs: reconcile the design of record with ADR 0001

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ The receipt-backed approval loop exists only for Verdict **`BoundTool`** on an a
 AI's **`RemembersConversations`** concern with a real (non-fake) gateway. Non-`BoundTool` approvals
 are observable but not Verdict-drivable. See design §3.
 
+Verdict **`require_review` is a separate, gated review lane**: it has no receipt and does not resume
+an agent. Its durable review substrate and read API are planned in Verdict #297 and #298, so this
+package does not yet expose review items or treat decision evidence as an inbox.
+
 ## Package family
 
 Install only the presentation stack you render in; all three sit on one headless core.

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -78,7 +78,7 @@ dropped. This boundary is a first-class precondition, stated in the README and e
 Division: **Laravel AI signals pause/resume · Verdict owns receipt state · the console joins and
 draws UI, owning only operational state and its own durable projections.**
 
-## 5. Verdict-side dependency this design forces (decision required)
+## 5. Verdict-side read dependency (filed)
 
 `ApprovalReceiptStore` exposes only `findForToolCall($toolCallId)` (which returns `null` on
 ambiguity) — **no `find(receiptId)` and no list/query API.**
@@ -86,7 +86,8 @@ ambiguity) — **no `find(receiptId)` and no list/query API.**
 
 Consequence: Verdict cannot enumerate receipts for an inbox. Resolution of the tension:
 
-- **The console's own `PendingApproval` table is the queryable index** (the inbox lists from it).
+- **The console's own `PendingApproval` table is the workflow/correlation index** (the inbox lists
+  from it); it is not a substitute receipt read-model.
 - **Per-row authoritative status is read from Verdict via `ApprovalManager::challengeForToolCall()`**
   — *not* the store's `findForToolCall()`, which is named above only to describe what the contract
   offers. A non-null challenge means "pending, unexpired, actionable"; null collapses **absent,
@@ -95,9 +96,10 @@ Consequence: Verdict cannot enumerate receipts for an inbox. Resolution of the t
   go through `ApprovalManager::approve/reject` keyed by `receiptId + toolCallId + actor`, and the
   **returned outcome** — never the actor's intent — decides whether the run resumes (§6.4).
   [`src/Approvals/ApprovalManager.php`]
-- The console therefore integrates **through `ApprovalManager`**, not by reaching into the store. If
-  a future generic integration needs receipt enumeration, that is an **additive Verdict contract
-  change** (a read API) — flag for PM as a possible companion Verdict issue, not assumed here.
+- The console therefore integrates **through `ApprovalManager`**, not by reaching into the store.
+  [verdict#298](https://github.com/fissible/verdict/issues/298) is the filed per-receipt read and
+  enumeration dependency: it is where generic receipt reads belong, and every console feature that
+  needs more than `challengeForToolCall()` waits for that contract rather than inferring state here.
 
 ## 6. Layer 1 — headless runtime
 
@@ -270,6 +272,14 @@ On a human decision: check approver authority (host `Gate`, §7) → `ApprovalMa
 tool-call id — never `approveAll()`** (Verdict deliberately ignores the wildcard).
 [`src/Approvals/ApprovalExecutionContext.php`]
 - On deny: resume with a clean refusal so the agent never hangs.
+- **Expiry `close` is a workflow exit, never an authorization decision.** When the live challenge is
+  null, `close` resumes the exact conversation with a keyed `Decision::reject()` without calling
+  `ApprovalManager::approve/reject`. It is gated by the configured approval ability, records a
+  resume attempt, and cannot execute a tool through that rejection. Null also covers an
+  already-decided receipt; Laravel AI's measured already-resolved response is reported as such,
+  while every other continuation failure remains phase-specific reconciliation rather than a false
+  success. Expiry has no transition moment and Verdict never auto-rejects it. VC-45 narrows that
+  both-halves defence after verdict#298 exposes receipt status.
 - **Must run OUTSIDE any outer `DB::transaction`** — Verdict throws `UnsafeOuterTransaction` via
   `SecurityStateTransaction → IndependentTransactionGuard`.
   [`src/Support/SecurityStateTransaction.php`], [`src/Support/IndependentTransactionGuard.php`]
@@ -305,8 +315,9 @@ configuration fingerprint is recorded in every decision record, so a config writ
 evidence trail *means* — any future write surface must announce that, not just save a value.
 
 ## 7. Cross-cutting
-- **Who may approve is the host's call** — Laravel `Gate` (`can('approve', $pendingApproval)`); ship
-  a default, never hard-code authority.
+- **Who may approve is the host's call** — Laravel `Gate` evaluates the configured
+  `verdict-console.approvals.gate` ability (default `approve-verdict-action`) for the pending row;
+  the package ships that default but never hard-codes authority.
 - **Tenancy/scoping delegates to the host.**
 - **Real-time transport degrades:** polling default (no infra); broadcast (Reverb/Pusher) opt-in.
 
@@ -418,9 +429,17 @@ Empirical, from #218/#234 and the two reviews. Each has cost real time before.
   each carry a named projection dependency (they are not deferred *out*, but not built until their
   projection exists).
 
-## 14. Open items for PM
-- Companion Verdict issue? — whether to add a receipt **read/enumeration API** to
-  `ApprovalReceiptStore` for generic (non-`ApprovalManager`) integrations (§5). Not required for v1.
+## 14. Filed dependency cluster
+- [verdict#297](https://github.com/fissible/verdict/issues/297) supplies the durable
+  `require_review` substrate; the console does not synthesize a review inbox from evidence.
+- [verdict#298](https://github.com/fissible/verdict/issues/298) supplies per-receipt status and
+  enumeration reads (§5), gating status-aware console consumers including VC-45.
+- [verdict#299](https://github.com/fissible/verdict/issues/299) supplies receipt-transition events;
+  it does not create an expiry event because expiry has no transition moment.
+- [verdict#300](https://github.com/fissible/verdict/issues/300) supplies `ApprovalChallenge::issuedAt`.
+- [Verdict ADR 0029](https://github.com/fissible/verdict/blob/main/docs/adr/0029-approval-challenge-issuance-is-the-measured-fact.md)
+  records the no-auto-reject rule used by §6.4. ADR 0029 postdates the Verdict documentation pinned
+  in this checkout, so this direct upstream link is the auditable source until the dependency updates.
 - Relationship to reference app **#237** and **#218** (Conversational resume): #218 is **closed
   (milestone v0.8.0), proven on both transports — streamed #233, queued #235** — *not deferred*. This
   package leans on that shipped mechanism; the implementer should read the #233/#235 reference tests

--- a/src/Presentation/DefaultApprovalPresenter.php
+++ b/src/Presentation/DefaultApprovalPresenter.php
@@ -24,10 +24,11 @@ use Laravel\Ai\Approvals\PendingApproval as LaravelPendingApproval;
  *   gave the row no expiry column for the same reason, and copying the deadline into a durable
  *   presentation would reintroduce exactly that divergence: an inbox rendering an approval as still
  *   actionable from a snapshot taken minutes ago.
- * - **`provenance`.** Surfacing where a proposal came from is the most useful thing an approver can
- *   see and the most dangerous to copy: [ADR 0026](https://github.com/fissible/verdict/blob/main/docs/adr/0026-what-an-approver-is-shown.md)
- *   treats showing it as a **context release** governed by ADR 0008, which is a host's decision to
- *   make through its own presenter and its own release policy — never a package default.
+ * - **`provenance`.** A presentation must never persist provenance: it is released application data,
+ *   not console-owned workflow state. A host surface may render provenance live from the challenge;
+ *   `ApprovalManager::issue()` already applied (or refused) that release while the invocation frame
+ *   existed, so rendering does not initiate a second context release. [ADR 0026](https://github.com/fissible/verdict/blob/main/docs/adr/0026-what-an-approver-is-shown.md)
+ *   makes the durable receipt payload the answer to a later request having no invocation frame.
  */
 final class DefaultApprovalPresenter implements ApprovalPresenter
 {

--- a/tests/Feature/DocumentationCorrectionsTest.php
+++ b/tests/Feature/DocumentationCorrectionsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\VerdictConsole\Presentation\DefaultApprovalPresenter;
+
+function documentation(string $path): string
+{
+    return (string) file_get_contents(dirname(__DIR__, 2).'/'.$path);
+}
+
+it('keeps ADR 0001 corrections in the design of record', function (): void {
+    $design = documentation('docs/design/0001-verdict-console-design.md');
+
+    expect($design)
+        ->toContain('`verdict-console.approvals.gate` ability')
+        ->toContain('`close` resumes the exact conversation')
+        ->toContain('without calling')
+        ->toContain('`ApprovalManager::approve/reject`')
+        ->toContain('filed per-receipt read')
+        ->toContain('enumeration dependency')
+        ->toContain('Expiry has no transition moment and Verdict never auto-rejects it.')
+        ->toContain('ADR 0029 postdates')
+        ->toContain('direct upstream link is the auditable source')
+        ->toContain('## 14. Filed dependency cluster')
+        ->not->toContain('Companion Verdict issue?');
+});
+
+it('distinguishes durable presentation from live challenge rendering', function (): void {
+    $docblock = (new ReflectionClass(DefaultApprovalPresenter::class))->getDocComment();
+
+    expect($docblock)
+        ->toContain('must never persist provenance')
+        ->toContain('may render provenance live from the challenge')
+        ->toContain('does not initiate a second context release');
+});
+
+it('tells adopters that require_review awaits its gated Verdict substrate', function (): void {
+    expect(documentation('README.md'))
+        ->toContain('`require_review` is a separate, gated review lane')
+        ->toContain('Verdict #297 and #298');
+});


### PR DESCRIPTION
Closes #44.

ADR 0001 is accepted and supersedes the design of record where they disagree. Four sections were still stating what it replaced — and since the last four PRs all edited or cited that document, every one of them made the correction larger.

## The corrections

**§5** — "the console's own `PendingApproval` table is the queryable index" narrows to **workflow and correlation index**. Enumeration and per-receipt status belong to [verdict#298](https://github.com/fissible/verdict/issues/298) when it ships; until then `challengeForToolCall()` is the whole read surface and no console code reads a Verdict table directly.

**§6.4** — gains the expiry `close` verb, its measurement precondition, and the fact that makes it necessary: **expiry has no transition moment and Verdict never auto-rejects.** Without that sentence, `close` reads as a convenience rather than as the only exit a lapsed run has.

**§7** — `can('approve', $pendingApproval)` → the configured `verdict-console.approvals.gate` ability (default `approve-verdict-action`), which is what the code has always done.

**§14** — "Companion Verdict issue?" → the filed cluster verdict#297–#300, with what each supplies.

## The provenance sentence was the substantive one

It said that rendering provenance live is a context release the host must authorize. ADR 0026 places that release in **`ApprovalManager::issue()`, inside the invocation frame**, storing the payload on the receipt — precisely because `challengeForToolCall()` runs in a later request with no frame to assemble from.

So the release has already been applied *or refused* by the time a challenge carries provenance. Calling the rendering a second release told a host to make a decision it had already made. ADR 0001 line 267 said this outright; the design did not.

## `ADR 0029` is linked and labelled

Two console issues cite it, and the Verdict release pinned in this checkout has ADRs only up to **0028** — nobody working from the tree could read it. It is now linked to `main` upstream and explicitly marked as postdating the pinned docs.

## What the tests do and don't prove

They assert the corrected phrases, and for §14 that the superseded one is **gone** — `->not->toContain('Companion Verdict issue?')`. A positive-only assertion would pass with the old text sitting beside the new.

They pin phrases, not agreement. They cannot prove the design and the ADR say the same thing; only that these four corrections have not been reverted. Mutation-checked: reverting the provenance sentence and dropping the no-auto-reject sentence each fail a test.

**No behaviour change.** The only `src/` edit is a docblock.

## Verification

Pint clean, PHPStan clean, 100% type coverage, **152 passed / 521 assertions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
