### PR TITLE
feat: install against Verdict 0.12, and catch its new failure mode at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Requires Verdict `^0.12`, and the doctor now catches its new failure mode at startup (#63).**
+  The previous `^0.9.2` locked the console below `0.10.0` — caret pins the minor on a `0.x` — so an
+  adopter on current Verdict could not install this package at all. The bound is `^0.12` **alone**
+  rather than a disjunction: `prefer-lowest` tests only the bottom of a range, so `^0.9.2 || ^0.12`
+  would have made 0.9.2 the lowest-dependency cell and CI would have silently stopped testing the
+  version every adopter runs. Verdict 0.12 also makes `ApprovalDecisionAuthorizer` **required and
+  fail-closed**, so without a host authorizer every decision now throws at the moment a person
+  clicks approve. The console ships neither an authorizer nor a bridge (ADR 0001 §4); instead
+  `verdict-console:doctor` gains three findings — `approval_authorizer_missing`,
+  `approval_authorizer_invalid`, and `approval_authorizer_allows_all` — which resolve the configured
+  class through the container rather than checking that a config string is non-empty. That catches
+  **fail-open** as well: Verdict's test-only `AllowAllApprovalAuthorizer` configured outside
+  `local`/`testing` authorizes every decision, which is the god-mode button §2 forbids reached from
+  the other direction. **Upgrading:** require `fissible/verdict:^0.12`, configure
+  `verdict.approvals.authorizer` (`php artisan verdict:make-approval-flow` publishes a working
+  example), then run `php artisan verdict-console:doctor`.
+
 - **ADR 0001 amended for Verdict 0.11–0.12 and ADR 0031** (console #63). Approval authority is now
   authorized **twice, by the host both times**: the console's `ApproverAuthority` is the actor
   binding (*may this person act on this row?*) and Verdict 0.12's required, fail-closed

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ the shipped authority **fails closed** until you do.
 - PHP 8.3+
 - Laravel 12 or 13
 - `laravel/ai` ^0.11
-- `fissible/verdict` ^0.9
+- `fissible/verdict` ^0.12
 
 ## Development
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "illuminate/contracts": "^12.0||^13.0",
     "illuminate/database": "^12.0||^13.0",
     "illuminate/support": "^12.0||^13.0",
-    "fissible/verdict": "^0.9.2",
+    "fissible/verdict": "^0.12",
     "laravel/ai": "^0.11.0"
   },
   "require-dev": {
@@ -81,6 +81,11 @@
     ]
   },
   "extra": {
+    "verdict-console": {
+      "dependency_constraints": {
+        "fissible/verdict": "^0.12 only: Verdict 0.12 requires a decision authorizer and ^0.x disjunctions make prefer-lowest skip the supported current minor."
+      }
+    },
     "laravel": {
       "providers": [
         "Fissible\\VerdictConsole\\VerdictConsoleServiceProvider"

--- a/src/Doctor/Doctor.php
+++ b/src/Doctor/Doctor.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Fissible\VerdictConsole\Doctor;
 
 use Fissible\Verdict\Capabilities\CapabilityRegistry;
+use Fissible\Verdict\Contracts\ApprovalDecisionAuthorizer;
 use Fissible\Verdict\LaravelAi\BoundTool;
 use Fissible\Verdict\LaravelAi\VerdictApprovalMiddleware;
+use Fissible\Verdict\Testing\AllowAllApprovalAuthorizer;
 use Fissible\VerdictConsole\Contracts\ResumableAgents;
 use Fissible\VerdictConsole\Exceptions\ResumableAgentFailure;
 use Illuminate\Contracts\Config\Repository as Config;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Schema\Builder as SchemaBuilder;
 use Laravel\Ai\Concerns\RemembersConversations as RemembersConversationsTrait;
 use Laravel\Ai\Contracts\Agent;
@@ -36,6 +39,7 @@ final readonly class Doctor
         private CapabilityRegistry $capabilities,
         private SchemaBuilder $schema,
         private Config $config,
+        private Application $app,
     ) {}
 
     /**
@@ -47,6 +51,7 @@ final readonly class Doctor
     {
         $findings = [
             ...$this->inspectPersistence(),
+            ...$this->inspectApprovalAuthorizer(),
             ...$this->inspectAgents(),
             ...$this->inspectCapabilities(),
         ];
@@ -55,6 +60,70 @@ final readonly class Doctor
             <=> [$b->severity === Severity::Warning, $b->subject]);
 
         return $findings;
+    }
+
+    /** @return list<Finding> */
+    private function inspectApprovalAuthorizer(): array
+    {
+        $authorizer = $this->config->get('verdict.approvals.authorizer');
+
+        if (! is_string($authorizer) || $authorizer === '') {
+            return [new Finding(
+                code: FindingCode::ApprovalAuthorizerMissing,
+                severity: Severity::Error,
+                subject: 'verdict.approvals.authorizer',
+                summary: 'Verdict 0.12 refuses every approval and rejection decision when no approval decision '
+                    .'authorizer is configured (fail-closed), so a person reaches a broken action only after '
+                    .'the console has allowed them to click it.',
+                fix: 'Configure the application\'s ApprovalDecisionAuthorizer at verdict.approvals.authorizer. '
+                    .'Run verdict:make-approval-flow to publish Verdict\'s working example, then adapt it to '
+                    .'the application\'s receipt ownership rules.',
+            )];
+        }
+
+        if (! class_exists($authorizer)) {
+            return [$this->invalidApprovalAuthorizer("The configured approval decision authorizer [{$authorizer}] does not exist.")];
+        }
+
+        try {
+            $resolved = $this->app->make($authorizer);
+        } catch (\Throwable $error) {
+            return [$this->invalidApprovalAuthorizer(
+                "The configured approval decision authorizer [{$authorizer}] could not be resolved: {$error->getMessage()}",
+            )];
+        }
+
+        if (! $resolved instanceof ApprovalDecisionAuthorizer) {
+            return [$this->invalidApprovalAuthorizer(
+                "The configured approval decision authorizer [{$authorizer}] must implement ".ApprovalDecisionAuthorizer::class.'.',
+            )];
+        }
+
+        if ($resolved instanceof AllowAllApprovalAuthorizer && ! $this->app->environment(['local', 'testing'])) {
+            return [new Finding(
+                code: FindingCode::ApprovalAuthorizerAllowsAll,
+                severity: Severity::Warning,
+                subject: 'verdict.approvals.authorizer',
+                summary: 'Verdict\'s test-only AllowAllApprovalAuthorizer authorizes every decision. Outside '
+                    .'local and testing this removes the per-receipt authorization the host must provide.',
+                fix: 'Configure the application\'s own ApprovalDecisionAuthorizer that verifies the receipt '
+                    .'belongs to a conversation the decision maker may decide.',
+            )];
+        }
+
+        return [];
+    }
+
+    private function invalidApprovalAuthorizer(string $summary): Finding
+    {
+        return new Finding(
+            code: FindingCode::ApprovalAuthorizerInvalid,
+            severity: Severity::Error,
+            subject: 'verdict.approvals.authorizer',
+            summary: $summary,
+            fix: 'Configure verdict.approvals.authorizer as a container-resolvable class implementing '
+                .ApprovalDecisionAuthorizer::class.'.',
+        );
     }
 
     /**

--- a/src/Doctor/Doctor.php
+++ b/src/Doctor/Doctor.php
@@ -81,11 +81,15 @@ final readonly class Doctor
             )];
         }
 
-        if (! class_exists($authorizer)) {
-            return [$this->invalidApprovalAuthorizer("The configured approval decision authorizer [{$authorizer}] does not exist.")];
-        }
-
         try {
+            // Inside the try because class_exists() autoloads: a ParseError or a failing
+            // side-effectful include in the host's authorizer file would otherwise escape the
+            // doctor entirely, and a diagnostic that dies on the thing it is diagnosing is worse
+            // than no diagnostic.
+            if (! class_exists($authorizer)) {
+                return [$this->invalidApprovalAuthorizer("The configured approval decision authorizer [{$authorizer}] does not exist.")];
+            }
+
             $resolved = $this->app->make($authorizer);
         } catch (\Throwable $error) {
             return [$this->invalidApprovalAuthorizer(

--- a/src/Doctor/FindingCode.php
+++ b/src/Doctor/FindingCode.php
@@ -29,4 +29,13 @@ enum FindingCode: string
 
     /** The #230 dead gate: asks for confirmation, declares no execution target, never pauses. */
     case ConfirmationGateCannotPause = 'confirmation_gate_cannot_pause';
+
+    /** Verdict 0.12 refuses every approval decision until the host configures its own authorizer. */
+    case ApprovalAuthorizerMissing = 'approval_authorizer_missing';
+
+    /** The configured authorizer cannot become Verdict's required decision contract. */
+    case ApprovalAuthorizerInvalid = 'approval_authorizer_invalid';
+
+    /** Verdict's test-only allow-all authorizer removes per-receipt authorization outside tests. */
+    case ApprovalAuthorizerAllowsAll = 'approval_authorizer_allows_all';
 }

--- a/src/Doctor/FindingCode.php
+++ b/src/Doctor/FindingCode.php
@@ -30,7 +30,14 @@ enum FindingCode: string
     /** The #230 dead gate: asks for confirmation, declares no execution target, never pauses. */
     case ConfirmationGateCannotPause = 'confirmation_gate_cannot_pause';
 
-    /** Verdict 0.12 refuses every approval decision until the host configures its own authorizer. */
+    /**
+     * Verdict 0.12 refuses every approval decision until the host configures its own authorizer.
+     *
+     * Deliberately an **error** here where `verdict:validate` only warns, and that asymmetry is
+     * correct rather than an oversight: Verdict warns because it cannot know whether an install has
+     * confirmation-gated capabilities, and the console can — every console install has them by
+     * definition, or there would be nothing to approve. Do not "align" this severity downward.
+     */
     case ApprovalAuthorizerMissing = 'approval_authorizer_missing';
 
     /** The configured authorizer cannot become Verdict's required decision contract. */

--- a/src/Doctor/FindingCode.php
+++ b/src/Doctor/FindingCode.php
@@ -43,6 +43,13 @@ enum FindingCode: string
     /** The configured authorizer cannot become Verdict's required decision contract. */
     case ApprovalAuthorizerInvalid = 'approval_authorizer_invalid';
 
-    /** Verdict's test-only allow-all authorizer removes per-receipt authorization outside tests. */
+    /**
+     * Verdict's test-only allow-all authorizer removes per-receipt authorization outside tests.
+     *
+     * Detected by **identity, not behaviour**: this recognises `AllowAllApprovalAuthorizer` itself
+     * and cannot see a host's own authorizer that happens to `return true`. Nothing can inspect an
+     * arbitrary implementation for that. Read a clean result as "not the shipped test double",
+     * never as "this install authorizes selectively".
+     */
     case ApprovalAuthorizerAllowsAll = 'approval_authorizer_allows_all';
 }

