### PR TITLE
ci: report every matrix cell instead of cancelling on the first failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      fail-fast: true
+      # A compatibility matrix exists to report every cell. fail-fast cancels the other 23 the
+      # moment one fails, which discards exactly the information the matrix is for: whether a
+      # failure is one cell or every cell. Cancelled jobs also render identically to failed ones,
+      # so a single broken combination reads as a broken matrix. Nothing is saved by stopping
+      # early -- the cells are independent and each takes about a minute.
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.3, 8.4, 8.5]


### PR DESCRIPTION
One line: `fail-fast: true` → `false`, with the reasoning in a comment beside it.

## Why

The matrix is 3 PHP versions × 2 Laravel versions × 2 stability settings, and it exists to say **which combinations work**. `fail-fast: true` cancels the remaining 23 jobs the moment one fails — so a failure reports that something broke, but not whether it broke in one cell or in all of them. That distinction is the diagnosis.

Cancelled jobs also render identically to failed ones in `gh pr checks`, so one broken combination presents as a broken matrix. That happened twice while triaging an unrelated upstream incident: three red checks, two of which were cancellations that never executed anything, and telling them apart meant reading per-job conclusions from the API.

Nothing is saved by stopping early — the cells are independent and each takes about a minute.

## What this is not

**Not a workaround for flakiness.** [#40](https://github.com/fissible/verdict-console/issues/40) proposed this alongside a retry, on the premise that a `setup-php` failure "fails every run". That premise was wrong — the failures were a bounded upstream incident on 2026-08-23, with 23 clean runs before and 25 after — and #40 is closed with the evidence.

This change stands on its own, and it matters most for the case that has nothing to do with flakes: a genuine single-cell incompatibility, such as a dependency that breaks only under `prefer-lowest`. That is exactly when knowing the other 23 results is the difference between a diagnosis and a guess.

## Verification

CI on this PR is itself the check — all 24 cells should report, and a green run looks the same either way. The behaviour under failure is what changed, and it will show the next time a cell genuinely breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
