### PR TITLE
feat: a render-time approval item over the live challenge

### DIFF
--- a/src/Approvals/ApprovalChallengeReader.php
+++ b/src/Approvals/ApprovalChallengeReader.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+use Fissible\Verdict\Approvals\ApprovalChallenge;
+
+/** The live, pending-only Verdict challenge lookup used while rendering an approval item. */
+interface ApprovalChallengeReader
+{
+    public function challengeForToolCall(string $toolCallId): ?ApprovalChallenge;
+}

--- a/src/Approvals/ApprovalItem.php
+++ b/src/Approvals/ApprovalItem.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+use DateTimeImmutable;
+use Fissible\Verdict\Approvals\ApprovalChallenge;
+use Fissible\Verdict\Approvals\ProposalProvenance;
+use Fissible\Verdict\Approvals\ProvenanceDisclosure;
+use Fissible\Verdict\Approvals\UpstreamSource;
+use Fissible\Verdict\Context\Trust;
+
+/**
+ * A render-time projection of one console row and its live Verdict challenge.
+ *
+ * Expiry and provenance intentionally live only in this DTO. They are copied from the challenge
+ * for this render and are never written to the console's workflow index.
+ *
+ * An inbox makes one `challengeForToolCall()` lookup per row. Verdict has no enumerable approval
+ * read contract yet; verdict#298 is the planned batched/read-model replacement.
+ */
+final readonly class ApprovalItem
+{
+    /**
+     * @param  array<string, mixed>|null  $presentation
+     * @param  list<ApprovalVerb>  $verbs
+     * @param  array<string, mixed>  $provenance
+     */
+    private function __construct(
+        public string $id,
+        public string $toolCallId,
+        public ?string $receiptId,
+        public ?array $presentation,
+        public ?string $capability,
+        public ?string $reason,
+        public string $reasonLabel,
+        public ?DateTimeImmutable $expiresAt,
+        public ?DateTimeImmutable $waitingSince,
+        public string $state,
+        public array $verbs,
+        public array $provenance,
+    ) {}
+
+    /** @param list<ApprovalVerb> $verbs */
+    public static function from(PendingApproval $approval, ?ApprovalChallenge $challenge, array $verbs): self
+    {
+        return new self(
+            id: (string) $approval->getKey(),
+            toolCallId: $approval->tool_call_id,
+            receiptId: $challenge === null ? $approval->receipt_id : $challenge->receiptId,
+            presentation: $approval->presentation,
+            capability: $challenge?->capability,
+            reason: $challenge?->reason,
+            reasonLabel: 'Why this capability is gated',
+            expiresAt: $challenge?->expiresAt,
+            // Verdict #300 adds issuedAt. The console row's created_at is ingestion time, not it.
+            waitingSince: null,
+            state: $challenge === null ? 'expired_or_already_decided' : 'pending',
+            verbs: $verbs,
+            provenance: self::provenance($challenge?->provenance),
+        );
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'tool_call_id' => $this->toolCallId,
+            'receipt_id' => $this->receiptId,
+            'presentation' => $this->presentation,
+            'capability' => $this->capability,
+            'reason' => $this->reason,
+            'reason_label' => $this->reasonLabel,
+            'expires_at' => $this->expiresAt?->format(DATE_ATOM),
+            'waiting_since' => $this->waitingSince?->format(DATE_ATOM),
+            'state' => $this->state,
+            'verbs' => array_map(static fn (ApprovalVerb $verb): string => $verb->value, $this->verbs),
+            'provenance' => $this->provenance,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private static function provenance(?ProposalProvenance $provenance): array
+    {
+        if ($provenance === null) {
+            return ['state' => 'issued_before_provenance_capture', 'message' => 'issued before provenance capture'];
+        }
+
+        return match ($provenance->disclosure) {
+            ProvenanceDisclosure::Unknown => [
+                'state' => 'unknown',
+                'message' => 'provenance unknown — no derivation was declared',
+            ],
+            ProvenanceDisclosure::Unreleased => [
+                'state' => 'unreleased',
+                'message' => 'the application has not configured provenance release to approvers',
+            ],
+            ProvenanceDisclosure::Declared => [
+                'state' => 'declared',
+                'sources' => array_map(self::source(...), $provenance->sources),
+                'undescribed_source_count' => $provenance->undescribedSourceCount,
+                'withheld_source_count' => $provenance->withheldSourceCount,
+            ],
+        };
+    }
+
+    /** @return array{kind: string, name: string, trust: string, data_class: string, channel: string, warning: bool} */
+    private static function source(UpstreamSource $source): array
+    {
+        return [
+            'kind' => $source->source->kind,
+            'name' => $source->source->name,
+            'trust' => $source->trust->value,
+            'data_class' => $source->dataClass->value,
+            'channel' => $source->channel->value,
+            // Source::user(), Source::application(), and Source::external() define this vocabulary.
+            // An untrusted user source is intentionally not a warning: the ADR signal is non-user
+            // untrusted upstream content that can be mistaken for the requester's own instruction.
+            'warning' => $source->source->kind !== 'user' && $source->trust === Trust::Untrusted,
+        ];
+    }
+}

--- a/src/Approvals/ApprovalItemFactory.php
+++ b/src/Approvals/ApprovalItemFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+/** Assembles an item at render time from the console index and the supported live Verdict read. */
+final readonly class ApprovalItemFactory
+{
+    public function __construct(
+        private ApprovalChallengeReader $challenges,
+        private ApprovalVerbs $verbs,
+    ) {}
+
+    public function make(PendingApproval $approval): ApprovalItem
+    {
+        $challenge = $this->challenges->challengeForToolCall($approval->tool_call_id);
+
+        return ApprovalItem::from($approval, $challenge, $this->verbs->resolve($approval, $challenge));
+    }
+}

--- a/src/Approvals/VerdictApprovalChallengeReader.php
+++ b/src/Approvals/VerdictApprovalChallengeReader.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+use Fissible\Verdict\Approvals\ApprovalChallenge;
+use Fissible\Verdict\Approvals\ApprovalManager;
+
+/**
+ * Keeps Verdict receipt storage behind its supported live-challenge API.
+ *
+ * The console must not query a Verdict table: a null challenge deliberately collapses absent,
+ * expired, and already-decided receipts until Verdict publishes its status read contract.
+ */
+final readonly class VerdictApprovalChallengeReader implements ApprovalChallengeReader
+{
+    public function __construct(private ApprovalManager $approvals) {}
+
+    public function challengeForToolCall(string $toolCallId): ?ApprovalChallenge
+    {
+        return $this->approvals->challengeForToolCall($toolCallId);
+    }
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Fissible\VerdictConsole;
 
 use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
+use Fissible\VerdictConsole\Approvals\ApprovalChallengeReader;
 use Fissible\VerdictConsole\Approvals\GateApproverAuthority;
 use Fissible\VerdictConsole\Approvals\UnscopedApprovalScope;
+use Fissible\VerdictConsole\Approvals\VerdictApprovalChallengeReader;
 use Fissible\VerdictConsole\Console\Commands\DoctorCommand;
 use Fissible\VerdictConsole\Contracts\ApprovalNotificationRecipients;
 use Fissible\VerdictConsole\Contracts\ApprovalPresenter;
@@ -44,6 +46,8 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         $this->app->singleton(ApprovalPresenter::class, DefaultApprovalPresenter::class);
 
         $this->app->singleton(ApprovalScope::class, UnscopedApprovalScope::class);
+
+        $this->app->singleton(ApprovalChallengeReader::class, VerdictApprovalChallengeReader::class);
 
         // Bound to the Gate-backed authority, which denies until the host defines the ability. A
         // host whose authority model is not a Gate rebinds this contract.

--- a/tests/Feature/ApprovalItemTest.php
+++ b/tests/Feature/ApprovalItemTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Approvals\ApprovalChallenge;
+use Fissible\Verdict\Approvals\ProposalProvenance;
+use Fissible\Verdict\Approvals\UpstreamSource;
+use Fissible\Verdict\Context\ContextChannel;
+use Fissible\Verdict\Context\DataClass;
+use Fissible\Verdict\Context\Source;
+use Fissible\Verdict\Context\Trust;
+use Fissible\VerdictConsole\Approvals\ApprovalChallengeReader;
+use Fissible\VerdictConsole\Approvals\ApprovalItem;
+use Fissible\VerdictConsole\Approvals\ApprovalItemFactory;
+use Fissible\VerdictConsole\Approvals\ApprovalVerbs;
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
+use Fissible\VerdictConsole\Approvals\Resumability;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function (): void {
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+
+    $this->store = new PendingApprovalStore;
+    $this->approval = $this->store->ingest(
+        toolCallId: 'call_1',
+        conversationId: 'conversation_1',
+        receiptId: 'persisted-receipt-id',
+        presentation: ['tool' => 'orders.cancel', 'arguments_fingerprint' => 'sha256:stored'],
+        resumability: Resumability::Drivable,
+    );
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists('verdict_console_pending_approvals');
+});
+
+it('renders every provenance disclosure distinctly from the live challenge', function (?ProposalProvenance $provenance, array $expected): void {
+    $item = approvalItem($this->store, $this->approval, challenge(provenance: $provenance));
+
+    expect($item->toArray())->toMatchArray([
+        'receipt_id' => 'live-receipt-id',
+        'capability' => 'orders.cancel',
+        'reason' => 'Cancelling an order needs confirmation.',
+        'reason_label' => 'Why this capability is gated',
+        'expires_at' => '2030-01-02T03:04:05+00:00',
+        'waiting_since' => null,
+        'state' => 'pending',
+        'verbs' => ['approve', 'reject'],
+        'provenance' => $expected,
+    ]);
+})->with([
+    'declared sources' => [ProposalProvenance::declared([
+        new UpstreamSource(Source::user('customer'), Trust::Trusted, DataClass::PII, ContextChannel::UserInput),
+    ]), [
+        'state' => 'declared',
+        'sources' => [[
+            'kind' => 'user', 'name' => 'customer', 'trust' => 'trusted', 'data_class' => 'pii',
+            'channel' => 'user_input', 'warning' => false,
+        ]],
+        'undescribed_source_count' => 0,
+        'withheld_source_count' => 0,
+    ]],
+    'declared partial release' => [ProposalProvenance::declared([
+        new UpstreamSource(Source::external('search'), Trust::Untrusted, DataClass::Public, ContextChannel::RetrievedDocument),
+    ], undescribedSourceCount: 2, withheldSourceCount: 1), [
+        'state' => 'declared',
+        'sources' => [[
+            'kind' => 'external', 'name' => 'search', 'trust' => 'untrusted', 'data_class' => 'public',
+            'channel' => 'retrieved_document', 'warning' => true,
+        ]],
+        'undescribed_source_count' => 2,
+        'withheld_source_count' => 1,
+    ]],
+    'unknown' => [ProposalProvenance::unknown(), ['state' => 'unknown', 'message' => 'provenance unknown — no derivation was declared']],
+    'unreleased' => [ProposalProvenance::unreleased(), ['state' => 'unreleased', 'message' => 'the application has not configured provenance release to approvers']],
+    'before capture' => [null, ['state' => 'issued_before_provenance_capture', 'message' => 'issued before provenance capture']],
+]);
+
+it('takes expiry from the live challenge, never the persisted presentation', function (): void {
+    $this->approval->forceFill(['presentation' => ['expires_at' => '1999-01-01T00:00:00+00:00']]);
+
+    expect(approvalItem($this->store, $this->approval, challenge())->toArray()['expires_at'])
+        ->toBe('2030-01-02T03:04:05+00:00');
+});
+
+it('does not warn for an untrusted user source', function (): void {
+    $item = approvalItem($this->store, $this->approval, challenge(provenance: ProposalProvenance::declared([
+        new UpstreamSource(Source::user('customer'), Trust::Untrusted, DataClass::PII, ContextChannel::UserInput),
+    ])));
+
+    expect($item->toArray()['provenance']['sources'][0]['warning'])->toBeFalse();
+});
+
+it('calls only the live challenge contract and makes a missing challenge non-actionable', function (): void {
+    $reader = new class implements ApprovalChallengeReader
+    {
+        public array $toolCallIds = [];
+
+        public function challengeForToolCall(string $toolCallId): ?ApprovalChallenge
+        {
+            $this->toolCallIds[] = $toolCallId;
+
+            return null;
+        }
+    };
+    $item = (new ApprovalItemFactory($reader, new ApprovalVerbs($this->store)))->make($this->approval);
+
+    expect($reader->toolCallIds)->toBe(['call_1'])
+        ->and($item->toArray())->toMatchArray([
+            'state' => 'expired_or_already_decided', 'expires_at' => null, 'verbs' => ['close'],
+        ]);
+});
+
+function approvalItem(PendingApprovalStore $store, PendingApproval $approval, ApprovalChallenge $challenge): ApprovalItem
+{
+    return (new ApprovalItemFactory(new class($challenge) implements ApprovalChallengeReader
+    {
+        public function __construct(private ApprovalChallenge $challenge) {}
+
+        public function challengeForToolCall(string $toolCallId): ?ApprovalChallenge
+        {
+            return $this->challenge;
+        }
+    }, new ApprovalVerbs($store)))->make($approval);
+}
+
+function challenge(?ProposalProvenance $provenance = null): ApprovalChallenge
+{
+    return new ApprovalChallenge(
+        receiptId: 'live-receipt-id',
+        toolCallId: 'call_1',
+        capability: 'orders.cancel',
+        reason: 'Cancelling an order needs confirmation.',
+        expiresAt: new DateTimeImmutable('2030-01-02T03:04:05+00:00'),
+        provenance: $provenance,
+    );
+}


### PR DESCRIPTION
Closes #42. First issue of **v0.3.0**.

One DTO assembled per row at render time from three sources: the console's workflow index, the live `ApprovalChallenge`, and VC-41's verb set. Expiry and provenance exist **only** in the DTO — copied from the challenge for this render, never written to the index. That is why the row has no expiry column and never will.

## Five provenance states, never collapsed

| Challenge payload | Rendered as |
|---|---|
| `Declared` | each source by kind / trust / data class / channel |
| `Declared` with counts | undescribed and withheld counts, shown as counts |
| `Unknown` | "provenance unknown — no derivation was declared" |
| `Unreleased` | "the application has not configured provenance release to approvers" |
| `null` | "issued before provenance capture" |

`Unknown` emits **no `sources` key at all**. An empty list reads as *"no untrusted sources"*, and that inference is precisely what ADR 0026 §4 exists to prevent — the ADR's own words are that silence reads as an absence of untrusted sources.

## The warning flag is the point of the feature

```php
'warning' => $source->source->kind !== 'user' && $source->trust === Trust::Untrusted,
```

Compared by **enum identity**, not by string value. This is the signal ADR 0026 exists to produce: an approver clicking through the tenth identical refund challenge has no other way to tell the one that came from an injected document. A rename upstream should break the build, not silently invert what an approver is shown.

`Source::kind` is a plain string upstream, set by `application()`/`user()`/`external()` — the comment names those as its vocabulary, since no enum exists to bind to.

**An untrusted *user* source deliberately does not warn**, and now has its own test saying so. The ADR's signal is non-user untrusted content that can be mistaken for the requester's own instruction; the requester's own input is not that. Written down because `UpstreamSource(Source::user(…), Trust::Untrusted, …)` is representable, and without a test its silence is indistinguishable from an oversight.

## `waiting_since` is null, and stays null

The challenge has no `issuedAt` until [verdict#300](https://github.com/fissible/verdict/issues/300) (adopted by VC-47). The row's `created_at` is **ingestion** time, and relabelling it as issuance time would show an approver a number that means something else.

Mutation-checked: doing exactly that fails five tests.

## Mutation checks

| Mutation | Fails |
|---|---|
| `warning` always false | the disclosure dataset |
| Invert the trust comparison | the disclosure dataset |
| Drop the user exemption | `does not warn for an untrusted user source` |
| `Unknown` serialises an empty `sources` list | the disclosure dataset |
| Expiry from the row instead of the challenge | six tests |
| `waiting_since` relabelled from `created_at` | five tests |

## Boundary

Reads go through `ApprovalChallengeReader`, so the supported live-challenge API is the only Verdict surface touched — no table is queried. The per-row lookup is documented as the known cost of having no enumeration until [verdict#298](https://github.com/fissible/verdict/issues/298); an inbox of N rows makes N calls, by design rather than by accident.

## Verification

Pint clean, PHPStan clean, 100% type coverage, **178 passed / 691 assertions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