--- a/tests/EndToEnd/ApprovalRoundTripTest.php
+++ b/tests/EndToEnd/ApprovalRoundTripTest.php
@@ -148,6 +148,11 @@ final readonly class ForcedApprovalOutcomeStore implements ApprovalReceiptStore
         return $this->delegate->findForToolCall($toolCallId);
     }
 
+    public function find(string $receiptId): ?ApprovalReceipt
+    {
+        return $this->delegate->find($receiptId);
+    }
+
     public function approve(string $receiptId, string $toolCallId, string $approvedBy, DateTimeImmutable $at): ApprovalTransition
     {
         return ApprovalTransition::to($this->outcome);
@@ -182,6 +187,11 @@ final readonly class CloseDecisionForbiddenStore implements ApprovalReceiptStore
     public function findForToolCall(string $toolCallId): ?ApprovalReceipt
     {
         return $this->delegate->findForToolCall($toolCallId);
+    }
+
+    public function find(string $receiptId): ?ApprovalReceipt
+    {
+        return $this->delegate->find($receiptId);
     }
 
     public function approve(string $receiptId, string $toolCallId, string $approvedBy, DateTimeImmutable $at): ApprovalTransition
@@ -426,6 +436,12 @@ beforeEach(function (): void {
         fn (Agent $agent): bool => $agent instanceof RoundTripAgent,
     );
 });
