### PR TITLE
feat: notify from the console's own observation points

### DIFF
--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -285,8 +285,12 @@ tool-call id — never `approveAll()`** (Verdict deliberately ignores the wildca
   [`src/Support/SecurityStateTransaction.php`], [`src/Support/IndependentTransactionGuard.php`]
 
 ### 6.5 Notifications
-Mail / database / Slack / broadcast. Copy obeys the ADR 0028 ceiling: never "the action completed" —
-at most *"Verdict recorded a completed claim (admission-side belief, not an executor receipt)."*
+Mail / database / Slack / broadcast. VC-11's notifications are limited to observations the console
+actually receives: a newly indexed pause, its own returned approval/rejection transition, and Laravel
+AI's `ToolApprovalResolved` continuation event. They never say an action completed or a receipt was
+consumed: the event carries post-resume tool results, not an execution-claim lifecycle, and a null
+challenge cannot distinguish consumption from expiry, rejection, ambiguity, or absence. Copy obeys
+the ADR 0028 ceiling by reporting the observation rather than inventing its unobservable consequence.
 
 ### 6.6 Evidence read-models
 Over `DecisionEvidence`, honoring ADR 0008 (fingerprints, not raw), surfacing `claimType` +

--- a/src/Approvals/ApprovalNotificationDispatcher.php
+++ b/src/Approvals/ApprovalNotificationDispatcher.php
@@ -56,14 +56,19 @@ final readonly class ApprovalNotificationDispatcher
     private function dispatch(PendingApproval $approval, ApprovalNotificationKey $key, object $notification): void
     {
         try {
-            $recipients = collect($this->recipients->forApproval($approval, $key));
+            // Materialised as a plain list rather than through collect(). The contract returns a
+            // bare `iterable`, whose key type collect() cannot resolve on every supported Laravel
+            // version -- it analysed clean here and failed all 24 CI cells. A host may also hand
+            // back a Generator, which must be walked once and kept, not counted and re-walked.
+            $supplied = $this->recipients->forApproval($approval, $key);
+            $recipients = is_array($supplied) ? array_values($supplied) : iterator_to_array($supplied, false);
         } catch (Throwable $e) {
             $this->markFailed($approval, $key, null, $e);
 
             return;
         }
 
-        if ($recipients->isEmpty()) {
+        if ($recipients === []) {
             return;
         }
 

--- a/src/Approvals/ApprovalNotificationDispatcher.php
+++ b/src/Approvals/ApprovalNotificationDispatcher.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+use Fissible\VerdictConsole\Contracts\ApprovalNotificationRecipients;
+use Fissible\VerdictConsole\Notifications\ApprovalResumeOutcomeNotification;
+use Fissible\VerdictConsole\Notifications\ApprovedApprovalNotification;
+use Fissible\VerdictConsole\Notifications\PendingApprovalNotification;
+use Fissible\VerdictConsole\Notifications\RejectedApprovalNotification;
+use Illuminate\Contracts\Notifications\Dispatcher;
+use Throwable;
+
+/**
+ * Delivers observations only after their row-level claim has made redelivery safe.
+ *
+ * One claim covers every recipient because the observation belongs to the approval, not to an
+ * individual delivery target. Recipient-specific claims would make changing a host's recipient
+ * list silently re-notify people who already received the same observation. Delivery is never
+ * allowed to interrupt the continuation whose observation it reports: Verdict's transition is
+ * already durable by then, while a channel outage is console operational state.
+ */
+final readonly class ApprovalNotificationDispatcher
+{
+    public function __construct(
+        private ApprovalNotificationStore $notifications,
+        private ApprovalNotificationRecipients $recipients,
+        private Dispatcher $dispatcher,
+    ) {}
+
+    /** Announce a newly indexed pending approval once. */
+    public function pending(PendingApproval $approval): void
+    {
+        $this->dispatch($approval, ApprovalNotificationKey::Pending, new PendingApprovalNotification($approval));
+    }
+
+    /** Announce Verdict's observed approval without inferring what the resumed tool did. */
+    public function approved(PendingApproval $approval): void
+    {
+        $this->dispatch($approval, ApprovalNotificationKey::Approved, new ApprovedApprovalNotification($approval));
+    }
+
+    /** Announce Verdict's observed rejection without claiming a consumed receipt. */
+    public function rejected(PendingApproval $approval): void
+    {
+        $this->dispatch($approval, ApprovalNotificationKey::Rejected, new RejectedApprovalNotification($approval));
+    }
+
+    /** Announce Laravel AI's reported continuation result without inferring a completed action. */
+    public function resumeOutcome(PendingApproval $approval): void
+    {
+        $this->dispatch($approval, ApprovalNotificationKey::ResumeOutcome, new ApprovalResumeOutcomeNotification($approval));
+    }
+
+    private function dispatch(PendingApproval $approval, ApprovalNotificationKey $key, object $notification): void
+    {
+        try {
+            $recipients = collect($this->recipients->forApproval($approval, $key));
+        } catch (Throwable $e) {
+            $this->markFailed($approval, $key, null, $e);
+
+            return;
+        }
+
+        if ($recipients->isEmpty()) {
+            return;
+        }
+
+        $claim = null;
+
+        try {
+            $claim = $this->notifications->claim($approval, $key->value);
+
+            if ($claim === null) {
+                return;
+            }
+
+            $this->dispatcher->send($recipients, $notification);
+            $this->notifications->markDelivered($claim);
+        } catch (Throwable $e) {
+            $this->markFailed($approval, $key, $claim, $e);
+        }
+    }
+
+    /**
+     * Preserve a delivery failure when possible without turning a failed audit write into a failed run.
+     *
+     * The stored exception class identifies the operational seam without retaining an exception
+     * message, which commonly includes recipient addresses or rendered copy this audit table must not
+     * become a second log for.
+     */
+    private function markFailed(
+        PendingApproval $approval,
+        ApprovalNotificationKey $key,
+        ?ApprovalNotification $claim,
+        Throwable $failure,
+    ): void {
+        try {
+            $claim ??= $this->notifications->claim($approval, $key->value);
+
+            if ($claim !== null) {
+                $this->notifications->markFailed($claim, $failure::class);
+            }
+        } catch (Throwable) {
+            // The observed decision and its continuation remain more important than an unavailable
+            // console audit table; a retry cannot make a notification channel authoritative.
+        }
+    }
+}

--- a/src/Approvals/ApprovalNotificationKey.php
+++ b/src/Approvals/ApprovalNotificationKey.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+/**
+ * Names observations the console can notify without pretending to observe a receipt lifecycle.
+ *
+ * Hosts receive this value to choose different audiences for a new pause, a recorded decision, and
+ * Laravel AI's continuation event. Keeping the set closed prevents a surface from routing a
+ * fabricated "consumed" or "action completed" observation that the console cannot know.
+ */
+enum ApprovalNotificationKey: string
+{
+    case Pending = 'approval-pending';
+    case Approved = 'approval-approved';
+    case Rejected = 'approval-rejected';
+    case ResumeOutcome = 'approval-resume-outcome';
+}

--- a/src/Approvals/ApprovalResolutionService.php
+++ b/src/Approvals/ApprovalResolutionService.php
@@ -29,6 +29,7 @@ final readonly class ApprovalResolutionService
         private ConversationParticipants $participants,
         private PendingApprovalStore $pendingApprovals,
         private ApprovalReconciliationStore $reconciliations,
+        private ApprovalNotificationDispatcher $notifications,
     ) {}
 
     /**
@@ -132,6 +133,11 @@ final readonly class ApprovalResolutionService
             throw ApprovalNotDrivable::forMissingResumeContext($approval);
         }
 
+        // Eloquent attributes are mutable. Preserve the context already admitted above before
+        // notifying host code, so that code cannot make this continuation use a different row value.
+        $resolverKey = $approval->resolver_key;
+        $conversationId = $approval->conversation_id;
+
         // The live manager is the only supported status read. Its null is intentionally not
         // classified: absent, ambiguous, expired, and non-pending collapse at this boundary.
         $challenge = $this->approvals->challengeForToolCall($approval->tool_call_id);
@@ -151,6 +157,11 @@ final readonly class ApprovalResolutionService
             return $transition;
         }
 
+        // This is the returned Verdict transition itself, the only decision observation the console
+        // owns here. Notify before attempting Laravel AI's continuation, whose outcome cannot turn
+        // this receipt transition into evidence that an action finished.
+        $approve ? $this->notifications->approved($approval) : $this->notifications->rejected($approval);
+
         // This is console-owned operational state, deliberately outside Verdict's security-state
         // transaction. It says a continuation was attempted, never that a receipt remains valid.
         $this->pendingApprovals->beginResumeAttempt($approval);
@@ -160,8 +171,8 @@ final readonly class ApprovalResolutionService
                 ? null
                 : $this->participants->resolve($approval->participant_reference);
 
-            $agent = $this->agents->resolve($approval->resolver_key)
-                ->continue($approval->conversation_id, $participant);
+            $agent = $this->agents->resolve($resolverKey)
+                ->continue($conversationId, $participant);
         } catch (Throwable $e) {
             // No prompt started, so Laravel AI could not have reached the approved tool.
             $this->reconciliations->detect($approval, ResumeFailurePhase::DefinitelyPreExecution);

--- a/src/Contracts/ApprovalNotificationRecipients.php
+++ b/src/Contracts/ApprovalNotificationRecipients.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Contracts;
+
+use Fissible\VerdictConsole\Approvals\ApprovalNotificationKey;
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+
+/**
+ * Lets the host choose who may see a console observation about one approval.
+ *
+ * Recipients belong to the host because the console has no safe default for an operator's identity
+ * or delivery policy. An approval is supplied so a host can route by its own tenant, participant,
+ * or operational ownership without the console inferring any of those relationships. The observation
+ * key is supplied because the audience awaiting a decision is often not the one that needs to hear
+ * its recorded outcome.
+ */
+interface ApprovalNotificationRecipients
+{
+    /** @return iterable<object> recipients accepted by Laravel's notification dispatcher */
+    public function forApproval(PendingApproval $approval, ApprovalNotificationKey $key): iterable;
+}

--- a/src/Contracts/ApprovalNotificationRecipients.php
+++ b/src/Contracts/ApprovalNotificationRecipients.php
@@ -18,6 +18,6 @@ use Fissible\VerdictConsole\Approvals\PendingApproval;
  */
 interface ApprovalNotificationRecipients
 {
-    /** @return iterable<object> recipients accepted by Laravel's notification dispatcher */
+    /** @return iterable<int, object> recipients accepted by Laravel's notification dispatcher */
     public function forApproval(PendingApproval $approval, ApprovalNotificationKey $key): iterable;
 }

--- a/src/Listeners/IngestToolApprovalRequests.php
+++ b/src/Listeners/IngestToolApprovalRequests.php
@@ -6,6 +6,7 @@ namespace Fissible\VerdictConsole\Listeners;
 
 use Fissible\Verdict\Approvals\ApprovalChallenge;
 use Fissible\Verdict\Approvals\ApprovalManager;
+use Fissible\VerdictConsole\Approvals\ApprovalNotificationDispatcher;
 use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
 use Fissible\VerdictConsole\Approvals\Resumability;
 use Fissible\VerdictConsole\Approvals\UnresumableReason;
@@ -33,6 +34,7 @@ final readonly class IngestToolApprovalRequests
         private ConversationParticipants $participants,
         private ApprovalPresenter $presenter,
         private PendingApprovalStore $pendingApprovals,
+        private ApprovalNotificationDispatcher $notifications,
         private Dispatcher $events,
         private LoggerInterface $logger,
     ) {}
@@ -87,6 +89,13 @@ final readonly class IngestToolApprovalRequests
             throw ApprovalReceiptCollision::forToolCall($approval->id, $e);
         } catch (QueryException $e) {
             throw ApprovalIngestionPersistenceFailed::forToolCall($approval->id, $e);
+        }
+
+        if ($outcome->created) {
+            // An event may be redelivered after its row was committed. Only the writer that created
+            // that durable observation may begin notification work; the dispatcher then claims it
+            // before sending so a second delivery path cannot duplicate it.
+            $this->notifications->pending($outcome->pendingApproval);
         }
 
         if ($reason !== null && $outcome->created) {

--- a/src/Listeners/NotifyApprovalResumeOutcome.php
+++ b/src/Listeners/NotifyApprovalResumeOutcome.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Listeners;
+
+use Fissible\VerdictConsole\Approvals\ApprovalNotificationDispatcher;
+use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
+use Laravel\Ai\Events\ToolApprovalResolved;
+
+/** Notifies only from Laravel AI's explicit continuation event, never from an ambiguous null challenge. */
+final readonly class NotifyApprovalResumeOutcome
+{
+    public function __construct(
+        private PendingApprovalStore $pendingApprovals,
+        private ApprovalNotificationDispatcher $notifications,
+    ) {}
+
+    public function handle(ToolApprovalResolved $event): void
+    {
+        foreach ($event->toolResults as $result) {
+            $approval = $this->pendingApprovals->findByToolCall($result->id, $event->conversationId);
+
+            if ($approval !== null) {
+                $this->notifications->resumeOutcome($approval);
+            }
+        }
+    }
+}

--- a/src/Notifications/ApprovalResumeOutcomeNotification.php
+++ b/src/Notifications/ApprovalResumeOutcomeNotification.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Notifications;
+
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+/** Reports Laravel AI's continuation observation without claiming an action or receipt completed. */
+final class ApprovalResumeOutcomeNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(private readonly PendingApproval $approval) {}
+
+    /** @return array<int, string> */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /** @return array{message: string, approval_id: string, tool_call_id: string} */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'message' => 'An approval continuation reported a tool result.',
+            'approval_id' => $this->approval->getKey(),
+            'tool_call_id' => $this->approval->tool_call_id,
+        ];
+    }
+}

