### PR TITLE
VC-15: Persist approval anomaly incidents

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "illuminate/contracts": "^12.0||^13.0",
     "illuminate/database": "^12.0||^13.0",
     "illuminate/support": "^12.0||^13.0",
-    "fissible/verdict": "^0.9",
+    "fissible/verdict": "^0.9.2",
     "laravel/ai": "^0.11.0"
   },
   "require-dev": {

--- a/database/migrations/create_verdict_console_incidents_table.php.stub
+++ b/database/migrations/create_verdict_console_incidents_table.php.stub
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/** Durable, console-owned projections of Verdict and approval-ingestion anomalies (VC-15). */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('verdict_console_incidents', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('source', 64);
+            $table->string('cause');
+            $table->json('context')->nullable();
+            $table->uuid('pending_approval_id')->nullable();
+            $table->foreign('pending_approval_id')
+                ->references('id')
+                ->on('verdict_console_pending_approvals')
+                ->nullOnDelete();
+            $table->timestamp('observed_at');
+            $table->timestamps();
+
+            // SQL UNIQUE permits multiple NULLs, so Verdict anomalies (which have no approval row)
+            // coexist here. The non-null ingestion reference is idempotent only within its source:
+            // a future anomaly source may legitimately point at the same approval without being
+            // collapsed into its ingestion incident. Do not use NULLS NOT DISTINCT here.
+            $table->unique(['source', 'pending_approval_id']);
+            $table->index(['source', 'observed_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('verdict_console_incidents');
+    }
+};

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,5 +4,9 @@ parameters:
         - src
         - config
     tmpDir: build/phpstan
+    # Larastan boots Testbench, whose provider manifest is a shared file. Parallel workers can
+    # race while replacing it on Windows, producing spurious access-denied failures.
+    parallel:
+        maximumNumberOfProcesses: 1
     configDirectories:
         - %currentWorkingDirectory%/config

--- a/src/Incidents/Incident.php
+++ b/src/Incidents/Incident.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Incidents;
+
+use Illuminate\Database\Eloquent\Model;
+
+/** A durable observation of an anomaly; it is never a copy of Verdict decision state. */
+final class Incident extends Model
+{
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $table = 'verdict_console_incidents';
+
+    protected $guarded = [];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'context' => 'array',
+            'observed_at' => 'datetime',
+        ];
+    }
+}

--- a/src/Incidents/IncidentStore.php
+++ b/src/Incidents/IncidentStore.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Incidents;
+
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Fissible\VerdictConsole\Approvals\UnresumableReason;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Str;
+
+/** Records anomaly observations without treating them as Verdict authority or workflow state. */
+final class IncidentStore
+{
+    /** @param array<string, scalar|null> $context */
+    public function record(string $source, string $cause, array $context = []): Incident
+    {
+        return Incident::query()->create([
+            'id' => Str::uuid()->toString(),
+            'source' => $source,
+            'cause' => $cause,
+            'context' => $context,
+            'observed_at' => now(),
+        ]);
+    }
+
+    public function recordIngestion(PendingApproval $approval, UnresumableReason $reason): Incident
+    {
+        if ($approval->unresumable_reason !== $reason) {
+            throw new \LogicException('An approval-ingestion incident must carry the row\'s typed unresumable reason.');
+        }
+
+        try {
+            return Incident::query()->create([
+                'id' => Str::uuid()->toString(),
+                'source' => 'approval_ingestion',
+                'cause' => $reason->value,
+                'context' => ['tool_call_id' => $approval->tool_call_id],
+                'pending_approval_id' => $approval->id,
+                'observed_at' => now(),
+            ]);
+        } catch (UniqueConstraintViolationException) {
+            return Incident::query()
+                ->where('source', 'approval_ingestion')
+                ->where('pending_approval_id', $approval->id)
+                ->sole();
+        }
+    }
+}

