### PR TITLE
docs: track the ADR 0001 follow-ups that had no issue

### DIFF
--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -8,8 +8,10 @@ Ordering is leaves → roots, **risk-first within a milestone**: the pause→app
 (VC-1) is built before the CRUD around it, because that is where the design can be *wrong*, not merely
 late (design [§11](docs/design/0001-verdict-console-design.md)).
 
-**Issue numbering:** filed 1:1, so `VC-N` is GitHub issue `#N`. (#40 is a CI issue, not a `VC-`;
-the ADR 0001 follow-ups resume at VC-41 = #41.)
+**Issue numbering:** the original plan filed 1:1, so `VC-N` is GitHub issue `#N` for VC-1 … VC-48.
+That convention **ended there** — the number space is shared with pull requests, so issues filed
+after #48 (#51, #63, #67–#69) carry descriptive titles and no `VC-` prefix. Refer to them by issue
+number; do not mint new `VC-` numbers.
 
 Current version: `0.1.0` (unreleased). Release procedure: fissible standards in
 [`fissible/.github`](https://github.com/fissible/.github).
@@ -20,9 +22,9 @@ Current version: `0.1.0` (unreleased). Release procedure: fissible standards in
 | --- | --- | --- |
 | **v0.1.0** | Headless approval round trip — pause → approve → resume → execute-once, driveable with no UI, plus the authorization + presentation contracts the loop needs | VC-1 … VC-8 |
 | **v0.2.0** | Production-grade workflow — notification idempotency, resume-failure reconciliation, notifications, tenancy scoping, plus the [ADR 0001](docs/adr/0001-approval-surface-contract.md) verb contract, the measured expiry `close`, and the design-doc corrections | VC-9 … VC-12, VC-41, VC-43, VC-44 |
-| **v0.3.0** | Evidence & health projections — evidence query contract, correlation + incident ledger, execution-claim + config read-models, and the approval item read-model | VC-13 … VC-17, VC-42 |
+| **v0.3.0** | Evidence & health projections — evidence query contract, correlation + incident ledger, execution-claim + config read-models, and the approval item read-model | VC-13 … VC-17, VC-42, [#67](https://github.com/fissible/verdict-console/issues/67) |
 | **v0.4.0** | Blade surfaces — embeddable inbox, audit page, basic chat, ops views + the host chat-entry contract | VC-18 … VC-22 |
-| **verdict-gated** | Designed against Verdict Proposed-contract issues [#297](https://github.com/fissible/verdict/issues/297)–[#300](https://github.com/fissible/verdict/issues/300); built against nothing until each ships, then migrated to a release milestone. Label `blocked:verdict` | VC-45 … VC-48 |
+| **verdict-gated** | Designed against Verdict Proposed-contract issues [#297](https://github.com/fissible/verdict/issues/297)–[#300](https://github.com/fissible/verdict/issues/300); built against nothing until each ships, then migrated to a release milestone. Label `blocked:verdict` | VC-45 … VC-48, [#68](https://github.com/fissible/verdict-console/issues/68), [#69](https://github.com/fissible/verdict-console/issues/69) |
 
 ## Adapter packages (own repos, own version streams)
 

--- a/docs/planning/ISSUES.md
+++ b/docs/planning/ISSUES.md
@@ -371,6 +371,22 @@ asserts the real transition outcome; tested.
 **Acceptance:** read-models list configuration; no write path exists; documented why.
 **Refs:** design §6.8, §13.
 
+### #67 · Verdict's `unauthorized` outcome is a named refusal · S · `type:feature` `area:runtime`
+**Deps:** none — **ungated**; `ApprovalOutcome::Unauthorized` is in `v0.12.0`, already required.
+**Context:** [ADR 0001](../adr/0001-approval-surface-contract.md) §4 (amended) decided this and the
+amendment assigned it to VC-6, which had already closed — so a decided behaviour lived only in the
+ADR. The safety half is pinned (#65 put `unauthorized` in the never-resumes dataset); the naming half
+does not exist.
+**Scope:** raise `AuthorizationException` with the *same* message as the approver and scope refusals,
+so authority cannot be probed by comparing errors; dispatch `ApprovalDecisionRefused` and record it
+through the shipped ledger (`IncidentStore::record()`); never touch the receipt;
+`ApprovalAuthorizerMissing` keeps propagating as the configuration error the doctor already prevents.
+**Acceptance:** identical exception and message to a Gate refusal, asserted against the shared
+fixture rather than a re-typed literal; exactly one incident row; receipt stays `pending`; the
+never-resumes dataset stays green.
+**Waiting on Verdict:** nothing.
+([#67](https://github.com/fissible/verdict-console/issues/67))
+
 ### VC-42 · Approval item read-model — live challenge over persisted presentation · M · `type:feature` `area:runtime`
 **Deps:** VC-6, VC-41. **Context:** ADR 0001 §5 — the item renders the ADR 0026 payload **live** from
 the challenge on top of the VC-8 presentation; expiry and provenance are never persisted.
@@ -523,6 +539,29 @@ admission with no record, event, or store) **then** verdict#298 for reads. **Dep
 (owned by #297): refusal payload shape, mandatory reason, table naming. **Nothing speculative is
 built before #297 ships** — ADR 0001 reserves the ability name only.
 ([#48](https://github.com/fissible/verdict-console/issues/48))
+
+### #68 · Capture Verdict's `approval_context` at ingestion · S · `blocked:verdict` `area:runtime`
+**Blocked on:** the next Verdict tag carrying verdict#327 (`ApprovalStatusReader`) — verify with
+`git tag --contains a84cbed`. **Deps:** #45.
+**Scope:** a nullable `approval_context` column in its own migration file, populated at ingestion from
+`ApprovalStatusReader::statusFor()`. A **correlation annotation, not mirrored status**: Verdict
+documents the field immutable after issue, which is what separates it from the receipt status and
+expiry this package deliberately never copies. At `v0.12.0` the field's only route is the store call
+design §5 forbids, which is why this waits rather than shipping now.
+**Acceptance:** captured when present, null when the receipt predates capture; a schema assertion
+proves no column mirrors Verdict receipt status or expiry; the migration publishes.
+([#68](https://github.com/fissible/verdict-console/issues/68))
+
+### #69 · Ship an `ApprovalContextScope` keyed on `approval_context` · S · `blocked:verdict` `area:runtime`
+**Blocked on:** #68. **Scope:** an `ApprovalScope` implementation over the captured context — non-empty
+map, **typed-exact** (integer `1` never matches string `'1'`), `null`/`[]` rows never in scope — the same
+rule as verdict ADR 0031 §3, so console scoping and Verdict's `pendingWithin()` cannot drift. **Additive:
+the published `ApprovalScope` contract is not narrowed**; a host's own scope keeps working, and this
+ships as the recommended binding because it is the one that guarantees *what the console shows a person
+is a subset of what Verdict would let them decide*.
+**Acceptance:** typed-exact matching proven; `null`/`[]` excluded; an existing host scope still works;
+the recommendation and its reason documented.
+([#69](https://github.com/fissible/verdict-console/issues/69))
 
 ---
 


### PR DESCRIPTION
## Summary
- Records #67, #68 and #69 in `docs/planning/ISSUES.md` and `MILESTONES.md`.
- Corrects the issue-numbering note: `VC-N` = `#N` held through VC-48 and ended there, since the number space is shared with PRs.

## Why
ADR 0001 §4's amendment decided three follow-ups and assigned them to VC-6, VC-4/5 and VC-12 — **all already closed**. The work existed only in the ADR, and an ADR is a record of decisions, not a work queue. One of the three is ungated and was never built: `grep -rn "Unauthorized\|ApprovalDecisionRefused" src/` returns nothing, and `resolve()` still returns the transition unexamined. Nothing is unsafe — #65 pinned the never-resumes property — but the console has no name for a refusal the two authorization layers disagreed on, which is what §4 says it should have.

| Issue | Gate |
|---|---|
| [#67](https://github.com/fissible/verdict-console/issues/67) `unauthorized` is a named refusal | none — buildable today |
| [#68](https://github.com/fissible/verdict-console/issues/68) capture `approval_context` | next Verdict tag carrying verdict#327 |
| [#69](https://github.com/fissible/verdict-console/issues/69) `ApprovalContextScope` | #68 |

## Test plan
- [x] Docs only — no code change.
- [x] Claims verified before writing: `ApprovalOutcome::Unauthorized` present in `v0.12.0`; neither symbol in `src/`; `tests/EndToEnd/ApprovalRoundTripTest.php:1538` pins the never-resumes case; `#4`, `#5`, `#6`, `#12` all closed; `git tag --contains a84cbed` empty.

## Notes
#69 is deliberately **additive** — it ships an `ApprovalScope` implementation and does not narrow the published contract, so a host's existing scope keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