--- a/src/Notifications/ApprovedApprovalNotification.php
+++ b/src/Notifications/ApprovedApprovalNotification.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Notifications;
+
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+/** Announces Verdict's recorded approval, not the subsequent action's completion. */
+final class ApprovedApprovalNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(private readonly PendingApproval $approval) {}
+
+    /** @return array<int, string> */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /** @return array{message: string, approval_id: string, tool_call_id: string} */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'message' => 'A tool approval was approved.',
+            'approval_id' => $this->approval->getKey(),
+            'tool_call_id' => $this->approval->tool_call_id,
+        ];
+    }
+}

--- a/src/Notifications/PendingApprovalNotification.php
+++ b/src/Notifications/PendingApprovalNotification.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Notifications;
+
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+/** Announces that the console observed a pause, without claiming anything about its later outcome. */
+final class PendingApprovalNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(private readonly PendingApproval $approval) {}
+
+    /** @return array<int, string> */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /** @return array{message: string, approval_id: string, tool_call_id: string} */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'message' => 'A tool approval is pending.',
+            'approval_id' => $this->approval->getKey(),
+            'tool_call_id' => $this->approval->tool_call_id,
+        ];
+    }
+}

--- a/src/Notifications/RejectedApprovalNotification.php
+++ b/src/Notifications/RejectedApprovalNotification.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Notifications;
+
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+/** Announces Verdict's recorded rejection, not whether a later action ran. */
+final class RejectedApprovalNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(private readonly PendingApproval $approval) {}
+
+    /** @return array<int, string> */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /** @return array{message: string, approval_id: string, tool_call_id: string} */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'message' => 'A tool approval was rejected.',
+            'approval_id' => $this->approval->getKey(),
+            'tool_call_id' => $this->approval->tool_call_id,
+        ];
+    }
+}

