### PR TITLE
feat: tenancy scoping the host owns

### DIFF
--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -322,7 +322,14 @@ evidence trail *means* — any future write surface must announce that, not just
 - **Who may approve is the host's call** — Laravel `Gate` evaluates the configured
   `verdict-console.approvals.gate` ability (default `approve-verdict-action`) for the pending row;
   the package ships that default but never hard-codes authority.
-- **Tenancy/scoping delegates to the host.**
+- **Tenancy/scoping delegates to the host.** `ApprovalScope` receives the console's
+  `PendingApproval` query and applies the host's tenant or ownership boundary; the console neither
+  adds a tenant column nor derives one from a conversation or participant. The same scoped read
+  gates rendered verbs and a direct resolve/close call, so a model retained across a tenant switch
+  is neither visible nor actionable. **It does not scope console correlation work:** ingest
+  read-backs, resume locks, and Laravel AI event joins must survive a worker with no current tenant,
+  because visibility is an operator boundary rather than a condition for recording a pause.
+  [`src/Contracts/ApprovalScope.php`]
 - **Real-time transport degrades:** polling default (no infra); broadcast (Reverb/Pusher) opt-in.
 
 ## 8. Layer 2 — surfaces, specialized by audience

--- a/src/Approvals/ApprovalResolutionService.php
+++ b/src/Approvals/ApprovalResolutionService.php
@@ -58,6 +58,8 @@ final readonly class ApprovalResolutionService
      */
     public function close(PendingApproval $approval, ?Authenticatable $approver): CloseOutcome
     {
+        $this->assertVisible($approval);
+
         if (! $this->authority->allows($approval, $approver)) {
             throw new AuthorizationException('This approver may not resolve this approval.');
         }
@@ -119,6 +121,8 @@ final readonly class ApprovalResolutionService
 
     private function resolve(PendingApproval $approval, ?Authenticatable $approver, bool $approve): ?ApprovalTransition
     {
+        $this->assertVisible($approval);
+
         if (! $this->authority->allows($approval, $approver)) {
             throw new AuthorizationException('This approver may not resolve this approval.');
         }
@@ -193,5 +197,19 @@ final readonly class ApprovalResolutionService
         }
 
         return $transition;
+    }
+
+    /**
+     * Refuse a row the host's current scope no longer exposes before consulting Verdict.
+     *
+     * A model can outlive a tenant switch or be supplied directly to this headless service. Treating
+     * either as merely "not found" would still allow a later manager call to spend its receipt, so
+     * the same non-disclosing refusal used for an unauthorized approver stops it at the boundary.
+     */
+    private function assertVisible(PendingApproval $approval): void
+    {
+        if (! $this->pendingApprovals->isVisible($approval)) {
+            throw new AuthorizationException('This approver may not resolve this approval.');
+        }
     }
 }