--- a/src/Listeners/RecordAnomalyIncident.php
+++ b/src/Listeners/RecordAnomalyIncident.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Listeners;
+
+use Fissible\Verdict\Capabilities\Events\CapabilityConfigurationUnrecorded;
+use Fissible\Verdict\Evidence\Events\ChainWriteFailed;
+use Fissible\Verdict\Evidence\Events\ConsequentialActionUnrecorded;
+use Fissible\Verdict\Evidence\Events\EvidenceWriteFailed;
+use Fissible\VerdictConsole\Events\ApprovalIngestionIncident;
+use Fissible\VerdictConsole\Incidents\IncidentStore;
+
+/** Projects the five ephemeral anomaly events into the console's durable incident ledger. */
+final readonly class RecordAnomalyIncident
+{
+    public function __construct(private IncidentStore $incidents) {}
+
+    public function handle(object $event): void
+    {
+        match (true) {
+            $event instanceof ConsequentialActionUnrecorded => $this->incidents->record(
+                'consequential_action_unrecorded', $event->message,
+            ),
+            $event instanceof EvidenceWriteFailed => $this->incidents->record('evidence_write_failed', $event->message, [
+                'capability' => $event->capability,
+                'stage' => $event->stage,
+                'invocation_id' => $event->invocationId,
+            ]),
+            $event instanceof ChainWriteFailed => $this->incidents->record('chain_write_failed', $event->message, [
+                'chain_id' => $event->chainId,
+                'correlation_id' => $event->correlationId,
+                'record_type' => $event->recordType,
+                'phase' => $event->phase,
+                'attempts' => $event->attempts,
+            ]),
+            $event instanceof CapabilityConfigurationUnrecorded => $this->incidents->record(
+                'capability_configuration_unrecorded', $event->reason, [
+                    'capability' => $event->capability,
+                    'configuration_fingerprint' => $event->configurationFingerprint,
+                ],
+            ),
+            $event instanceof ApprovalIngestionIncident => $this->incidents->recordIngestion($event->pendingApproval, $event->reason),
+            default => null,
+        };
+    }
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Fissible\VerdictConsole;
 
+use Fissible\Verdict\Capabilities\Events\CapabilityConfigurationUnrecorded;
+use Fissible\Verdict\Evidence\Events\ChainWriteFailed;
+use Fissible\Verdict\Evidence\Events\ConsequentialActionUnrecorded;
+use Fissible\Verdict\Evidence\Events\EvidenceWriteFailed;
 use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
 use Fissible\VerdictConsole\Approvals\ApprovalChallengeReader;
 use Fissible\VerdictConsole\Approvals\GateApproverAuthority;
@@ -17,9 +21,11 @@ use Fissible\VerdictConsole\Contracts\ApproverAuthority;
 use Fissible\VerdictConsole\Contracts\ConversationParticipants;
 use Fissible\VerdictConsole\Contracts\ResumableAgents;
 use Fissible\VerdictConsole\Events\ApprovalIngestionIncident;
+use Fissible\VerdictConsole\Incidents\IncidentStore;
 use Fissible\VerdictConsole\Listeners\IngestToolApprovalRequests;
 use Fissible\VerdictConsole\Listeners\LogApprovalIngestionIncident;
 use Fissible\VerdictConsole\Listeners\NotifyApprovalResumeOutcome;
+use Fissible\VerdictConsole\Listeners\RecordAnomalyIncident;
 use Fissible\VerdictConsole\Notifications\UnconfiguredApprovalNotificationRecipients;
 use Fissible\VerdictConsole\Participants\UnconfiguredConversationParticipants;
 use Fissible\VerdictConsole\Presentation\DefaultApprovalPresenter;
@@ -61,6 +67,8 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         $this->app->singleton(ConversationParticipants::class, UnconfiguredConversationParticipants::class);
 
         $this->app->singleton(ApprovalNotificationRecipients::class, UnconfiguredApprovalNotificationRecipients::class);
+
+        $this->app->singleton(IncidentStore::class);
     }
 
     public function boot(Dispatcher $events): void
@@ -70,6 +78,14 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         $events->listen(ToolApprovalRequested::class, IngestToolApprovalRequests::class);
         $events->listen(ToolApprovalResolved::class, NotifyApprovalResumeOutcome::class);
 
+        $events->listen(ConsequentialActionUnrecorded::class, RecordAnomalyIncident::class);
+        $events->listen(EvidenceWriteFailed::class, RecordAnomalyIncident::class);
+        $events->listen(ChainWriteFailed::class, RecordAnomalyIncident::class);
+        $events->listen(CapabilityConfigurationUnrecorded::class, RecordAnomalyIncident::class);
+        $events->listen(ApprovalIngestionIncident::class, RecordAnomalyIncident::class);
+
+        // The ledger is the durable projection; the released opt-out log sink remains a separate
+        // operational alerting surface for hosts that already route it.
         if (config('verdict-console.ingestion_incidents.log', true)) {
             $events->listen(ApprovalIngestionIncident::class, LogApprovalIngestionIncident::class);
         }
@@ -105,6 +121,9 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
             ),
             __DIR__.'/../database/migrations/create_verdict_console_approval_reconciliations_table.php.stub' => database_path(
                 'migrations/2026_08_25_000003_create_verdict_console_approval_reconciliations_table.php',
+            ),
+            __DIR__.'/../database/migrations/create_verdict_console_incidents_table.php.stub' => database_path(
+                'migrations/2026_08_25_000004_create_verdict_console_incidents_table.php',
             ),
         ], ['verdict-console', 'verdict-console-migrations']);
     }