--- a/src/Notifications/UnconfiguredApprovalNotificationRecipients.php
+++ b/src/Notifications/UnconfiguredApprovalNotificationRecipients.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Notifications;
+
+use Fissible\VerdictConsole\Approvals\ApprovalNotificationKey;
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Fissible\VerdictConsole\Contracts\ApprovalNotificationRecipients;
+
+/**
+ * Ships silent until the host declares recipients.
+ *
+ * Fabricating a recipient would disclose approval state across an identity boundary the package does
+ * not own. Returning none lets an installation adopt notifications deliberately without turning a
+ * missing binding into a delivery decision.
+ */
+final class UnconfiguredApprovalNotificationRecipients implements ApprovalNotificationRecipients
+{
+    public function forApproval(PendingApproval $approval, ApprovalNotificationKey $key): iterable
+    {
+        return [];
+    }
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -7,6 +7,7 @@ namespace Fissible\VerdictConsole;
 use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
 use Fissible\VerdictConsole\Approvals\GateApproverAuthority;
 use Fissible\VerdictConsole\Console\Commands\DoctorCommand;
+use Fissible\VerdictConsole\Contracts\ApprovalNotificationRecipients;
 use Fissible\VerdictConsole\Contracts\ApprovalPresenter;
 use Fissible\VerdictConsole\Contracts\ApproverAuthority;
 use Fissible\VerdictConsole\Contracts\ConversationParticipants;
@@ -14,11 +15,14 @@ use Fissible\VerdictConsole\Contracts\ResumableAgents;
 use Fissible\VerdictConsole\Events\ApprovalIngestionIncident;
 use Fissible\VerdictConsole\Listeners\IngestToolApprovalRequests;
 use Fissible\VerdictConsole\Listeners\LogApprovalIngestionIncident;
+use Fissible\VerdictConsole\Listeners\NotifyApprovalResumeOutcome;
+use Fissible\VerdictConsole\Notifications\UnconfiguredApprovalNotificationRecipients;
 use Fissible\VerdictConsole\Participants\UnconfiguredConversationParticipants;
 use Fissible\VerdictConsole\Presentation\DefaultApprovalPresenter;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Ai\Events\ToolApprovalRequested;
+use Laravel\Ai\Events\ToolApprovalResolved;
 
 /**
  * Service provider for the headless core of `fissible/verdict-console`.
@@ -47,6 +51,8 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         $this->app->singleton(ResumableAgents::class, AgentResolverRegistry::class);
 
         $this->app->singleton(ConversationParticipants::class, UnconfiguredConversationParticipants::class);
+
+        $this->app->singleton(ApprovalNotificationRecipients::class, UnconfiguredApprovalNotificationRecipients::class);
     }
 
     public function boot(Dispatcher $events): void
@@ -54,6 +60,7 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         // Listener registration belongs in boot, after every provider has registered its bindings.
         // It must precede the console-only guard: approvals are ingested on ordinary web requests.
         $events->listen(ToolApprovalRequested::class, IngestToolApprovalRequests::class);
+        $events->listen(ToolApprovalResolved::class, NotifyApprovalResumeOutcome::class);
 
         if (config('verdict-console.ingestion_incidents.log', true)) {
             $events->listen(ApprovalIngestionIncident::class, LogApprovalIngestionIncident::class);

--- a/tests/EndToEnd/ApprovalRoundTripTest.php
+++ b/tests/EndToEnd/ApprovalRoundTripTest.php
@@ -19,6 +19,8 @@ use Fissible\Verdict\LaravelAi\VerdictApprovalMiddleware;
 use Fissible\Verdict\Targets\ExecutionTargetPolicy;
 use Fissible\Verdict\VerdictManager;
 use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
+use Fissible\VerdictConsole\Approvals\ApprovalNotification;
+use Fissible\VerdictConsole\Approvals\ApprovalNotificationKey;
 use Fissible\VerdictConsole\Approvals\ApprovalReconciliation;
 use Fissible\VerdictConsole\Approvals\ApprovalResolutionService;
 use Fissible\VerdictConsole\Approvals\CloseOutcome;
@@ -26,26 +28,34 @@ use Fissible\VerdictConsole\Approvals\PendingApproval as StoredPendingApproval;
 use Fissible\VerdictConsole\Approvals\Resumability;
 use Fissible\VerdictConsole\Approvals\ResumeFailurePhase;
 use Fissible\VerdictConsole\Approvals\UnresumableReason;
+use Fissible\VerdictConsole\Contracts\ApprovalNotificationRecipients;
 use Fissible\VerdictConsole\Contracts\ApprovalPresenter;
 use Fissible\VerdictConsole\Contracts\ConversationParticipants;
 use Fissible\VerdictConsole\Contracts\ResumableAgents;
 use Fissible\VerdictConsole\Events\ApprovalIngestionIncident;
 use Fissible\VerdictConsole\Exceptions\ApprovalNotDrivable;
 use Fissible\VerdictConsole\Exceptions\ApprovalResumeFailed;
+use Fissible\VerdictConsole\Notifications\ApprovalResumeOutcomeNotification;
+use Fissible\VerdictConsole\Notifications\ApprovedApprovalNotification;
+use Fissible\VerdictConsole\Notifications\PendingApprovalNotification;
+use Fissible\VerdictConsole\Notifications\RejectedApprovalNotification;
 use Fissible\VerdictConsole\Participants\UnconfiguredConversationParticipants;
 use Fissible\VerdictConsole\Presentation\ApprovalPresentation;
 use Fissible\VerdictConsole\Tests\EndToEndTestCase;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\GenericUser;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Contracts\Notifications\Dispatcher as NotificationDispatcher;
 use Illuminate\Database\QueryException;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Schema;
 use Laravel\Ai\Approvals\Decision as AiDecision;
 use Laravel\Ai\Approvals\Decisions;
@@ -82,6 +92,18 @@ final readonly class RoundTripOrder
 final readonly class RoundTripCustomer
 {
     public function __construct(public int $id) {}
+}
+
+final class RoundTripNotificationRecipient
+{
+    use Notifiable;
+
+    public function __construct(private readonly string $key) {}
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
 }
 
 /** Faithfully rebuilds the simple participant fixture by its host-owned opaque reference. */
@@ -378,6 +400,7 @@ beforeEach(function (): void {
     $this->migrateRoundTripTables();
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
     (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_approval_notifications_table.php.stub')->up();
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_approval_reconciliations_table.php.stub')->up();
 
     $this->app->instance(RoundTripLedger::class, new RoundTripLedger);
@@ -412,6 +435,28 @@ function pauseForApproval(RoundTripAgent $agent): string
 
     return $paused->pendingApprovals->first()->id;
 }
+
+it('notifies host recipients when the listener indexes a new pending approval', function (): void {
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->toolCallResponse(TOOL_CALL_ID, 'CancelOrderTool', ['order_id' => ORDER_ID])),
+    ]);
+    $recipient = new RoundTripNotificationRecipient('pending');
+    app()->instance(ApprovalNotificationRecipients::class, new class($recipient) implements ApprovalNotificationRecipients
+    {
+        public function __construct(private object $recipient) {}
+
+        public function forApproval(StoredPendingApproval $approval, ApprovalNotificationKey $key): iterable
+        {
+            return [$this->recipient];
+        }
+    });
+    Notification::fake();
+
+    pauseForApproval(new RoundTripAgent);
+
+    Notification::assertSentToTimes($recipient, PendingApprovalNotification::class, 1);
+});
 
 it('projects a Verdict-backed pause into one drivable console row', function (): void {
     Http::fake([
@@ -1037,6 +1082,127 @@ it('approves through the console and resumes the captured participant-bound conv
         ->and(StoredPendingApproval::query()->sole()->resume_attempts)->toBe(1, 'A successful resume is still an attempt.')
         ->and(StoredPendingApproval::query()->sole()->last_resume_attempt_at)->not->toBeNull()
         ->and(ApprovalReconciliation::query()->count())->toBe(0, 'Nothing diverged, so there is nothing to reconcile.');
+});
+
+it('notifies host recipients of the approval transition the console received', function (bool $approve, string $notification): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->toolCallResponse(TOOL_CALL_ID, 'CancelOrderTool', ['order_id' => ORDER_ID]))
+            ->push($this->textResponse($approve ? 'Order cancelled.' : 'I did not cancel the order.')),
+    ]);
+    $recipient = new RoundTripNotificationRecipient($approve ? 'approved' : 'rejected');
+    app()->instance(ApprovalNotificationRecipients::class, new class($recipient) implements ApprovalNotificationRecipients
+    {
+        public function __construct(private object $recipient) {}
+
+        public function forApproval(StoredPendingApproval $approval, ApprovalNotificationKey $key): iterable
+        {
+            return [$this->recipient];
+        }
+    });
+    Notification::fake();
+
+    pauseForApproval(new RoundTripAgent);
+    $approval = StoredPendingApproval::query()->sole();
+
+    $approve
+        ? app(ApprovalResolutionService::class)->approve($approval, new GenericUser(['id' => 'operator-1']))
+        : app(ApprovalResolutionService::class)->reject($approval, new GenericUser(['id' => 'operator-1']));
+
+    Notification::assertSentToTimes($recipient, $notification, 1);
+})->with([
+    'approved' => [true, ApprovedApprovalNotification::class],
+    'rejected' => [false, RejectedApprovalNotification::class],
+]);
+
+it('continues an approved run when its notification delivery fails', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->toolCallResponse(TOOL_CALL_ID, 'CancelOrderTool', ['order_id' => ORDER_ID]))
+            ->push($this->textResponse('Order cancelled.')),
+    ]);
+
+    pauseForApproval(new RoundTripAgent);
+    app()->instance(ApprovalNotificationRecipients::class, new class implements ApprovalNotificationRecipients
+    {
+        public function forApproval(StoredPendingApproval $approval, ApprovalNotificationKey $key): iterable
+        {
+            throw new LogicException('Delivery for operator@example.test is unavailable.');
+        }
+    });
+
+    $transition = app(ApprovalResolutionService::class)->approve(StoredPendingApproval::query()->sole(), new GenericUser(['id' => 'operator-1']));
+    $delivery = ApprovalNotification::query()->where('notification_key', 'approval-approved')->sole();
+
+    expect($transition?->outcome)->toBe(ApprovalOutcome::Approved)
+        ->and(app(RoundTripLedger::class)->executions)->toBe(1)
+        ->and(StoredPendingApproval::query()->sole()->resume_attempts)->toBe(1)
+        ->and($delivery->failed_at)->not->toBeNull()
+        ->and($delivery->failure_reason)->toBe(LogicException::class)
+        ->and($delivery->failure_reason)->not->toContain('operator@example.test');
+});
+
+it('continues an approved run when the notification dispatcher cannot send', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->toolCallResponse(TOOL_CALL_ID, 'CancelOrderTool', ['order_id' => ORDER_ID]))
+            ->push($this->textResponse('Order cancelled.')),
+    ]);
+
+    pauseForApproval(new RoundTripAgent);
+    app()->instance(ApprovalNotificationRecipients::class, new class implements ApprovalNotificationRecipients
+    {
+        public function forApproval(StoredPendingApproval $approval, ApprovalNotificationKey $key): iterable
+        {
+            return [new RoundTripNotificationRecipient('unavailable-channel')];
+        }
+    });
+    app()->instance(NotificationDispatcher::class, new class implements NotificationDispatcher
+    {
+        public function send($notifiables, $notification)
+        {
+            throw new LogicException('Notification transport is unavailable.');
+        }
+
+        public function sendNow($notifiables, $notification, ?array $channels = null) {}
+    });
+
+    $transition = app(ApprovalResolutionService::class)->approve(StoredPendingApproval::query()->sole(), new GenericUser(['id' => 'operator-1']));
+    $delivery = ApprovalNotification::query()->where('notification_key', 'approval-approved')->sole();
+
+    expect($transition?->outcome)->toBe(ApprovalOutcome::Approved)
+        ->and(app(RoundTripLedger::class)->executions)->toBe(1)
+        ->and(StoredPendingApproval::query()->sole()->resume_attempts)->toBe(1)
+        ->and($delivery->failed_at)->not->toBeNull()
+        ->and($delivery->failure_reason)->toBe(LogicException::class);
+});
+
+it('notifies host recipients when Laravel AI reports the approval continuation outcome', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->toolCallResponse(TOOL_CALL_ID, 'CancelOrderTool', ['order_id' => ORDER_ID]))
+            ->push($this->textResponse('Order cancelled.')),
+    ]);
+    $recipient = new RoundTripNotificationRecipient('resume-outcome');
+    app()->instance(ApprovalNotificationRecipients::class, new class($recipient) implements ApprovalNotificationRecipients
+    {
+        public function __construct(private object $recipient) {}
+
+        public function forApproval(StoredPendingApproval $approval, ApprovalNotificationKey $key): iterable
+        {
+            return [$this->recipient];
+        }
+    });
+    Notification::fake();
+
+    pauseForApproval(new RoundTripAgent);
+    app(ApprovalResolutionService::class)->approve(StoredPendingApproval::query()->sole(), new GenericUser(['id' => 'operator-1']));
+
+    Notification::assertSentToTimes($recipient, ApprovalResumeOutcomeNotification::class, 1);
 });
 
 /**

--- a/tests/Feature/ApprovalNotificationDispatchTest.php
+++ b/tests/Feature/ApprovalNotificationDispatchTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\VerdictConsole\Approvals\ApprovalNotification;
+use Fissible\VerdictConsole\Approvals\ApprovalNotificationDispatcher;
+use Fissible\VerdictConsole\Approvals\ApprovalNotificationKey;
+use Fissible\VerdictConsole\Approvals\ApprovalNotificationStore;
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
+use Fissible\VerdictConsole\Contracts\ApprovalNotificationRecipients;
+use Fissible\VerdictConsole\Notifications\ApprovalResumeOutcomeNotification;
+use Fissible\VerdictConsole\Notifications\ApprovedApprovalNotification;
+use Fissible\VerdictConsole\Notifications\PendingApprovalNotification;
+use Fissible\VerdictConsole\Notifications\RejectedApprovalNotification;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Notification;
+
+final class ApprovalNotificationRecipient
+{
+    use Notifiable;
+
+    public function __construct(private readonly string $key) {}
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+}
+
+beforeEach(function (): void {
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_approval_notifications_table.php.stub')->up();
+});
+
+it('claims one pending observation before notifying every host recipient', function (): void {
+    $approval = app(PendingApprovalStore::class)->ingest('call_pending_notification');
+    $first = new ApprovalNotificationRecipient('first');
+    $second = new ApprovalNotificationRecipient('second');
+
+    app()->instance(ApprovalNotificationRecipients::class, new class($first, $second) implements ApprovalNotificationRecipients
+    {
+        public function __construct(private object $first, private object $second) {}
+
+        public function forApproval(PendingApproval $approval, ApprovalNotificationKey $key): iterable
+        {
+            return [$this->first, $this->second];
+        }
+    });
+    Notification::fake();
+
+    app(ApprovalNotificationDispatcher::class)->pending($approval);
+    app(ApprovalNotificationDispatcher::class)->pending($approval);
+
+    Notification::assertSentToTimes($first, PendingApprovalNotification::class, 1);
+    Notification::assertSentToTimes($second, PendingApprovalNotification::class, 1);
+    expect(ApprovalNotification::query()->count())->toBe(1, 'A claim belongs to the approval observation, not to each recipient.');
+});
+
+it('never presents a notification as a consumed receipt or a finished action', function (): void {
+    $approval = app(PendingApprovalStore::class)->ingest('call_notification_copy');
+    $recipient = new ApprovalNotificationRecipient('copy');
+
+    $messages = [
+        (new PendingApprovalNotification($approval))->toArray($recipient)['message'],
+        (new ApprovedApprovalNotification($approval))->toArray($recipient)['message'],
+        (new RejectedApprovalNotification($approval))->toArray($recipient)['message'],
+        (new ApprovalResumeOutcomeNotification($approval))->toArray($recipient)['message'],
+    ];
+
+    foreach ($messages as $message) {
+        expect($message)->not->toContain('consumed')
+            ->not->toContain('completed')
+            ->not->toContain('finished');
+    }
+});
+
+it('gives the host the observation key needed to route different notification audiences', function (): void {
+    $approval = app(PendingApprovalStore::class)->ingest('call_keyed_recipients');
+    $recipient = new ApprovalNotificationRecipient('routing');
+    $recipients = new class($recipient) implements ApprovalNotificationRecipients
+    {
+        /** @var array<int, ApprovalNotificationKey> */
+        public array $requested = [];
+
+        public function __construct(private object $recipient) {}
+
+        public function forApproval(PendingApproval $approval, ApprovalNotificationKey $key): iterable
+        {
+            $this->requested[] = $key;
+
+            return [$this->recipient];
+        }
+    };
+    app()->instance(ApprovalNotificationRecipients::class, $recipients);
+    app()->instance(ApprovalNotificationStore::class, new ApprovalNotificationStore);
+    Notification::fake();
+
+    app(ApprovalNotificationDispatcher::class)->pending($approval);
+
+    expect($recipients->requested)->toBe([ApprovalNotificationKey::Pending]);
+});
+
+it('routes every observation only to the recipient selected for its key', function (): void {
+    $approval = app(PendingApprovalStore::class)->ingest('call_keyed_audiences');
+    $pending = new ApprovalNotificationRecipient('pending');
+    $approved = new ApprovalNotificationRecipient('approved');
+    $rejected = new ApprovalNotificationRecipient('rejected');
+    $resumed = new ApprovalNotificationRecipient('resumed');
+    app()->instance(ApprovalNotificationRecipients::class, new class($pending, $approved, $rejected, $resumed) implements ApprovalNotificationRecipients
+    {
+        public function __construct(
+            private object $pending,
+            private object $approved,
+            private object $rejected,
+            private object $resumed,
+        ) {}
+
+        public function forApproval(PendingApproval $approval, ApprovalNotificationKey $key): iterable
+        {
+            return match ($key) {
+                ApprovalNotificationKey::Pending => [$this->pending],
+                ApprovalNotificationKey::Approved => [$this->approved],
+                ApprovalNotificationKey::Rejected => [$this->rejected],
+                ApprovalNotificationKey::ResumeOutcome => [$this->resumed],
+            };
+        }
+    });
+    Notification::fake();
+
+    $dispatcher = app(ApprovalNotificationDispatcher::class);
+    $dispatcher->pending($approval);
+    $dispatcher->approved($approval);
+    $dispatcher->rejected($approval);
+    $dispatcher->resumeOutcome($approval);
+
+    Notification::assertSentToTimes($pending, PendingApprovalNotification::class, 1);
+    Notification::assertSentToTimes($approved, ApprovedApprovalNotification::class, 1);
+    Notification::assertSentToTimes($rejected, RejectedApprovalNotification::class, 1);
+    Notification::assertSentToTimes($resumed, ApprovalResumeOutcomeNotification::class, 1);
+});