--- a/src/Approvals/ApprovalVerbs.php
+++ b/src/Approvals/ApprovalVerbs.php
@@ -10,6 +10,12 @@ use Fissible\Verdict\Approvals\ApprovalChallenge;
 final class ApprovalVerbs
 {
     /**
+     * The store is required rather than fabricated here so a rendering surface cannot silently drop
+     * the host scope by constructing its own neutral store around a stale row.
+     */
+    public function __construct(private PendingApprovalStore $pendingApprovals) {}
+
+    /**
      * Return the verbs a surface may offer for this item.
      *
      * A persisted row proves only that Laravel AI once paused; the live challenge proves Verdict
@@ -20,6 +26,10 @@ final class ApprovalVerbs
      */
     public function resolve(PendingApproval $approval, ?ApprovalChallenge $challenge): array
     {
+        if (! $this->pendingApprovals->isVisible($approval)) {
+            return [];
+        }
+
         if ($approval->resumability !== Resumability::Drivable) {
             return [];
         }

--- a/src/Approvals/PendingApprovalStore.php
+++ b/src/Approvals/PendingApprovalStore.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Fissible\VerdictConsole\Approvals;
 
+use Fissible\VerdictConsole\Contracts\ApprovalScope;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -16,6 +18,15 @@ use Illuminate\Support\Str;
  */
 final class PendingApprovalStore
 {
+    private ApprovalScope $scope;
+
+    public function __construct(?ApprovalScope $scope = null)
+    {
+        // Direct construction remains neutral for package consumers that only write or test rows;
+        // container resolution receives the host binding, which is the runtime boundary for reads.
+        $this->scope = $scope ?? new UnscopedApprovalScope;
+    }
+
     /**
      * Record a pause, or return the row that already records it.
      *
@@ -120,7 +131,7 @@ final class PendingApprovalStore
         } catch (UniqueConstraintViolationException $e) {
             // Read back by the natural key rather than trusting the id generated above: whoever won
             // the race wrote a different one, and theirs is the row that matters.
-            $existing = PendingApproval::query()->where('ingest_key', $ingestKey)->first();
+            $existing = $this->correlationQuery()->where('ingest_key', $ingestKey)->first();
 
             if ($existing === null) {
                 throw $e;
@@ -130,7 +141,7 @@ final class PendingApprovalStore
         }
 
         return new PendingApprovalIngestion(
-            PendingApproval::query()->where('ingest_key', $ingestKey)->sole(),
+            $this->correlationQuery()->where('ingest_key', $ingestKey)->sole(),
             true,
         );
     }
@@ -140,7 +151,7 @@ final class PendingApprovalStore
      */
     public function findByToolCall(string $toolCallId, ?string $conversationId = null): ?PendingApproval
     {
-        return PendingApproval::query()
+        return $this->correlationQuery()
             ->where('ingest_key', PendingApproval::ingestKey($toolCallId, $conversationId))
             ->first();
     }
@@ -162,7 +173,7 @@ final class PendingApprovalStore
     public function beginResumeAttempt(PendingApproval $approval): int
     {
         return DB::transaction(function () use ($approval): int {
-            $locked = PendingApproval::query()
+            $locked = $this->correlationQuery()
                 ->whereKey($approval->getKey())
                 ->lockForUpdate()
                 ->firstOrFail();
@@ -186,6 +197,27 @@ final class PendingApprovalStore
      */
     public function findByReceipt(string $receiptId): ?PendingApproval
     {
-        return PendingApproval::query()->where('receipt_id', $receiptId)->first();
+        return $this->correlationQuery()->where('receipt_id', $receiptId)->first();
+    }
+
+    /**
+     * Whether this approval remains inside the host's current query boundary.
+     *
+     * Actions accept a row because a surface just rendered it, but that row can outlive a tenant
+     * switch. Re-reading only its key through the scope prevents a stale or injected model from
+     * becoming an authorization bypass.
+     */
+    public function isVisible(PendingApproval $approval): bool
+    {
+        return $this->scope->apply(PendingApproval::query())->whereKey($approval->getKey())->exists();
+    }
+
+    /** @return Builder<PendingApproval> */
+    private function correlationQuery(): Builder
+    {
+        // Queue listeners must be able to correlate Laravel AI events even when they have no
+        // operator tenant context. Scope decides what a human may see or act on, not whether a
+        // console-owned pause can be written, locked, or joined to its framework event.
+        return PendingApproval::query();
     }
 }

--- a/src/Approvals/UnscopedApprovalScope.php
+++ b/src/Approvals/UnscopedApprovalScope.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+use Fissible\VerdictConsole\Contracts\ApprovalScope;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Leaves the package neutral until a host supplies its own tenancy boundary.
+ *
+ * A fabricated tenant default would be an authority decision made without the host's data model.
+ * Hosts that have a boundary replace this binding, and every console read then carries that scope.
+ */
+final class UnscopedApprovalScope implements ApprovalScope
+{
+    public function apply(Builder $query): Builder
+    {
+        return $query;
+    }
+}

--- a/src/Contracts/ApprovalScope.php
+++ b/src/Contracts/ApprovalScope.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Contracts;
+
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Lets the host constrain approval queries with its own tenancy or ownership model.
+ *
+ * The console has neither a tenant identifier nor authority to derive one from a participant or
+ * conversation. Receiving the query keeps that decision in host code, where a scope may use the
+ * host's tenant context, joins, or existing ownership columns without this package storing a second
+ * tenancy model.
+ */
+interface ApprovalScope
+{
+    /**
+     * @param  Builder<PendingApproval>  $query
+     * @return Builder<PendingApproval>
+     */
+    public function apply(Builder $query): Builder;
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -6,9 +6,11 @@ namespace Fissible\VerdictConsole;
 
 use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
 use Fissible\VerdictConsole\Approvals\GateApproverAuthority;
+use Fissible\VerdictConsole\Approvals\UnscopedApprovalScope;
 use Fissible\VerdictConsole\Console\Commands\DoctorCommand;
 use Fissible\VerdictConsole\Contracts\ApprovalNotificationRecipients;
 use Fissible\VerdictConsole\Contracts\ApprovalPresenter;
+use Fissible\VerdictConsole\Contracts\ApprovalScope;
 use Fissible\VerdictConsole\Contracts\ApproverAuthority;
 use Fissible\VerdictConsole\Contracts\ConversationParticipants;
 use Fissible\VerdictConsole\Contracts\ResumableAgents;
@@ -40,6 +42,8 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/verdict-console.php', 'verdict-console');
 
         $this->app->singleton(ApprovalPresenter::class, DefaultApprovalPresenter::class);
+
+        $this->app->singleton(ApprovalScope::class, UnscopedApprovalScope::class);
 
         // Bound to the Gate-backed authority, which denies until the host defines the ability. A
         // host whose authority model is not a Gate rebinds this contract.

--- a/tests/EndToEnd/ApprovalRoundTripTest.php
+++ b/tests/EndToEnd/ApprovalRoundTripTest.php
@@ -30,6 +30,7 @@ use Fissible\VerdictConsole\Approvals\ResumeFailurePhase;
 use Fissible\VerdictConsole\Approvals\UnresumableReason;
 use Fissible\VerdictConsole\Contracts\ApprovalNotificationRecipients;
 use Fissible\VerdictConsole\Contracts\ApprovalPresenter;
+use Fissible\VerdictConsole\Contracts\ApprovalScope;
 use Fissible\VerdictConsole\Contracts\ConversationParticipants;
 use Fissible\VerdictConsole\Contracts\ResumableAgents;
 use Fissible\VerdictConsole\Events\ApprovalIngestionIncident;
@@ -46,6 +47,7 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\GenericUser;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Contracts\Notifications\Dispatcher as NotificationDispatcher;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\QueryException;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\JsonSchema\Types\Type;
@@ -1203,6 +1205,87 @@ it('notifies host recipients when Laravel AI reports the approval continuation o
     app(ApprovalResolutionService::class)->approve(StoredPendingApproval::query()->sole(), new GenericUser(['id' => 'operator-1']));
 
     Notification::assertSentToTimes($recipient, ApprovalResumeOutcomeNotification::class, 1);
+});
+
+it('refuses a row outside the host scope before Verdict can spend its receipt or notify', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->toolCallResponse(TOOL_CALL_ID, 'CancelOrderTool', ['order_id' => ORDER_ID])),
+    ]);
+
+    $toolCallId = pauseForApproval(new RoundTripAgent);
+    $row = StoredPendingApproval::query()->sole();
+    app()->instance(ApprovalNotificationRecipients::class, new class implements ApprovalNotificationRecipients
+    {
+        public function forApproval(StoredPendingApproval $approval, ApprovalNotificationKey $key): iterable
+        {
+            return [new RoundTripNotificationRecipient('foreign-scope')];
+        }
+    });
+    Notification::fake();
+    app()->instance(ApprovalScope::class, new class implements ApprovalScope
+    {
+        public function apply(Builder $query): Builder
+        {
+            return $query->where('conversation_id', 'another-tenant');
+        }
+    });
+
+    $failure = null;
+
+    try {
+        app(ApprovalResolutionService::class)->approve($row, new GenericUser(['id' => 'operator-1']));
+    } catch (Throwable $e) {
+        $failure = $e;
+    }
+
+    Notification::assertNothingSent();
+    expect($failure)->toBeInstanceOf(AuthorizationException::class);
+    expect(app(VerdictManager::class)->approvals()->challengeForToolCall($toolCallId))->not->toBeNull()
+        ->and(app(RoundTripLedger::class)->executions)->toBe(0)
+        ->and(StoredPendingApproval::query()->sole()->resume_attempts)->toBe(0);
+});
+
+it('refuses a foreign-scope close without sending a notification', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->toolCallResponse(TOOL_CALL_ID, 'CancelOrderTool', ['order_id' => ORDER_ID])),
+    ]);
+
+    pauseForApproval(new RoundTripAgent);
+    $row = StoredPendingApproval::query()->sole();
+    DB::table('verdict_approval_receipts')->where('tool_call_id', $row->tool_call_id)->update([
+        'expires_at' => now()->subMinute(),
+    ]);
+    app()->instance(ApprovalNotificationRecipients::class, new class implements ApprovalNotificationRecipients
+    {
+        public function forApproval(StoredPendingApproval $approval, ApprovalNotificationKey $key): iterable
+        {
+            return [new RoundTripNotificationRecipient('foreign-close')];
+        }
+    });
+    Notification::fake();
+    app()->instance(ApprovalScope::class, new class implements ApprovalScope
+    {
+        public function apply(Builder $query): Builder
+        {
+            return $query->where('conversation_id', 'another-tenant');
+        }
+    });
+
+    $failure = null;
+
+    try {
+        app(ApprovalResolutionService::class)->close($row, new GenericUser(['id' => 'operator-1']));
+    } catch (Throwable $e) {
+        $failure = $e;
+    }
+
+    Notification::assertNothingSent();
+    expect($failure)->toBeInstanceOf(AuthorizationException::class);
+    expect($row->fresh()->resume_attempts)->toBe(0);
 });
 
 /**

--- a/tests/Feature/ApprovalScopeTest.php
+++ b/tests/Feature/ApprovalScopeTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Approvals\ApprovalChallenge;
+use Fissible\VerdictConsole\Approvals\ApprovalVerbs;
+use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
+use Fissible\VerdictConsole\Approvals\Resumability;
+use Fissible\VerdictConsole\Contracts\ApprovalScope;
+use Illuminate\Database\Eloquent\Builder;
+
+final readonly class ConversationApprovalScope implements ApprovalScope
+{
+    public function __construct(private string $conversationId) {}
+
+    public function apply(Builder $query): Builder
+    {
+        return $query->where('conversation_id', $this->conversationId);
+    }
+}
+
+beforeEach(function (): void {
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
+});
+
+it('keeps correlation reads available while hiding another tenant approval', function (): void {
+    $writer = new PendingApprovalStore;
+    $visible = $writer->ingest('call_visible', conversationId: 'tenant-a');
+    $writer->ingest('call_hidden', conversationId: 'tenant-b');
+
+    app()->instance(ApprovalScope::class, new ConversationApprovalScope('tenant-a'));
+    $approvals = app(PendingApprovalStore::class);
+    $hidden = $approvals->findByToolCall('call_hidden', 'tenant-b');
+
+    expect($approvals->findByToolCall('call_visible', 'tenant-a')?->id)->toBe($visible->id)
+        ->and($hidden)->not->toBeNull();
+    expect($hidden)->not->toBeNull()
+        ->and($approvals->isVisible($hidden))->toBeFalse();
+});
+
+it('records a pause even when the worker has no matching host scope', function (): void {
+    app()->instance(ApprovalScope::class, new ConversationApprovalScope('tenant-a'));
+
+    $approval = app(PendingApprovalStore::class)->ingest('call_worker', conversationId: 'tenant-b');
+
+    expect($approval->tool_call_id)->toBe('call_worker')
+        ->and($approval->conversation_id)->toBe('tenant-b');
+});
+
+it('does not render an action for a row outside the host scope', function (): void {
+    $approval = (new PendingApprovalStore)->ingest(
+        toolCallId: 'call_hidden_verb',
+        conversationId: 'tenant-b',
+        resumability: Resumability::Drivable,
+    );
+    app()->instance(ApprovalScope::class, new ConversationApprovalScope('tenant-a'));
+    $challenge = new ApprovalChallenge(
+        receiptId: 'receipt_hidden_verb',
+        toolCallId: 'call_hidden_verb',
+        capability: 'orders.cancel',
+        reason: null,
+        expiresAt: new DateTimeImmutable('+10 minutes'),
+    );
+
+    expect(app(ApprovalVerbs::class)->resolve($approval, $challenge))->toBe([]);
+});

--- a/tests/Feature/ApprovalVerbsTest.php
+++ b/tests/Feature/ApprovalVerbsTest.php
@@ -17,7 +17,7 @@ beforeEach(function (): void {
     (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
 
     $this->approvals = new PendingApprovalStore;
-    $this->verbs = new ApprovalVerbs;
+    $this->verbs = new ApprovalVerbs($this->approvals);
     $this->challenge = new ApprovalChallenge(
         receiptId: 'receipt_1',
         toolCallId: 'call_1',


### PR DESCRIPTION
Closes #12. **Last issue in v0.2.0.**

`ApprovalScope` receives the query and returns it constrained. The console stores no tenant column and derives no tenancy from a participant or conversation — it has neither the identifier nor the authority to invent one. The shipped default constrains nothing, so a host without a boundary is unaffected and a host with one replaces the binding.

## Rebased onto VC-11, which merged mid-flight

`7aee94c`. VC-11 and VC-12 were both leaves off this milestone and looked independent on the dependency graph — but they land on the same three files and **interact inside `resolve()`**.

The pre-rebase run reported *155 passed* against a tree missing VC-11's thirteen tests. That was a different baseline, not a regression and not a pass, and the mutation kills measured on it said nothing about the merged code. This branch is now at `7aee94c` with zero commits behind main.

## Scope guards precede both the Verdict transition and the notification dispatch

`assertVisible()` is the **first statement** in `resolve()` and `close()` — ahead of approver authority, ahead of `challengeForToolCall()`, ahead of `approve()`/`reject()`, and ahead of VC-11's notification dispatch.

That ordering is the substance of the interaction. A row outside the host's boundary cannot spend its Verdict receipt, and cannot cause a notification **about itself** — which would otherwise disclose approval state across the very boundary this feature exists to enforce, by email, to a recipient list resolved from a row the caller was never allowed to see.

A mutation moving the guard below the transition fails a test whose name says `before Verdict can spend it`.

A refused scope raises the **same** `AuthorizationException` message as a refused approver, so scope membership cannot be probed by comparing errors.

## Scope is not the same as finding your own row

An earlier revision routed every store read through the scope, including `ingest()`'s read-back. Probed:

```
thrown => Illuminate\Database\Eloquent\ModelNotFoundException
row    => none
rows   => 1        ← the insert succeeded
```

`IngestToolApprovalRequests` would log that as *"could not ingest a paused approval"* — a pause recorded in the database and treated as lost, which is the outcome §6.3 forbids. It's the same failure VC-4 fixed when `insertOrIgnore` swallowed a conflict, reintroduced through a different door.

The same applied to the conflict path, the resume lock, and the `findByToolCall()` that `NotifyApprovalResumeOutcome` uses — where a queue worker without tenant context would silently drop the resume-outcome notification.

Correlation reads are now unscoped and say why **at the call site**, because two near-identical query helpers invite a future tidy-up that collapses them again. Scope decides what a human may see or act on; it does not decide whether a console-owned pause can be written, locked, or joined to its framework event.

## Mutation checks

| Mutation | Fails |
|---|---|
| Re-apply scope to correlation reads | `records a pause even when the worker has no matching host scope`, `keeps correlation reads available…` |
| `isVisible()` ignores the scope | four tests — both action refusals and verb rendering |
| Remove the scope guard | both refusal tests |
| Move the guard below the transition | `refuses a row outside the host scope before Verdict can spend it` |

## Verification

Pint clean, PHPStan clean, 100% type coverage, **170 passed / 592 assertions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