+
+/** The configured Verdict receipt table: test fixture reads must follow the store and its migrations. */
+function approvalReceiptTable(): string
+{
+    return (string) config('verdict.approvals.table', 'verdict_approval_receipts');
+}
 
 /** Pause the run and return the tool call id Verdict issued a receipt for. */
 function pauseForApproval(RoundTripAgent $agent): string
@@ -825,7 +841,7 @@ it('records an expired receipt exactly like a receiptless pause', function (): v
     // Set up the state Verdict must collapse. The bridge itself only observes the public manager's
     // null and never reads this table or infers that expiry was the reason.
     StoredPendingApproval::query()->delete();
-    DB::table('verdict_approval_receipts')->where('tool_call_id', $approval->id)->update([
+    DB::table(approvalReceiptTable())->where('tool_call_id', $approval->id)->update([
         'expires_at' => now()->subMinute(),
     ]);
 
@@ -1252,7 +1268,7 @@ it('refuses a foreign-scope close without sending a notification', function (): 
 
     pauseForApproval(new RoundTripAgent);
     $row = StoredPendingApproval::query()->sole();
-    DB::table('verdict_approval_receipts')->where('tool_call_id', $row->tool_call_id)->update([
+    DB::table(approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->update([
         'expires_at' => now()->subMinute(),
     ]);
     app()->instance(ApprovalNotificationRecipients::class, new class implements ApprovalNotificationRecipients
@@ -1341,7 +1357,7 @@ it('closes an expired receipt by resuming its exact conversation without decidin
 
     pauseForApproval((new RoundTripAgent)->forParticipant(new RoundTripCustomer(7)));
     $row = StoredPendingApproval::query()->sole();
-    DB::table('verdict_approval_receipts')->where('tool_call_id', $row->tool_call_id)->update([
+    DB::table(approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->update([
         'expires_at' => now()->subMinute(),
     ]);
     app()->instance(ApprovalReceiptStore::class, new CloseDecisionForbiddenStore(app(ApprovalReceiptStore::class)));
@@ -1351,7 +1367,7 @@ it('closes an expired receipt by resuming its exact conversation without decidin
 
     expect($outcome)->toBe(CloseOutcome::Closed)
         ->and(app(RoundTripLedger::class)->executions)->toBe(0, 'Close must only send Laravel AI a rejection.')
-        ->and(DB::table('verdict_approval_receipts')->where('tool_call_id', $row->tool_call_id)->value('status'))
+        ->and(DB::table(approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->value('status'))
         ->toBe('pending', 'Close does not mutate Verdict receipt state.')
         ->and($row->fresh()->resume_attempts)->toBe(1);
 });
@@ -1374,7 +1390,7 @@ it('measures Laravel AIs already-decided close path before any tool can execute'
     expect(app(ApprovalResolutionService::class)->close($row, new GenericUser(['id' => 'operator-1'])))
         ->toBe(CloseOutcome::AlreadyResolved);
     expect(app(RoundTripLedger::class)->executions)->toBe(0)
-        ->and(DB::table('verdict_approval_receipts')->where('tool_call_id', $toolCallId)->value('status'))
+        ->and(DB::table(approvalReceiptTable())->where('tool_call_id', $toolCallId)->value('status'))
         ->toBe('rejected')
         ->and(ApprovalReconciliation::query()->count())->toBe(0);
 });
@@ -1389,7 +1405,7 @@ it('does not report a drifted participant as an already-resolved close', functio
 
     pauseForApproval((new RoundTripAgent)->forParticipant(new RoundTripCustomer(7)));
     $row = StoredPendingApproval::query()->sole();
-    DB::table('verdict_approval_receipts')->where('tool_call_id', $row->tool_call_id)->update([
+    DB::table(approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->update([
         'expires_at' => now()->subMinute(),
     ]);
     app()->instance(ConversationParticipants::class, new class implements ConversationParticipants
@@ -1431,7 +1447,7 @@ it('records an indeterminate reconciliation when close reaches prompt and then f
 
     pauseForApproval((new RoundTripAgent)->forParticipant(new RoundTripCustomer(7)));
     $row = StoredPendingApproval::query()->sole();
-    DB::table('verdict_approval_receipts')->where('tool_call_id', $row->tool_call_id)->update([
+    DB::table(approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->update([
         'expires_at' => now()->subMinute(),
     ]);
     $recorder = new RecordingResumableAgent;
@@ -1449,7 +1465,7 @@ it('records a pre-execution reconciliation when close cannot rebuild the agent',
 
     pauseForApproval((new RoundTripAgent)->forParticipant(new RoundTripCustomer(7)));
     $row = StoredPendingApproval::query()->sole();
-    DB::table('verdict_approval_receipts')->where('tool_call_id', $row->tool_call_id)->update([
+    DB::table(approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->update([
         'expires_at' => now()->subMinute(),
     ]);
     app()->instance(ResumableAgents::class, (new AgentResolverRegistry)->register(
@@ -1469,7 +1485,7 @@ it('refuses an unauthorized approver before close can resume a lapsed row', func
 
     pauseForApproval((new RoundTripAgent)->forParticipant(new RoundTripCustomer(7)));
     $row = StoredPendingApproval::query()->sole();
-    DB::table('verdict_approval_receipts')->where('tool_call_id', $row->tool_call_id)->update([
+    DB::table(approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->update([
         'expires_at' => now()->subMinute(),
     ]);
 

--- a/tests/EndToEnd/ApprovalRoundTripTest.php
+++ b/tests/EndToEnd/ApprovalRoundTripTest.php
@@ -1532,6 +1532,10 @@ it('does not resume when Verdict returns a non-approval transition', function (A
     'expired' => [ApprovalOutcome::Expired],
     'not_found' => [ApprovalOutcome::NotFound],
     'invalid_state' => [ApprovalOutcome::InvalidState],
+    // Verdict 0.12's outcome when the host's required authorizer refuses. #6 adds the named
+    // refusal; the property the §2 invariant actually stands on -- that it never resumes -- is
+    // pinned in the PR that first makes the outcome reachable.
+    'unauthorized' => [ApprovalOutcome::Unauthorized],
 ]);
 
 it('refuses an unauthorized approver before it can record or resume a decision', function (): void {

--- a/tests/EndToEnd/ApprovalRoundTripTest.php
+++ b/tests/EndToEnd/ApprovalRoundTripTest.php
@@ -437,12 +437,6 @@ beforeEach(function (): void {
     );
 });
 
-/** The configured Verdict receipt table: test fixture reads must follow the store and its migrations. */
-function approvalReceiptTable(): string
-{
-    return (string) config('verdict.approvals.table', 'verdict_approval_receipts');
-}
-
 /** Pause the run and return the tool call id Verdict issued a receipt for. */
 function pauseForApproval(RoundTripAgent $agent): string
 {
@@ -841,7 +835,7 @@ it('records an expired receipt exactly like a receiptless pause', function (): v
     // Set up the state Verdict must collapse. The bridge itself only observes the public manager's
     // null and never reads this table or infers that expiry was the reason.
     StoredPendingApproval::query()->delete();
-    DB::table(approvalReceiptTable())->where('tool_call_id', $approval->id)->update([
+    DB::table($this->approvalReceiptTable())->where('tool_call_id', $approval->id)->update([
         'expires_at' => now()->subMinute(),
     ]);
 
@@ -1268,7 +1262,7 @@ it('refuses a foreign-scope close without sending a notification', function (): 
 
     pauseForApproval(new RoundTripAgent);
     $row = StoredPendingApproval::query()->sole();
-    DB::table(approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->update([
+    DB::table($this->approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->update([
         'expires_at' => now()->subMinute(),
     ]);
     app()->instance(ApprovalNotificationRecipients::class, new class implements ApprovalNotificationRecipients
@@ -1357,7 +1351,7 @@ it('closes an expired receipt by resuming its exact conversation without decidin
 
     pauseForApproval((new RoundTripAgent)->forParticipant(new RoundTripCustomer(7)));
     $row = StoredPendingApproval::query()->sole();
-    DB::table(approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->update([
+    DB::table($this->approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->update([
         'expires_at' => now()->subMinute(),
     ]);
     app()->instance(ApprovalReceiptStore::class, new CloseDecisionForbiddenStore(app(ApprovalReceiptStore::class)));
@@ -1367,7 +1361,7 @@ it('closes an expired receipt by resuming its exact conversation without decidin
 
     expect($outcome)->toBe(CloseOutcome::Closed)
         ->and(app(RoundTripLedger::class)->executions)->toBe(0, 'Close must only send Laravel AI a rejection.')
-        ->and(DB::table(approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->value('status'))
+        ->and(DB::table($this->approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->value('status'))
         ->toBe('pending', 'Close does not mutate Verdict receipt state.')
         ->and($row->fresh()->resume_attempts)->toBe(1);
 });
@@ -1390,7 +1384,7 @@ it('measures Laravel AIs already-decided close path before any tool can execute'
     expect(app(ApprovalResolutionService::class)->close($row, new GenericUser(['id' => 'operator-1'])))
         ->toBe(CloseOutcome::AlreadyResolved);
     expect(app(RoundTripLedger::class)->executions)->toBe(0)
-        ->and(DB::table(approvalReceiptTable())->where('tool_call_id', $toolCallId)->value('status'))
+        ->and(DB::table($this->approvalReceiptTable())->where('tool_call_id', $toolCallId)->value('status'))
         ->toBe('rejected')
         ->and(ApprovalReconciliation::query()->count())->toBe(0);
 });
@@ -1405,7 +1399,7 @@ it('does not report a drifted participant as an already-resolved close', functio
 
     pauseForApproval((new RoundTripAgent)->forParticipant(new RoundTripCustomer(7)));
     $row = StoredPendingApproval::query()->sole();
-    DB::table(approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->update([
+    DB::table($this->approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->update([
         'expires_at' => now()->subMinute(),
     ]);
     app()->instance(ConversationParticipants::class, new class implements ConversationParticipants
@@ -1447,7 +1441,7 @@ it('records an indeterminate reconciliation when close reaches prompt and then f
 
     pauseForApproval((new RoundTripAgent)->forParticipant(new RoundTripCustomer(7)));
     $row = StoredPendingApproval::query()->sole();
-    DB::table(approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->update([
+    DB::table($this->approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->update([
         'expires_at' => now()->subMinute(),
     ]);
     $recorder = new RecordingResumableAgent;
@@ -1465,7 +1459,7 @@ it('records a pre-execution reconciliation when close cannot rebuild the agent',
 
     pauseForApproval((new RoundTripAgent)->forParticipant(new RoundTripCustomer(7)));
     $row = StoredPendingApproval::query()->sole();
-    DB::table(approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->update([
+    DB::table($this->approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->update([
         'expires_at' => now()->subMinute(),
     ]);
     app()->instance(ResumableAgents::class, (new AgentResolverRegistry)->register(
@@ -1485,7 +1479,7 @@ it('refuses an unauthorized approver before close can resume a lapsed row', func
 
     pauseForApproval((new RoundTripAgent)->forParticipant(new RoundTripCustomer(7)));
     $row = StoredPendingApproval::query()->sole();
-    DB::table(approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->update([
+    DB::table($this->approvalReceiptTable())->where('tool_call_id', $row->tool_call_id)->update([
         'expires_at' => now()->subMinute(),
     ]);
 

--- a/tests/EndToEndTestCase.php
+++ b/tests/EndToEndTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Fissible\VerdictConsole\Tests;
 
+use Fissible\Verdict\Testing\AllowAllApprovalAuthorizer;
 use Illuminate\Foundation\Application;
 
 /**
@@ -54,6 +55,15 @@ abstract class EndToEndTestCase extends IntegrationTestCase
 
         // Titling a conversation would spend a second faked response on a turn nothing asserts on.
         $app['config']->set('ai.conversations.generate_title', false);
+
+        // Exercise Verdict #290's config-driven migration stubs. A production host may rename
+        // this table, and the round trip is meaningful only when the store and every migration
+        // agree on that configured name.
+        $app['config']->set('verdict.approvals.table', 'console_e2e_approval_receipts');
+
+        // Verdict 0.12 deliberately fails closed without a host authorizer. This is test-only
+        // wiring for the real round trip; the console provider must not supply an allow-all one.
+        $app['config']->set('verdict.approvals.authorizer', AllowAllApprovalAuthorizer::class);
     }
 
     /**
@@ -70,6 +80,7 @@ abstract class EndToEndTestCase extends IntegrationTestCase
 
         (require $verdict.'/create_verdict_approval_receipts_table.php.stub')->up();
         (require $verdict.'/add_proposal_provenance_to_verdict_approval_receipts_table.php.stub')->up();
+        (require $verdict.'/add_approval_context_to_verdict_approval_receipts_table.php.stub')->up();
         (require $ai.'/2026_01_11_000001_create_agent_conversations_table.php')->up();
         (require dirname(__DIR__).'/database/migrations/create_verdict_console_incidents_table.php.stub')->up();
     }

--- a/tests/EndToEndTestCase.php
+++ b/tests/EndToEndTestCase.php
@@ -126,4 +126,19 @@ abstract class EndToEndTestCase extends IntegrationTestCase
             'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
         ];
     }
+
+    /**
+     * The configured Verdict receipt table, resolved the way the store resolves it.
+     *
+     * It lives beside the config line that renames the table, not in one test file. Verdict 0.11
+     * (#290) made published stubs read table names from config, and this suite sets a non-default
+     * one so the round trip exercises that rather than tolerating it. A fixture reading
+     * `verdict_approval_receipts` directly would then fail with "no such table" and read as a
+     * migration fault -- so the helper belongs where anyone writing a second end-to-end file will
+     * find it.
+     */
+    protected function approvalReceiptTable(): string
+    {
+        return (string) config('verdict.approvals.table', 'verdict_approval_receipts');
+    }
 }

--- a/tests/Integration/DoctorTest.php
+++ b/tests/Integration/DoctorTest.php
@@ -5,13 +5,17 @@ declare(strict_types=1);
 use Fissible\Verdict\Actions\ActionContext;
 use Fissible\Verdict\Actions\ActionEnvelope;
 use Fissible\Verdict\Actions\AuthorizedAction;
+use Fissible\Verdict\Approvals\ApprovalDecisionKind;
 use Fissible\Verdict\Approvals\ApprovalExecutionContext;
+use Fissible\Verdict\Approvals\ApprovalReceipt;
 use Fissible\Verdict\Capabilities\Capability;
 use Fissible\Verdict\Capabilities\CapabilityRegistry;
+use Fissible\Verdict\Contracts\ApprovalDecisionAuthorizer;
 use Fissible\Verdict\Contracts\CapabilityAuthorizer;
 use Fissible\Verdict\Decisions\Decision;
 use Fissible\Verdict\LaravelAi\VerdictApprovalMiddleware;
 use Fissible\Verdict\Targets\ExecutionTargetPolicy;
+use Fissible\Verdict\Testing\AllowAllApprovalAuthorizer;
 use Fissible\Verdict\VerdictManager;
 use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
 use Fissible\VerdictConsole\Contracts\ResumableAgents;
@@ -46,6 +50,14 @@ final class DoctorSubjectTool implements Tool
     public function schema(JsonSchema $schema): array
     {
         return [];
+    }
+}
+
+final class DoctorApprovalAuthorizer implements ApprovalDecisionAuthorizer
+{
+    public function authorize(ApprovalReceipt $receipt, ApprovalDecisionKind $kind, string $decidedBy): bool
+    {
+        return true;
     }
 }
 
@@ -251,10 +263,82 @@ beforeEach(function (): void {
         }
     });
 
+    config()->set('verdict.approvals.authorizer', DoctorApprovalAuthorizer::class);
+
 });
 
 it('reports nothing when every precondition is satisfied', function (): void {
+    config()->set('verdict.approvals.authorizer', DoctorApprovalAuthorizer::class);
+
     expect(doctorFor(['healthy' => new HealthyAgent])->run())->toBe([]);
+});
+
+it('reports a missing approval decision authorizer before a person clicks approve', function (): void {
+    config()->set('verdict.approvals.authorizer', null);
+
+    $findings = doctorFor()->run();
+    $finding = current(array_filter($findings, fn ($f) => $f->code === FindingCode::ApprovalAuthorizerMissing));
+
+    expect($finding)->not->toBeFalse()
+        ->and($finding->severity)->toBe(Severity::Error)
+        ->and($finding->summary)->toContain('fail-closed')
+        ->and($finding->fix)->toContain('verdict:make-approval-flow');
+});
+
+it('does not report an approval decision authorizer the host configures', function (): void {
+    config()->set('verdict.approvals.authorizer', DoctorApprovalAuthorizer::class);
+
+    expect(array_map(fn ($finding) => $finding->code, doctorFor()->run()))
+        ->not->toContain(FindingCode::ApprovalAuthorizerMissing);
+});
+
+it('reports an approval decision authorizer class that cannot resolve', function (): void {
+    config()->set('verdict.approvals.authorizer', 'App\\Support\\MissingApprovalAuthorizer');
+
+    $finding = current(array_filter(
+        doctorFor()->run(),
+        fn ($finding) => $finding->code === FindingCode::ApprovalAuthorizerInvalid,
+    ));
+
+    expect($finding)->not->toBeFalse()
+        ->and($finding->severity)->toBe(Severity::Error)
+        ->and($finding->summary)->toBe(
+            'The configured approval decision authorizer [App\\Support\\MissingApprovalAuthorizer] does not exist.',
+        );
+});
+
+it('reports an approval decision authorizer that implements the wrong contract', function (): void {
+    config()->set('verdict.approvals.authorizer', DoctorSubjectTool::class);
+
+    $finding = current(array_filter(
+        doctorFor()->run(),
+        fn ($finding) => $finding->code === FindingCode::ApprovalAuthorizerInvalid,
+    ));
+
+    expect($finding)->not->toBeFalse()
+        ->and($finding->severity)->toBe(Severity::Error)
+        ->and($finding->summary)->toContain(ApprovalDecisionAuthorizer::class);
+});
+
+it('warns when production configures Verdict\'s test-only allow-all authorizer', function (): void {
+    app()->detectEnvironment(fn (): string => 'production');
+    config()->set('verdict.approvals.authorizer', AllowAllApprovalAuthorizer::class);
+
+    $finding = current(array_filter(
+        doctorFor()->run(),
+        fn ($finding) => $finding->code === FindingCode::ApprovalAuthorizerAllowsAll,
+    ));
+
+    expect($finding)->not->toBeFalse()
+        ->and($finding->severity)->toBe(Severity::Warning)
+        ->and($finding->summary)->toContain('authorizes every decision');
+});
+
+it('permits Verdict\'s test-only allow-all authorizer in the testing environment', function (): void {
+    config()->set('verdict.approvals.authorizer', AllowAllApprovalAuthorizer::class);
+
+    expect(array_map(fn ($finding) => $finding->code, doctorFor()->run()))
+        ->not->toContain(FindingCode::ApprovalAuthorizerAllowsAll);
 });
 
 it('reports a resolver key that does not rebuild an agent', function (): void {


### PR DESCRIPTION
Closes #63.

The console required `fissible/verdict: ^0.9.2`. Caret on a `0.x` locks the minor, so that is `<0.10.0` while Verdict is at **0.12** — an adopter on current Verdict could not install this package at all.

## The bound is `^0.12` alone, and the reason is the matrix

A `^0.9.2 || ^0.12` disjunction would mean two code paths for zero adopters: the decision authorizer is required on one side and absent on the other.

The stronger reason is that `prefer-lowest` tests only the **bottom** of the range. Under a disjunction the bottom would be 0.9.2, so **0.12 would never be the lowest-dependency cell** — CI would silently stop testing the version every adopter runs. `prefer-lowest` is exactly what caught the `^0.9` floor error in #62; a disjunction would have blinded that check.

## What 0.12 breaks, and why the fix is a doctor finding

verdict#305 makes `ApprovalDecisionAuthorizer` **required and fail-closed**: with none configured, `approve()` and `reject()` refuse every decision. `ApprovalResolutionService` calls both — so without a host authorizer the round trip throws at the moment a human clicks approve, *after* the console has shown them the button.

**The console ships no authorizer and no bridge.** An allow-all default would be the god-mode button ADR 0001 §2 forbids. A bridge to the console's Gate is mechanically impossible, not merely inelegant: Verdict's authorizer receives an opaque `string $decidedBy`, and VC-7 deliberately made the actor key an audit label rather than an identity to reconstruct. ADR 0001 §4 as amended (#64) states the two-layer model.

So what ships is the cheapest available conversion of a click-time failure into a startup one.

### It resolves rather than reads

The check resolves the configured authorizer **through the container** instead of asking whether a config string is non-empty — the house style `inspectAgents()` already uses, and the difference between checking configuration and checking what configuration produces.

That matters because it catches **fail-open** as well as fail-closed. Configuring Verdict's test-only `AllowAllApprovalAuthorizer` outside `local`/`testing` authorizes every decision, and a check that only asked "is something set" would pass it silently — the exact outcome §2 forbids, reached from the other direction.

The environment exemption is load-bearing rather than a convenience: warning in every environment breaks the test harness, and a mutation proves it.

## Mutation checks

Four branches, each failing only its own test:

| Mutation | Fails |
|---|---|
| Skip the contract check | `…implements the wrong contract` |
| Remove the allow-all warning | `warns when production configures Verdict's test-only allow-all authorizer` |
| Warn in every environment | `permits Verdict's test-only allow-all authorizer in the testing environment` |
| Remove `class_exists()` | `…class that cannot resolve` |

The last one **initially survived**. The test asserted a substring — `does not exist` — that the container's own reflection error also contains, so two different branches satisfied one assertion. It now requires the clean operator message, and the branch is held for the reason it exists: message quality, not detection.

## Also

Harness updated for 0.11's config-driven migration stubs (#290), the approval-context migration, and the expanded receipt store interface.

## Not in this PR

Behaviour changes arising from 0.12 are follow-ups on their original threads, so each is sized against the code it reopens:

- **#6** — the `unauthorized` decision path. Buildable after this lands; `ApprovalOutcome::Unauthorized` is in the `v0.12.0` tag.
- **#5** and **#12** — `approval_context` capture and the additive `ApprovalContextScope`. Both wait on Verdict's **next release**: `ApprovalStatusReader` is settled in ADR 0031 and implemented in verdict#327, but is in no tagged release, and at `v0.12.0` the field's only route is the `findForToolCall()` call design §5 forbids.

## Verification

Pint clean, PHPStan clean, 100% type coverage, `composer validate --strict` clean, **187 passed / 718 assertions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