--- a/tests/Feature/ApprovalNotificationDispatchTest.php
+++ b/tests/Feature/ApprovalNotificationDispatchTest.php
@@ -139,3 +139,39 @@ it('routes every observation only to the recipient selected for its key', functi
     Notification::assertSentToTimes($rejected, RejectedApprovalNotification::class, 1);
     Notification::assertSentToTimes($resumed, ApprovalResumeOutcomeNotification::class, 1);
 });
+
+/**
+ * A host may return a Generator, and it must be walked once rather than counted and re-walked.
+ *
+ * This was a real bug, found only because PHPStan rejected the `collect()` that hid it: the
+ * emptiness check consumed the generator, and `send()` then received nothing while the claim was
+ * still marked delivered — notifications reaching nobody, with the audit reporting success. That is
+ * the same false-delivery shape as an empty recipient list, arrived at from the other direction.
+ *
+ * `iterable` admits a Generator, so this is the contract's own surface rather than an exotic case.
+ */
+it('walks a generator of recipients once instead of consuming it on the emptiness check', function (): void {
+    Notification::fake();
+
+    $approval = app(PendingApprovalStore::class)->ingest('call_generator_recipients');
+    $recipient = new ApprovalNotificationRecipient('lazy');
+
+    app()->instance(ApprovalNotificationRecipients::class, new class($recipient) implements ApprovalNotificationRecipients
+    {
+        public function __construct(private readonly ApprovalNotificationRecipient $recipient) {}
+
+        public function forApproval(PendingApproval $approval, ApprovalNotificationKey $key): iterable
+        {
+            yield $this->recipient;
+        }
+    });
+
+    app(ApprovalNotificationDispatcher::class)->pending($approval);
+
+    Notification::assertSentTo($recipient, PendingApprovalNotification::class);
+
+    $claim = app(ApprovalNotificationStore::class)->find($approval, ApprovalNotificationKey::Pending->value);
+
+    expect($claim)->not->toBeNull()
+        ->and($claim->delivered_at)->not->toBeNull('A delivered claim must mean somebody was actually sent to.');
+});

