### PR TITLE
feat: a console-owned read boundary over Verdict decision evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Evidence query contract and the shipped table adapter (VC-13).** `EvidenceQuery` is a
+  console-owned, host-replaceable read boundary over Verdict's published decision-evidence table;
+  it projects fingerprints plus `claimType`/`recordDigest`, never raw arguments, identifiers, or
+  host-controlled reason text. Its result distinguishes recording **Off**, table-readable **On**,
+  and **Elsewhere** (with the configured writer class), so an audit surface never mistakes an
+  opt-out or a different sink for "nothing happened." The default adapter supports disposition,
+  capability, and time filters and honors Verdict's `writer ?? recorder` configuration precedence.
+
 - **Requires Verdict `^0.12`, and the doctor now catches its new failure mode at startup (#63).**
   The previous `^0.9.2` locked the console below `0.10.0` — caret pins the minor on a `0.x` — so an
   adopter on current Verdict could not install this package at all. The bound is `^0.12` **alone**

--- a/src/Contracts/EvidenceQuery.php
+++ b/src/Contracts/EvidenceQuery.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Contracts;
+
+use Fissible\VerdictConsole\Evidence\EvidenceFilter;
+use Fissible\VerdictConsole\Evidence\EvidenceQueryResult;
+
+/**
+ * Console-owned read boundary for Verdict decision evidence.
+ *
+ * Verdict deliberately exposes evidence as a write contract. Hosts that do not use the shipped SQL
+ * recorder can bind this contract to their own read model without making a surface depend on a
+ * recorder implementation or Verdict's private storage choices.
+ */
+interface EvidenceQuery
+{
+    public function search(EvidenceFilter $filter): EvidenceQueryResult;
+}

--- a/src/Evidence/DatabaseEvidenceQuery.php
+++ b/src/Evidence/DatabaseEvidenceQuery.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Evidence;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Fissible\VerdictConsole\Contracts\EvidenceQuery;
+use Illuminate\Contracts\Config\Repository as Config;
+use Illuminate\Database\DatabaseManager;
+
+/**
+ * Reads Verdict's published `verdict_evidence` decision-row schema without depending on its writer.
+ *
+ * The Null recorder check is configuration inspection only. This adapter never resolves Verdict's
+ * recorder, imports its recorder contracts, or reaches through a recorder to discover storage.
+ */
+final readonly class DatabaseEvidenceQuery implements EvidenceQuery
+{
+    private const string NULL_RECORDER = 'Fissible\\Verdict\\Evidence\\NullEvidenceRecorder';
+
+    public function __construct(
+        private DatabaseManager $database,
+        private Config $config,
+    ) {}
+
+    public function search(EvidenceFilter $filter): EvidenceQueryResult
+    {
+        if ($this->recordingIsOff()) {
+            return new EvidenceQueryResult(EvidenceRecordingState::Off, []);
+        }
+
+        $connection = $this->config->get('verdict.evidence.connection');
+        $table = $this->config->get('verdict.evidence.table', 'verdict_evidence');
+        $query = $this->database
+            ->connection(is_string($connection) ? $connection : null)
+            ->table(is_string($table) ? $table : 'verdict_evidence')
+            ->where('record_type', 'decision');
+
+        if ($filter->disposition !== null) {
+            $query->where('disposition', $filter->disposition);
+        }
+
+        if ($filter->capability !== null) {
+            $query->where('capability', $filter->capability);
+        }
+
+        if ($filter->recordedFrom !== null) {
+            $query->where('recorded_at', '>=', $filter->recordedFrom);
+        }
+
+        if ($filter->recordedUntil !== null) {
+            $query->where('recorded_at', '<=', $filter->recordedUntil);
+        }
+
+        $records = [];
+
+        foreach ($query->orderBy('recorded_at')->orderBy('id')->get() as $row) {
+            $records[] = new EvidenceRecord(
+                id: (string) $row->id,
+                capability: $this->nullableString($row->capability),
+                stage: (string) $row->stage,
+                disposition: (string) $row->disposition,
+                claimType: $this->nullableString($row->claim_type),
+                recordDigest: $this->nullableString($row->record_digest),
+                argumentFingerprint: $this->nullableString($row->argument_fingerprint),
+                idempotencyKeyFingerprint: $this->nullableString($row->idempotency_key_fingerprint),
+                approvalReceiptFingerprint: $this->nullableString($row->approval_receipt_fingerprint),
+                configurationFingerprint: $this->nullableString($row->configuration_fingerprint),
+                actorFingerprint: $this->nullableString($row->actor_fingerprint),
+                subjectFingerprint: $this->nullableString($row->subject_fingerprint),
+                proposalTargetIdentityFingerprint: $this->nullableString($row->proposal_target_identity_fingerprint),
+                executionTargetIdentityFingerprint: $this->nullableString($row->execution_target_identity_fingerprint),
+                rateLimitKeyFingerprint: $this->nullableString($row->rate_limit_key_fingerprint),
+                executionClaimFingerprint: $this->nullableString($row->execution_claim_fingerprint),
+                executionClaimBindingFingerprint: $this->nullableString($row->execution_claim_binding_fingerprint),
+                rateLimitResetAt: $this->nullableDate($row->rate_limit_reset_at),
+                recordedAt: $this->date((string) $row->recorded_at),
+            );
+        }
+
+        return new EvidenceQueryResult(EvidenceRecordingState::On, $records);
+    }
+
+    private function recordingIsOff(): bool
+    {
+        return $this->config->get('verdict.evidence.recorder', self::NULL_RECORDER) === self::NULL_RECORDER;
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        return $value === null ? null : (string) $value;
+    }
+
+    private function nullableDate(mixed $value): ?DateTimeImmutable
+    {
+        return $value === null ? null : $this->date((string) $value);
+    }
+
+    private function date(string $value): DateTimeImmutable
+    {
+        // Verdict's published evidence schema stores UTC-naive timestamps. This adapter translates
+        // that schema; a host whose evidence connection writes a different timezone owns a custom
+        // EvidenceQuery rather than silently reinterpreting its historical rows here.
+        return new DateTimeImmutable($value, new DateTimeZone('UTC'));
+    }
+}

--- a/src/Evidence/DatabaseEvidenceQuery.php
+++ b/src/Evidence/DatabaseEvidenceQuery.php
@@ -20,6 +20,10 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
 {
     private const string NULL_RECORDER = 'Fissible\\Verdict\\Evidence\\NullEvidenceRecorder';
 
+    private const string DATABASE_RECORDER = 'Fissible\\Verdict\\Evidence\\DatabaseEvidenceRecorder';
+
+    private const string ATTEST_RECORDER = 'Fissible\\Verdict\\Evidence\\AttestEvidenceRecorder';
+
     public function __construct(
         private DatabaseManager $database,
         private Config $config,
@@ -27,8 +31,10 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
 
     public function search(EvidenceFilter $filter): EvidenceQueryResult
     {
-        if ($this->recordingIsOff()) {
-            return new EvidenceQueryResult(EvidenceRecordingState::Off, []);
+        $recording = $this->recording();
+
+        if ($recording['state'] !== EvidenceRecordingState::On) {
+            return new EvidenceQueryResult($recording['state'], [], $recording['writer']);
         }
 
         $connection = $this->config->get('verdict.evidence.connection');
@@ -47,11 +53,11 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
         }
 
         if ($filter->recordedFrom !== null) {
-            $query->where('recorded_at', '>=', $filter->recordedFrom);
+            $query->where('recorded_at', '>=', $filter->recordedFrom->setTimezone(new DateTimeZone('UTC')));
         }
 
         if ($filter->recordedUntil !== null) {
-            $query->where('recorded_at', '<=', $filter->recordedUntil);
+            $query->where('recorded_at', '<=', $filter->recordedUntil->setTimezone(new DateTimeZone('UTC')));
         }
 
         $records = [];
@@ -83,9 +89,27 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
         return new EvidenceQueryResult(EvidenceRecordingState::On, $records);
     }
 
-    private function recordingIsOff(): bool
+    /** @return array{state: EvidenceRecordingState, writer: ?string} */
+    private function recording(): array
     {
-        return $this->config->get('verdict.evidence.recorder', self::NULL_RECORDER) === self::NULL_RECORDER;
+        // Verdict's narrow writer takes precedence over the legacy mixed recorder. The table is a
+        // known sink only for the two shipped durable recorders; an unknown configured writer may
+        // retain evidence elsewhere, so calling it an empty table would lie to an operator.
+        $writer = $this->config->get('verdict.evidence.writer');
+        $effectiveWriter = $writer ?? $this->config->get('verdict.evidence.recorder', self::NULL_RECORDER);
+
+        if ($effectiveWriter === self::NULL_RECORDER) {
+            return ['state' => EvidenceRecordingState::Off, 'writer' => null];
+        }
+
+        if (in_array($effectiveWriter, [self::DATABASE_RECORDER, self::ATTEST_RECORDER], true)) {
+            return ['state' => EvidenceRecordingState::On, 'writer' => null];
+        }
+
+        return [
+            'state' => EvidenceRecordingState::Elsewhere,
+            'writer' => is_string($effectiveWriter) ? $effectiveWriter : null,
+        ];
     }
 
     private function nullableString(mixed $value): ?string
@@ -100,9 +124,9 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
 
     private function date(string $value): DateTimeImmutable
     {
-        // Verdict's published evidence schema stores UTC-naive timestamps. This adapter translates
-        // that schema; a host whose evidence connection writes a different timezone owns a custom
-        // EvidenceQuery rather than silently reinterpreting its historical rows here.
+        // The published schema is timezone-naive. This adapter treats its values as UTC under
+        // Laravel's shipped UTC default; Verdict 0.12 itself does not normalize every writer to
+        // UTC, so a host that writes this table in another application timezone owns a custom query.
         return new DateTimeImmutable($value, new DateTimeZone('UTC'));
     }
 }

--- a/src/Evidence/EvidenceFilter.php
+++ b/src/Evidence/EvidenceFilter.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Evidence;
+
+use DateTimeImmutable;
+
+/** Optional filters over the durable decision-evidence vocabulary. */
+final readonly class EvidenceFilter
+{
+    public function __construct(
+        public ?string $disposition = null,
+        public ?string $capability = null,
+        public ?DateTimeImmutable $recordedFrom = null,
+        public ?DateTimeImmutable $recordedUntil = null,
+    ) {}
+}

--- a/src/Evidence/EvidenceQueryResult.php
+++ b/src/Evidence/EvidenceQueryResult.php
@@ -11,5 +11,7 @@ final readonly class EvidenceQueryResult
     public function __construct(
         public EvidenceRecordingState $recording,
         public array $records,
+        /** The configured writer when evidence is retained somewhere this table adapter cannot read. */
+        public ?string $recordedBy = null,
     ) {}
 }

--- a/src/Evidence/EvidenceQueryResult.php
+++ b/src/Evidence/EvidenceQueryResult.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Evidence;
+
+/** @param list<EvidenceRecord> $records */
+final readonly class EvidenceQueryResult
+{
+    /** @param list<EvidenceRecord> $records */
+    public function __construct(
+        public EvidenceRecordingState $recording,
+        public array $records,
+    ) {}
+}

--- a/src/Evidence/EvidenceRecord.php
+++ b/src/Evidence/EvidenceRecord.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Evidence;
+
+use DateTimeImmutable;
+
+/**
+ * A display-safe projection of one Verdict decision record.
+ *
+ * Fingerprints are correlation values, not anonymization. Raw arguments and identifiers intentionally
+ * do not cross this boundary. Reasons are excluded too: they are host-controlled free text, not a
+ * Verdict display-safe vocabulary, and could carry the same application content. A host that has
+ * governed that audience may replace EvidenceQuery with its own projection.
+ */
+final readonly class EvidenceRecord
+{
+    public function __construct(
+        public string $id,
+        public ?string $capability,
+        public string $stage,
+        public string $disposition,
+        public ?string $claimType,
+        public ?string $recordDigest,
+        public ?string $argumentFingerprint,
+        public ?string $idempotencyKeyFingerprint,
+        public ?string $approvalReceiptFingerprint,
+        public ?string $configurationFingerprint,
+        public ?string $actorFingerprint,
+        public ?string $subjectFingerprint,
+        public ?string $proposalTargetIdentityFingerprint,
+        public ?string $executionTargetIdentityFingerprint,
+        public ?string $rateLimitKeyFingerprint,
+        public ?string $executionClaimFingerprint,
+        public ?string $executionClaimBindingFingerprint,
+        public ?DateTimeImmutable $rateLimitResetAt,
+        public DateTimeImmutable $recordedAt,
+    ) {}
+}

--- a/src/Evidence/EvidenceRecordingState.php
+++ b/src/Evidence/EvidenceRecordingState.php
@@ -9,4 +9,5 @@ enum EvidenceRecordingState: string
 {
     case Off = 'off';
     case On = 'on';
+    case Elsewhere = 'elsewhere';
 }

--- a/src/Evidence/EvidenceRecordingState.php
+++ b/src/Evidence/EvidenceRecordingState.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Evidence;
+
+/** Whether Verdict was configured to retain evidence when this read was made. */
+enum EvidenceRecordingState: string
+{
+    case Off = 'off';
+    case On = 'on';
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -19,8 +19,10 @@ use Fissible\VerdictConsole\Contracts\ApprovalPresenter;
 use Fissible\VerdictConsole\Contracts\ApprovalScope;
 use Fissible\VerdictConsole\Contracts\ApproverAuthority;
 use Fissible\VerdictConsole\Contracts\ConversationParticipants;
+use Fissible\VerdictConsole\Contracts\EvidenceQuery;
 use Fissible\VerdictConsole\Contracts\ResumableAgents;
 use Fissible\VerdictConsole\Events\ApprovalIngestionIncident;
+use Fissible\VerdictConsole\Evidence\DatabaseEvidenceQuery;
 use Fissible\VerdictConsole\Incidents\IncidentStore;
 use Fissible\VerdictConsole\Listeners\IngestToolApprovalRequests;
 use Fissible\VerdictConsole\Listeners\LogApprovalIngestionIncident;
@@ -67,6 +69,8 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         $this->app->singleton(ConversationParticipants::class, UnconfiguredConversationParticipants::class);
 
         $this->app->singleton(ApprovalNotificationRecipients::class, UnconfiguredApprovalNotificationRecipients::class);
+
+        $this->app->singleton(EvidenceQuery::class, DatabaseEvidenceQuery::class);
 
         $this->app->singleton(IncidentStore::class);
     }

--- a/tests/Feature/EvidenceQueryTest.php
+++ b/tests/Feature/EvidenceQueryTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Fissible\Verdict\Evidence\AttestEvidenceRecorder;
 use Fissible\Verdict\Evidence\DatabaseEvidenceRecorder;
 use Fissible\Verdict\Evidence\NullEvidenceRecorder;
 use Fissible\VerdictConsole\Contracts\EvidenceQuery;
@@ -48,6 +49,30 @@ it('exposes recording being off separately from an empty enabled evidence table'
         ->and($off->records)->toBe([])
         ->and($empty->recording)->toBe(EvidenceRecordingState::On)
         ->and($empty->records)->toBe([]);
+});
+
+it('uses Verdicts narrow writer before the legacy recorder and distinguishes an unreadable writer', function (): void {
+    config()->set('verdict.evidence.writer', DatabaseEvidenceRecorder::class);
+    config()->set('verdict.evidence.recorder', NullEvidenceRecorder::class);
+
+    $tableWriter = app(EvidenceQuery::class)->search(new EvidenceFilter);
+
+    config()->set('verdict.evidence.writer', 'App\\Evidence\\ExternalWriter');
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+
+    $elsewhere = app(EvidenceQuery::class)->search(new EvidenceFilter);
+
+    config()->set('verdict.evidence.writer', null);
+    config()->set('verdict.evidence.recorder', AttestEvidenceRecorder::class);
+
+    $attestWriter = app(EvidenceQuery::class)->search(new EvidenceFilter);
+
+    expect($tableWriter->recording)->toBe(EvidenceRecordingState::On)
+        ->and($tableWriter->recordedBy)->toBeNull()
+        ->and($elsewhere->recording)->toBe(EvidenceRecordingState::Elsewhere)
+        ->and($elsewhere->recordedBy)->toBe('App\\Evidence\\ExternalWriter')
+        ->and($elsewhere->records)->toBe([])
+        ->and($attestWriter->recording)->toBe(EvidenceRecordingState::On);
 });
 
 it('treats Verdicts absent recorder configuration as recording off', function (): void {
@@ -135,8 +160,8 @@ it('filters decision evidence by disposition, capability, and inclusive recorded
     $records = app(EvidenceQuery::class)->search(new EvidenceFilter(
         disposition: 'deny',
         capability: 'orders.refund',
-        recordedFrom: new DateTimeImmutable('2026-08-25 11:00:00'),
-        recordedUntil: new DateTimeImmutable('2026-08-25 12:00:00'),
+        recordedFrom: new DateTimeImmutable('2026-08-25 06:00:00-05:00'),
+        recordedUntil: new DateTimeImmutable('2026-08-25 07:00:00-05:00'),
     ))->records;
 
     expect(array_map(fn ($record) => $record->id, $records))->toBe(['first-deny']);

--- a/tests/Feature/EvidenceQueryTest.php
+++ b/tests/Feature/EvidenceQueryTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Evidence\DatabaseEvidenceRecorder;
+use Fissible\Verdict\Evidence\NullEvidenceRecorder;
+use Fissible\VerdictConsole\Contracts\EvidenceQuery;
+use Fissible\VerdictConsole\Evidence\DatabaseEvidenceQuery;
+use Fissible\VerdictConsole\Evidence\EvidenceFilter;
+use Fissible\VerdictConsole\Evidence\EvidenceQueryResult;
+use Fissible\VerdictConsole\Evidence\EvidenceRecordingState;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function (): void {
+    config()->set('verdict.evidence.table', 'console_test_evidence');
+    config()->set('verdict.evidence.recorder', NullEvidenceRecorder::class);
+
+    $migrations = dirname(__DIR__, 2).'/vendor/fissible/verdict/database/migrations';
+
+    foreach ([
+        'create_verdict_evidence_table.php.stub',
+        'add_provenance_to_verdict_evidence_table.php.stub',
+        'add_invocation_id_to_verdict_evidence_table.php.stub',
+        'add_tool_kind_to_verdict_evidence_table.php.stub',
+        'add_configuration_fingerprint_to_verdict_evidence_table.php.stub',
+        'add_actor_and_subject_fingerprints_to_verdict_evidence_table.php.stub',
+        'add_target_source_to_verdict_evidence_table.php.stub',
+        'add_tool_description_fingerprints_to_verdict_evidence_table.php.stub',
+        'add_record_identity_to_verdict_evidence_table.php.stub',
+    ] as $migration) {
+        (require $migrations.'/'.$migration)->up();
+    }
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists('console_test_evidence');
+});
+
+it('exposes recording being off separately from an empty enabled evidence table', function (): void {
+    $off = app(EvidenceQuery::class)->search(new EvidenceFilter);
+
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+
+    $empty = app(EvidenceQuery::class)->search(new EvidenceFilter);
+
+    expect($off->recording)->toBe(EvidenceRecordingState::Off)
+        ->and($off->records)->toBe([])
+        ->and($empty->recording)->toBe(EvidenceRecordingState::On)
+        ->and($empty->records)->toBe([]);
+});
+
+it('treats Verdicts absent recorder configuration as recording off', function (): void {
+    $evidence = config('verdict.evidence');
+    unset($evidence['recorder']);
+    config()->set('verdict.evidence', $evidence);
+
+    $result = app(EvidenceQuery::class)->search(new EvidenceFilter);
+
+    expect($result->recording)->toBe(EvidenceRecordingState::Off)
+        ->and($result->records)->toBe([]);
+});
+
+it('reads only decision evidence from Verdicts shipped schema without exposing raw values', function (): void {
+    insertEvidence([
+        'id' => 'decision-1',
+        'record_type' => 'decision',
+        'capability' => 'orders.refund',
+        'stage' => 'proposal',
+        'disposition' => 'throttle',
+        'claim_type' => 'rate_limit.refused',
+        'record_digest' => 'canonicaljson-sha256:decision-1',
+        'reason' => 'The customer email and refund amount must not reach this surface.',
+        'argument_fingerprint' => str_repeat('a', 64),
+        'idempotency_key_fingerprint' => str_repeat('b', 64),
+        'approval_receipt_fingerprint' => str_repeat('c', 64),
+        'configuration_fingerprint' => str_repeat('d', 64),
+        'actor_fingerprint' => str_repeat('e', 64),
+        'subject_fingerprint' => str_repeat('f', 64),
+        'proposal_target_identity_fingerprint' => str_repeat('1', 64),
+        'execution_target_identity_fingerprint' => str_repeat('2', 64),
+        'rate_limit_key_fingerprint' => str_repeat('3', 64),
+        'execution_claim_fingerprint' => str_repeat('4', 64),
+        'execution_claim_binding_fingerprint' => str_repeat('5', 64),
+        'rate_limit_reset_at' => '2026-08-25 12:30:00',
+        'recorded_at' => '2026-08-25 12:00:00',
+    ]);
+    insertEvidence([
+        'id' => 'provenance-1',
+        'record_type' => 'provenance',
+        'stage' => 'input',
+        'disposition' => 'recorded',
+        'recorded_at' => '2026-08-25 12:01:00',
+    ]);
+
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+
+    $result = app(EvidenceQuery::class)->search(new EvidenceFilter);
+
+    expect($result->recording)->toBe(EvidenceRecordingState::On)
+        ->and($result->records)->toHaveCount(1)
+        ->and($result->records[0])->toMatchArray([
+            'id' => 'decision-1',
+            'capability' => 'orders.refund',
+            'stage' => 'proposal',
+            'disposition' => 'throttle',
+            'claimType' => 'rate_limit.refused',
+            'recordDigest' => 'canonicaljson-sha256:decision-1',
+            'argumentFingerprint' => str_repeat('a', 64),
+            'idempotencyKeyFingerprint' => str_repeat('b', 64),
+            'approvalReceiptFingerprint' => str_repeat('c', 64),
+            'configurationFingerprint' => str_repeat('d', 64),
+            'actorFingerprint' => str_repeat('e', 64),
+            'subjectFingerprint' => str_repeat('f', 64),
+            'proposalTargetIdentityFingerprint' => str_repeat('1', 64),
+            'executionTargetIdentityFingerprint' => str_repeat('2', 64),
+            'rateLimitKeyFingerprint' => str_repeat('3', 64),
+            'executionClaimFingerprint' => str_repeat('4', 64),
+            'executionClaimBindingFingerprint' => str_repeat('5', 64),
+            'rateLimitResetAt' => new DateTimeImmutable('2026-08-25 12:30:00 UTC'),
+            'recordedAt' => new DateTimeImmutable('2026-08-25 12:00:00 UTC'),
+        ])
+        ->and(property_exists($result->records[0], 'reason'))->toBeFalse();
+});
+
+it('filters decision evidence by disposition, capability, and inclusive recorded-at bounds', function (): void {
+    insertEvidence(['id' => 'permit', 'record_type' => 'decision', 'capability' => 'orders.refund', 'stage' => 'proposal', 'disposition' => 'permit', 'recorded_at' => '2026-08-25 10:00:00']);
+    insertEvidence(['id' => 'early-deny', 'record_type' => 'decision', 'capability' => 'orders.refund', 'stage' => 'proposal', 'disposition' => 'deny', 'recorded_at' => '2026-08-25 10:00:00']);
+    insertEvidence(['id' => 'first-deny', 'record_type' => 'decision', 'capability' => 'orders.refund', 'stage' => 'proposal', 'disposition' => 'deny', 'recorded_at' => '2026-08-25 11:00:00']);
+    insertEvidence(['id' => 'second-deny', 'record_type' => 'decision', 'capability' => 'billing.refund', 'stage' => 'proposal', 'disposition' => 'deny', 'recorded_at' => '2026-08-25 12:00:00']);
+    insertEvidence(['id' => 'late-deny', 'record_type' => 'decision', 'capability' => 'orders.refund', 'stage' => 'proposal', 'disposition' => 'deny', 'recorded_at' => '2026-08-25 13:00:00']);
+
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+
+    $records = app(EvidenceQuery::class)->search(new EvidenceFilter(
+        disposition: 'deny',
+        capability: 'orders.refund',
+        recordedFrom: new DateTimeImmutable('2026-08-25 11:00:00'),
+        recordedUntil: new DateTimeImmutable('2026-08-25 12:00:00'),
+    ))->records;
+
+    expect(array_map(fn ($record) => $record->id, $records))->toBe(['first-deny']);
+});
+
+it('keeps the read boundary independent of Verdicts writer and recorder implementations', function (): void {
+    $source = file_get_contents(dirname(__DIR__, 2).'/src/Evidence/DatabaseEvidenceQuery.php');
+
+    expect($source)->not->toContain('Fissible\\Verdict\\Contracts\\EvidenceWriter')
+        ->and($source)->not->toContain('Fissible\\Verdict\\Contracts\\EvidenceRecorder')
+        ->and($source)->not->toContain('Fissible\\Verdict\\Evidence\\DatabaseEvidenceRecorder')
+        ->and($source)->not->toContain('Fissible\\Verdict\\Evidence\\DecisionEvidence');
+});
+
+it('binds the shipped table adapter to a contract a host may replace', function (): void {
+    expect(app(EvidenceQuery::class))->toBeInstanceOf(DatabaseEvidenceQuery::class);
+
+    $replacement = new class implements EvidenceQuery
+    {
+        public function search(EvidenceFilter $filter): EvidenceQueryResult
+        {
+            return new EvidenceQueryResult(EvidenceRecordingState::On, []);
+        }
+    };
+
+    app()->instance(EvidenceQuery::class, $replacement);
+
+    expect(app(EvidenceQuery::class))->toBe($replacement);
+});
+
+/** @param array<string, mixed> $attributes */
+function insertEvidence(array $attributes): void
+{
+    DB::table('console_test_evidence')->insert([
+        'id' => $attributes['id'],
+        'record_type' => $attributes['record_type'],
+        'capability' => $attributes['capability'] ?? null,
+        'stage' => $attributes['stage'],
+        'disposition' => $attributes['disposition'],
+        'reason' => $attributes['reason'] ?? null,
+        'argument_fingerprint' => $attributes['argument_fingerprint'] ?? null,
+        'idempotency_key_fingerprint' => $attributes['idempotency_key_fingerprint'] ?? null,
+        'approval_receipt_fingerprint' => $attributes['approval_receipt_fingerprint'] ?? null,
+        'proposal_target_identity_fingerprint' => $attributes['proposal_target_identity_fingerprint'] ?? null,
+        'execution_target_identity_fingerprint' => $attributes['execution_target_identity_fingerprint'] ?? null,
+        'rate_limit_key_fingerprint' => $attributes['rate_limit_key_fingerprint'] ?? null,
+        'execution_claim_fingerprint' => $attributes['execution_claim_fingerprint'] ?? null,
+        'execution_claim_binding_fingerprint' => $attributes['execution_claim_binding_fingerprint'] ?? null,
+        'configuration_fingerprint' => $attributes['configuration_fingerprint'] ?? null,
+        'actor_fingerprint' => $attributes['actor_fingerprint'] ?? null,
+        'subject_fingerprint' => $attributes['subject_fingerprint'] ?? null,
+        'claim_type' => $attributes['claim_type'] ?? null,
+        'record_digest' => $attributes['record_digest'] ?? null,
+        'rate_limit_reset_at' => $attributes['rate_limit_reset_at'] ?? null,
+        'recorded_at' => $attributes['recorded_at'],
+    ]);
+}


### PR DESCRIPTION
Closes #13.

Verdict's `EvidenceWriter` is write-only and the shipped recorder publishes no query API, so any evidence surface would otherwise couple to private storage. This is a **console-owned** `EvidenceQuery` contract with a default adapter over the published `verdict_evidence` schema — filterable by disposition, capability, and inclusive `recorded_at` bounds.

## Independence is structural, not asserted

Nothing under `src/Evidence/` or the contract imports `Fissible\Verdict` at all. A host binding its own read model carries no dependency on a recorder implementation, and the acceptance clause holds by the absence of a `use` statement rather than by a test that could rot.

## Recording-off is a state, not an empty list

`NullEvidenceRecorder` is Verdict's default, so a fresh install has no evidence **by configuration** rather than because nothing happened. A surface rendering *"no records found"* for that tells an operator the opposite of the truth. The result carries an explicit `Off`/`On` alongside its rows.

**The default matters as much as the guard.** An absent `verdict.evidence.recorder` key *is* the blank-by-config case — and it was the one thing nothing held. Before its test existed, flipping the fallback so an unset key read as recording-**on** passed 193 green, because every case either set the key explicitly or never reached the unset path. It now fails exactly that test.

## The projection

Fingerprints, `claimType`, `recordDigest`, and the rate-limit reset time.

Raw arguments, identifiers, and **reasons** do not cross the boundary. Reasons included deliberately: they are host-controlled free text rather than a field this package can vouch for, and ADR 0008 makes that absence part of the contract rather than an omission. UTC parsing follows Verdict's shipped timestamp schema, now stated as the assumption it is.

## Mutation checks

| Mutation | Fails |
|---|---|
| Delete the recording-off guard | `exposes recording being off separately from an empty enabled evidence table` |
| Make the time bounds exclusive | `filters decision evidence by disposition, capability, and inclusive recorded-at bounds` |
| Unset key reads as recording-on | `treats Verdicts absent recorder configuration as recording off` |

Each fails only its own test.

## Verification

Pint clean, PHPStan clean, 100% type coverage, `composer validate --strict` clean, **194 passed / 777 assertions**. Based on `49298de`, zero behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review corrections (second commit)

- **Recording state follows Verdict's precedence, `writer ?? recorder ?? Null`.** The first cut read only the legacy `recorder` key, so a host on the documented narrow-writer path reported *Off* while recording.
- **A third state, `Elsewhere`, with `recordedBy`.** A configured sink this table adapter cannot read is reported as such, never as an empty table. Verdict's database and Attest recorders are pinned as the two table-readable sinks.
- **Filter bounds are normalised to UTC** before binding — Laravel formats a `DateTimeInterface` binding in its own zone without converting, so a non-UTC host's window was off by its offset.
- The timestamp assumption is now stated as what it is (Laravel's shipped UTC default); Verdict 0.12 does not itself normalise every write to UTC, which is an upstream finding rather than this adapter's to hide.
- The VC-13 changelog entry.

## Notes

- **VC-14 will widen this shape additively.** Conversation ↔ invocation correlation needs `invocation_id` on both `EvidenceFilter` and `EvidenceRecord`; neither carries it yet, by design — VC-14 is where that field earns its place, and adding it is a non-breaking extension of the contract and the DTO.
- `On` means "the shipped table is the sink", not "evidence exists"; `Elsewhere` is the honest answer for everything else.