--- a/tests/Configuration/IncidentLoggingConfigurationTest.php
+++ b/tests/Configuration/IncidentLoggingConfigurationTest.php
@@ -2,18 +2,36 @@
 
 declare(strict_types=1);
 
-use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
+use Fissible\VerdictConsole\Approvals\Resumability;
 use Fissible\VerdictConsole\Approvals\UnresumableReason;
 use Fissible\VerdictConsole\Events\ApprovalIngestionIncident;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function (): void {
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_incidents_table.php.stub')->up();
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists('verdict_console_incidents');
+    Schema::dropIfExists('verdict_console_pending_approvals');
+});
 
 it('does not register the default warning logger when disabled in configuration', function (): void {
     Log::spy();
-    $row = new PendingApproval;
-    $row->id = 'pending-approval-1';
-    $row->tool_call_id = 'tool-call-1';
+    $row = (new PendingApprovalStore)->ingest(
+        toolCallId: 'tool-call-1',
+        resumability: Resumability::Unresumable,
+        unresumableReason: UnresumableReason::ChallengeUnavailable,
+    );
 
     event(new ApprovalIngestionIncident($row, UnresumableReason::ChallengeUnavailable));
 
     Log::shouldNotHaveReceived('warning');
+
+    expect(DB::table('verdict_console_incidents')->count())->toBe(1);
 });

--- a/tests/EndToEnd/ApprovalRoundTripTest.php
+++ b/tests/EndToEnd/ApprovalRoundTripTest.php
@@ -796,9 +796,7 @@ it('logs a receipt collision as a critical anomaly rather than malformed input',
         );
 });
 