--- a/tests/Feature/ApprovalNotificationRecipientsTest.php
+++ b/tests/Feature/ApprovalNotificationRecipientsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\VerdictConsole\Approvals\ApprovalNotification;
+use Fissible\VerdictConsole\Approvals\ApprovalNotificationDispatcher;
+use Fissible\VerdictConsole\Approvals\ApprovalNotificationKey;
+use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
+use Fissible\VerdictConsole\Contracts\ApprovalNotificationRecipients;
+
+beforeEach(function (): void {
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_approval_notifications_table.php.stub')->up();
+});
+
+it('ships with no approval-notification recipients until the host opts in', function (): void {
+    $approval = app(PendingApprovalStore::class)->ingest('call_default_recipient');
+
+    expect(app(ApprovalNotificationRecipients::class)->forApproval($approval, ApprovalNotificationKey::Pending))->toBe([]);
+});
+
+it('does not claim or report delivery when the shipped recipient default has nobody to notify', function (): void {
+    $approval = app(PendingApprovalStore::class)->ingest('call_default_delivery');
+
+    app(ApprovalNotificationDispatcher::class)->pending($approval);
+
+    expect(ApprovalNotification::query()->count())->toBe(0);
+});


### PR DESCRIPTION
Closes #11.

Verdict emits no receipt-transition events — its only events are the four anomalies. So the console publishes from **its own** observation points rather than by subscribing to Verdict: VC-5's ingestion, VC-6's returned transition, and Laravel AI's `ToolApprovalResolved`. Idempotency is VC-9's claim table, which has been sitting unused since it shipped.