-it('logs the default warning for an ingestion incident until the ledger exists', function (): void {
-    Log::spy();
-
+it('persists an ingestion incident when the paused approval cannot be resumed', function (): void {
     event(new ToolApprovalRequested(
         invocationId: 'warning-log-invocation',
         agent: new RoundTripAgent,
@@ -806,12 +804,10 @@ it('logs the default warning for an ingestion incident until the ledger exists',
         conversationId: 'warning-log-conversation',
     ));
 
-    Log::shouldHaveReceived('warning')
-        ->once()
-        ->withArgs(fn (string $message, array $context): bool => $message === 'Verdict Console recorded a paused approval it cannot resume.'
-            && $context['tool_call_id'] === 'warning-log-call'
-            && $context['unresumable_reason'] === UnresumableReason::ChallengeUnavailable->value,
-        );
+    expect(DB::table('verdict_console_incidents')->sole())
+        ->source->toBe('approval_ingestion')
+        ->cause->toBe(UnresumableReason::ChallengeUnavailable->value)
+        ->context->toBe(json_encode(['tool_call_id' => 'warning-log-call']));
 });
 
 /** The manager intentionally collapses an expired receipt and an absent one into the same null. */

--- a/tests/EndToEndTestCase.php
+++ b/tests/EndToEndTestCase.php
@@ -71,6 +71,7 @@ abstract class EndToEndTestCase extends IntegrationTestCase
         (require $verdict.'/create_verdict_approval_receipts_table.php.stub')->up();
         (require $verdict.'/add_proposal_provenance_to_verdict_approval_receipts_table.php.stub')->up();
         (require $ai.'/2026_01_11_000001_create_agent_conversations_table.php')->up();
+        (require dirname(__DIR__).'/database/migrations/create_verdict_console_incidents_table.php.stub')->up();
     }
 
     /**

--- a/tests/Feature/IncidentLedgerTest.php
+++ b/tests/Feature/IncidentLedgerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Capabilities\Events\CapabilityConfigurationUnrecorded;
+use Fissible\Verdict\Evidence\Events\ChainWriteFailed;
+use Fissible\Verdict\Evidence\Events\ConsequentialActionUnrecorded;
+use Fissible\Verdict\Evidence\Events\EvidenceWriteFailed;
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
+use Fissible\VerdictConsole\Approvals\Resumability;
+use Fissible\VerdictConsole\Approvals\UnresumableReason;
+use Fissible\VerdictConsole\Events\ApprovalIngestionIncident;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function (): void {
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_incidents_table.php.stub')->up();
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists('verdict_console_incidents');
+    Schema::dropIfExists('verdict_console_pending_approvals');
+});
+
+it('persists each Verdict anomaly as one incident', function (): void {
+    event(new ConsequentialActionUnrecorded('No durable recorder.'));
+    event(new EvidenceWriteFailed('orders.refund', 'after_execution', 'invocation-1', 'Write failed.'));
+    event(new ChainWriteFailed('chain-1', 'correlation-1', 'decision', 'append', 3, 'Append failed.'));
+    event(new CapabilityConfigurationUnrecorded('orders.refund', 'fingerprint-1', 'Database unavailable.'));
+
+    expect(DB::table('verdict_console_incidents')->orderBy('source')->get()->map(fn (object $incident): array => [
+        'source' => $incident->source,
+        'cause' => $incident->cause,
+        'pending_approval_id' => $incident->pending_approval_id,
+    ])->all())->toBe([
+        ['source' => 'capability_configuration_unrecorded', 'cause' => 'Database unavailable.', 'pending_approval_id' => null],
+        ['source' => 'chain_write_failed', 'cause' => 'Append failed.', 'pending_approval_id' => null],
+        ['source' => 'consequential_action_unrecorded', 'cause' => 'No durable recorder.', 'pending_approval_id' => null],
+        ['source' => 'evidence_write_failed', 'cause' => 'Write failed.', 'pending_approval_id' => null],
+    ]);
+});
+
+it('persists an ingestion incident once with the row\'s typed cause', function (): void {
+    $approval = (new PendingApprovalStore)->ingest(
+        toolCallId: 'call-1',
+        resumability: Resumability::Unresumable,
+        unresumableReason: UnresumableReason::ChallengeUnavailable,
+    );
+    $incident = new ApprovalIngestionIncident($approval, UnresumableReason::ChallengeUnavailable);
+
+    event($incident);
+    event($incident);
+
+    $stored = DB::table('verdict_console_incidents')->sole();
+
+    expect($stored->source)->toBe('approval_ingestion')
+        ->and($stored->cause)->toBe(UnresumableReason::ChallengeUnavailable->value)
+        ->and($stored->pending_approval_id)->toBe($approval->id)
+        ->and(PendingApproval::query()->sole()->unresumable_reason)->toBe(UnresumableReason::ChallengeUnavailable);
+});
+
+it('refuses an ingestion event whose cause disagrees with its persisted row', function (): void {
+    $approval = (new PendingApprovalStore)->ingest(
+        toolCallId: 'call-1',
+        resumability: Resumability::Unresumable,
+        unresumableReason: UnresumableReason::ChallengeUnavailable,
+    );
+
+    expect(fn (): mixed => event(new ApprovalIngestionIncident($approval, UnresumableReason::AgentUnresolvable)))
+        ->toThrow(LogicException::class, 'must carry the row\'s typed unresumable reason.')
+        ->and(DB::table('verdict_console_incidents')->count())->toBe(0);
+});

--- a/tests/Feature/MigrationPublishingTest.php
+++ b/tests/Feature/MigrationPublishingTest.php
@@ -49,7 +49,7 @@ it('publishes every migration, in an order that can actually run', function (): 
         ->sort()
         ->values();
 
-    expect($published)->toHaveCount(4);
+    expect($published)->toHaveCount(5);
 
     $position = fn (string $fragment): int => $published->search(fn (string $name): bool => str_contains($name, $fragment));
 
@@ -58,7 +58,9 @@ it('publishes every migration, in an order that can actually run', function (): 
         ->and($position('create_verdict_console_pending_approvals_table'))
         ->toBeLessThan($position('create_verdict_console_approval_notifications_table'), 'The notifications foreign key requires the pause table.')
         ->and($position('create_verdict_console_pending_approvals_table'))
-        ->toBeLessThan($position('create_verdict_console_approval_reconciliations_table'), 'The reconciliation foreign key requires the pause table.');
+        ->toBeLessThan($position('create_verdict_console_approval_reconciliations_table'), 'The reconciliation foreign key requires the pause table.')
+        ->and($position('create_verdict_console_pending_approvals_table'))
+        ->toBeLessThan($position('create_verdict_console_incidents_table'), 'The incident foreign key requires the pause table.');
 
     File::cleanDirectory($target);
 });


### PR DESCRIPTION
## Summary
- project the four Verdict anomaly events and `ApprovalIngestionIncident` into a console-owned ledger
- preserve the released `ingestion_incidents.log` warning sink and its boot-time configuration gate
- make ingestion incident persistence idempotent by `(source, pending_approval_id)` and reject event/row cause drift

## Verification
- `composer test` — 181 passed, 703 assertions; Pint and PHPStan clean; 100% type coverage
- rebased on `origin/main` at `51d5418` (merged VC-42) before validation

The nullable composite unique constraint is documented: Verdict anomalies intentionally coexist with `NULL` approval IDs; `NULLS NOT DISTINCT` would break that behavior.