## Recipients are the host's, and the default is silence

`ApprovalNotificationRecipients::forApproval(PendingApproval $row, ApprovalNotificationKey $key)`, with a shipped implementation returning none.

The package has no safe guess for who may see approval state: approvers come from a `Gate` ability, which is a predicate rather than a list, and participants are opaque by design. Returning none lets an installation adopt notifications deliberately instead of turning a missing binding into a delivery decision. The key is passed through so "pending" can reach reviewers while "approved" reaches whoever asked.

**One claim per observation, not per recipient.** The observation belongs to the approval; keying claims by recipient would re-notify everyone the moment a host edited its recipient list.

## Three things this deliberately does not do

- **No completion notice.** Verdict emits no execution-claim-completed event, and `ToolApprovalResolved` carries post-resume tool results, not a claim lifecycle signal.
- **No `consumed` notice.** `challengeForToolCall()` returning null after a resume means expired, rejected, ambiguous, *or* absent. A detector built on it asserts a transition it cannot observe, and reading receipt status directly breaks the §5 boundary.
- **No copy claiming an action finished** — ADR 0028's ceiling.

## Notifying cannot interrupt the run it observes

An earlier revision dispatched before the continuation and rethrew on failure. That put the send between Verdict recording a decision and the console attempting to resume — **outside both `try` blocks**. A mail outage would have stranded an approved run with no reconciliation record and `resume_attempts` reading 0: indistinguishable from never having tried, and invisible to VC-10.

Failures are now recorded on the claim and swallowed. That column exists for exactly this.

**Empty recipients create no claim.** Claiming first and recording `delivered_at` when nothing was sent made the audit answer *"was anyone told?"* with **yes** — and permanently silenced every row that passed through before a host configured recipients, since `claim()` returns null forever after.

**`failure_reason` stores the exception class, never its message.** VC-9's migration says that column is an audit of console work and *"never the recipient's address or the message body"* — and delivery exceptions routinely contain both.

## A note on what the test count meant

Both fixes above were **correct in code before they were pinned**. The suite grew by three tests and ten assertions, and reverting either fix still left it green — the number moved in the right direction for the wrong reason. The controls that actually hold them are `continues an approved run when the notification dispatcher cannot send` and `routes every observation only to the recipient selected for its key`.

| Mutation | Fails |
|---|---|
| Restore the rethrow on `send()` failure | `continues an approved run when the notification dispatcher cannot…` |
| Hard-code the `Pending` key | `routes every observation only to the recipient selected for its key` |
| Claim with no recipients | `does not claim or report delivery when the shipped recipient default…` |
| Record the message instead of the class | both delivery-failure tests |

## Verification

Pint clean, PHPStan clean, 100% type coverage, **164 passed / 570 assertions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
