### PR TITLE
feat: name Verdict's unauthorized outcome as a refusal, never a non-approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Names a Verdict authorization refusal without spending its receipt (#67).** When Verdict's
+  required host `ApprovalDecisionAuthorizer` returns `unauthorized` after the console's own Gate
+  permitted an approver, the console now raises the same non-disclosing authorization refusal as
+  its Gate and scope boundaries, dispatches `ApprovalDecisionRefused`, and records each attempt in
+  the incident ledger — one row per refused attempt, linked through `context` because the ledger's
+  `(source, pending_approval_id)` unique index makes that column a one-per-row slot. The receipt
+  remains pending and no Laravel AI continuation is attempted. A missing authorizer still surfaces
+  as `ApprovalAuthorizerMissing` and a throwing one as its own exception: those are configuration
+  and host defects, not refusals, and relabelling them would send an operator to the wrong place.
+
 - **Evidence query contract and the shipped table adapter (VC-13).** `EvidenceQuery` is a
   console-owned, host-replaceable read boundary over Verdict's published decision-evidence table;
   it projects fingerprints plus `claimType`/`recordDigest`, never raw arguments, identifiers, or

--- a/src/Approvals/ApprovalResolutionService.php
+++ b/src/Approvals/ApprovalResolutionService.php
@@ -4,16 +4,19 @@ declare(strict_types=1);
 
 namespace Fissible\VerdictConsole\Approvals;
 
+use Fissible\Verdict\Approvals\ApprovalDecisionKind;
 use Fissible\Verdict\Approvals\ApprovalManager;
 use Fissible\Verdict\Approvals\ApprovalOutcome;
 use Fissible\Verdict\Approvals\ApprovalTransition;
 use Fissible\VerdictConsole\Contracts\ApproverAuthority;
 use Fissible\VerdictConsole\Contracts\ConversationParticipants;
 use Fissible\VerdictConsole\Contracts\ResumableAgents;
+use Fissible\VerdictConsole\Events\ApprovalDecisionRefused;
 use Fissible\VerdictConsole\Exceptions\ApprovalNotDrivable;
 use Fissible\VerdictConsole\Exceptions\ApprovalResumeFailed;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Ai\Approvals\Decision;
 use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Exceptions\ApprovalMismatchException;
@@ -22,6 +25,8 @@ use Throwable;
 /** Turns one authorized human decision into one exact Laravel AI continuation. */
 final readonly class ApprovalResolutionService
 {
+    private const string AUTHORIZATION_REFUSAL_MESSAGE = 'This approver may not resolve this approval.';
+
     public function __construct(
         private ApprovalManager $approvals,
         private ApproverAuthority $authority,
@@ -30,6 +35,7 @@ final readonly class ApprovalResolutionService
         private PendingApprovalStore $pendingApprovals,
         private ApprovalReconciliationStore $reconciliations,
         private ApprovalNotificationDispatcher $notifications,
+        private Dispatcher $events,
     ) {}
 
     /**
@@ -61,7 +67,7 @@ final readonly class ApprovalResolutionService
         $this->assertVisible($approval);
 
         if (! $this->authority->allows($approval, $approver)) {
-            throw new AuthorizationException('This approver may not resolve this approval.');
+            throw new AuthorizationException(self::AUTHORIZATION_REFUSAL_MESSAGE);
         }
 
         if ($approval->resumability !== Resumability::Drivable) {
@@ -124,7 +130,7 @@ final readonly class ApprovalResolutionService
         $this->assertVisible($approval);
 
         if (! $this->authority->allows($approval, $approver)) {
-            throw new AuthorizationException('This approver may not resolve this approval.');
+            throw new AuthorizationException(self::AUTHORIZATION_REFUSAL_MESSAGE);
         }
 
         if ($approval->resumability !== Resumability::Drivable) {
@@ -156,6 +162,14 @@ final readonly class ApprovalResolutionService
             : $this->approvals->reject($challenge->receiptId, $challenge->toolCallId, $actorKey);
 
         $expected = $approve ? ApprovalOutcome::Approved : ApprovalOutcome::Rejected;
+
+        if ($transition->outcome === ApprovalOutcome::Unauthorized) {
+            $kind = $approve ? ApprovalDecisionKind::Approve : ApprovalDecisionKind::Reject;
+
+            $this->events->dispatch(new ApprovalDecisionRefused($approval, $kind));
+
+            throw new AuthorizationException(self::AUTHORIZATION_REFUSAL_MESSAGE);
+        }
 
         if ($transition->outcome !== $expected) {
             return $transition;
@@ -209,7 +223,7 @@ final readonly class ApprovalResolutionService
     private function assertVisible(PendingApproval $approval): void
     {
         if (! $this->pendingApprovals->isVisible($approval)) {
-            throw new AuthorizationException('This approver may not resolve this approval.');
+            throw new AuthorizationException(self::AUTHORIZATION_REFUSAL_MESSAGE);
         }
     }
 }

--- a/src/Events/ApprovalDecisionRefused.php
+++ b/src/Events/ApprovalDecisionRefused.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Events;
+
+use Fissible\Verdict\Approvals\ApprovalDecisionKind;
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+
+/**
+ * Verdict refused a decision the console's own authority had already admitted.
+ *
+ * The anomaly listener projects this rather than the resolver writing inline, so this per-attempt
+ * observation follows the same durable ledger path as every other console anomaly.
+ */
+final readonly class ApprovalDecisionRefused
+{
+    public function __construct(
+        public PendingApproval $pendingApproval,
+        public ApprovalDecisionKind $kind,
+    ) {}
+}

--- a/src/Listeners/RecordAnomalyIncident.php
+++ b/src/Listeners/RecordAnomalyIncident.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace Fissible\VerdictConsole\Listeners;
 
+use Fissible\Verdict\Approvals\ApprovalOutcome;
 use Fissible\Verdict\Capabilities\Events\CapabilityConfigurationUnrecorded;
 use Fissible\Verdict\Evidence\Events\ChainWriteFailed;
 use Fissible\Verdict\Evidence\Events\ConsequentialActionUnrecorded;
 use Fissible\Verdict\Evidence\Events\EvidenceWriteFailed;
+use Fissible\VerdictConsole\Events\ApprovalDecisionRefused;
 use Fissible\VerdictConsole\Events\ApprovalIngestionIncident;
 use Fissible\VerdictConsole\Incidents\IncidentStore;
 
-/** Projects the five ephemeral anomaly events into the console's durable incident ledger. */
+/** Projects the six ephemeral anomaly events into the console's durable incident ledger. */
 final readonly class RecordAnomalyIncident
 {
     public function __construct(private IncidentStore $incidents) {}
@@ -41,6 +43,13 @@ final readonly class RecordAnomalyIncident
                 ],
             ),
             $event instanceof ApprovalIngestionIncident => $this->incidents->recordIngestion($event->pendingApproval, $event->reason),
+            $event instanceof ApprovalDecisionRefused => $this->incidents->record(
+                'approval_decision_refused', ApprovalOutcome::Unauthorized->value, [
+                    'decision' => $event->kind->value,
+                    'tool_call_id' => $event->pendingApproval->tool_call_id,
+                    'pending_approval_id' => $event->pendingApproval->id,
+                ],
+            ),
             default => null,
         };
     }

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -21,6 +21,7 @@ use Fissible\VerdictConsole\Contracts\ApproverAuthority;
 use Fissible\VerdictConsole\Contracts\ConversationParticipants;
 use Fissible\VerdictConsole\Contracts\EvidenceQuery;
 use Fissible\VerdictConsole\Contracts\ResumableAgents;
+use Fissible\VerdictConsole\Events\ApprovalDecisionRefused;
 use Fissible\VerdictConsole\Events\ApprovalIngestionIncident;
 use Fissible\VerdictConsole\Evidence\DatabaseEvidenceQuery;
 use Fissible\VerdictConsole\Incidents\IncidentStore;
@@ -87,6 +88,7 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         $events->listen(ChainWriteFailed::class, RecordAnomalyIncident::class);
         $events->listen(CapabilityConfigurationUnrecorded::class, RecordAnomalyIncident::class);
         $events->listen(ApprovalIngestionIncident::class, RecordAnomalyIncident::class);
+        $events->listen(ApprovalDecisionRefused::class, RecordAnomalyIncident::class);
 
         // The ledger is the durable projection; the released opt-out log sink remains a separate
         // operational alerting surface for hosts that already route it.

--- a/tests/EndToEnd/ApprovalRoundTripTest.php
+++ b/tests/EndToEnd/ApprovalRoundTripTest.php
@@ -6,14 +6,17 @@ use Fissible\Verdict\Actions\ActionContext;
 use Fissible\Verdict\Actions\ActionEnvelope;
 use Fissible\Verdict\Actions\AuthorizedAction;
 use Fissible\Verdict\Approvals\ApprovalChallenge;
+use Fissible\Verdict\Approvals\ApprovalDecisionKind;
 use Fissible\Verdict\Approvals\ApprovalOutcome;
 use Fissible\Verdict\Approvals\ApprovalReceipt;
 use Fissible\Verdict\Approvals\ApprovalTransition;
 use Fissible\Verdict\Capabilities\Capability;
 use Fissible\Verdict\Capabilities\CapabilityRegistry;
+use Fissible\Verdict\Contracts\ApprovalDecisionAuthorizer;
 use Fissible\Verdict\Contracts\ApprovalReceiptStore;
 use Fissible\Verdict\Contracts\CapabilityAuthorizer;
 use Fissible\Verdict\Decisions\Decision;
+use Fissible\Verdict\Exceptions\ApprovalAuthorizerMissing;
 use Fissible\Verdict\Exceptions\UnsafeOuterTransaction;
 use Fissible\Verdict\LaravelAi\VerdictApprovalMiddleware;
 use Fissible\Verdict\Targets\ExecutionTargetPolicy;
@@ -33,9 +36,11 @@ use Fissible\VerdictConsole\Contracts\ApprovalPresenter;
 use Fissible\VerdictConsole\Contracts\ApprovalScope;
 use Fissible\VerdictConsole\Contracts\ConversationParticipants;
 use Fissible\VerdictConsole\Contracts\ResumableAgents;
+use Fissible\VerdictConsole\Events\ApprovalDecisionRefused;
 use Fissible\VerdictConsole\Events\ApprovalIngestionIncident;
 use Fissible\VerdictConsole\Exceptions\ApprovalNotDrivable;
 use Fissible\VerdictConsole\Exceptions\ApprovalResumeFailed;
+use Fissible\VerdictConsole\Incidents\Incident;
 use Fissible\VerdictConsole\Notifications\ApprovalResumeOutcomeNotification;
 use Fissible\VerdictConsole\Notifications\ApprovedApprovalNotification;
 use Fissible\VerdictConsole\Notifications\PendingApprovalNotification;
@@ -128,6 +133,65 @@ final class RoundTripParticipants implements ConversationParticipants
 
         return new RoundTripCustomer((int) $matches[1]);
     }
+}
+
+/**
+ * A host authorizer that refuses every decision, recording what Verdict handed it.
+ *
+ * This is the real Verdict 0.12 path — the manager consults the configured authorizer and returns
+ * `unauthorized` without touching the receipt — not a forced store outcome, so a test built on it
+ * proves the console reacts to the layer that actually refused.
+ *
+ * @var list<array{kind: ApprovalDecisionKind, decidedBy: string}>
+ */
+final class RefusingDecisionAuthorizer implements ApprovalDecisionAuthorizer
+{
+    /** @var list<array{kind: ApprovalDecisionKind, decidedBy: string}> */
+    public static array $consulted = [];
+
+    public function authorize(ApprovalReceipt $receipt, ApprovalDecisionKind $kind, string $decidedBy): bool
+    {
+        self::$consulted[] = ['kind' => $kind, 'decidedBy' => $decidedBy];
+
+        return false;
+    }
+}
+
+/** A second refusing authorizer, so a console that keyed on the fixture's class name would fail. */
+final class ReceiptOwnershipAuthorizer implements ApprovalDecisionAuthorizer
+{
+    public static int $consulted = 0;
+
+    public function authorize(ApprovalReceipt $receipt, ApprovalDecisionKind $kind, string $decidedBy): bool
+    {
+        self::$consulted++;
+
+        return false;
+    }
+}
+
+/** What a host's own authorizer raises when it breaks: not a refusal, a defect. */
+final class HostAuthorizerFailure extends RuntimeException {}
+
+final class FailingDecisionAuthorizer implements ApprovalDecisionAuthorizer
+{
+    public static ?HostAuthorizerFailure $thrown = null;
+
+    public function authorize(ApprovalReceipt $receipt, ApprovalDecisionKind $kind, string $decidedBy): bool
+    {
+        throw self::$thrown = new HostAuthorizerFailure('The ownership lookup is unavailable.');
+    }
+}
+
+/** Collects refusal announcements so a test can assert their absence as precisely as their presence. */
+function listenForRefusals(): ArrayObject
+{
+    $refusals = new ArrayObject;
+    Event::listen(ApprovalDecisionRefused::class, function (ApprovalDecisionRefused $event) use ($refusals): void {
+        $refusals[] = $event;
+    });
+
+    return $refusals;
 }
 
 /** Keeps the real receipt lifecycle, changing only the transition under this control. */
@@ -1511,6 +1575,7 @@ it('returns the live-challenge null path on a second approve without resuming ag
 
 it('does not resume when Verdict returns a non-approval transition', function (ApprovalOutcome $outcome): void {
     Gate::define('approve-verdict-action', fn (): bool => true);
+    $refusals = listenForRefusals();
     app()->instance(ApprovalReceiptStore::class, new ForcedApprovalOutcomeStore(app(ApprovalReceiptStore::class), $outcome));
     Http::fake(['*/chat/completions' => Http::sequence()->push($this->toolCallResponse(TOOL_CALL_ID, 'CancelOrderTool', ['order_id' => ORDER_ID]))]);
 
@@ -1525,17 +1590,20 @@ it('does not resume when Verdict returns a non-approval transition', function (A
         ->not->toThrow(ApprovalResumeFailed::class);
 
     expect($transition?->outcome)->toBe($outcome)
-        ->and(app(RoundTripLedger::class)->executions)->toBe(0, 'Only an Approved transition may resume this tool call.');
+        ->and(app(RoundTripLedger::class)->executions)->toBe(0, 'Only an Approved transition may resume this tool call.')
+        // These are non-approvals, not refusals: nobody disagreed with anybody. Only `unauthorized`
+        // is announced (#67); naming any of these would flood the ledger with ordinary lifecycle.
+        ->and(Incident::query()->where('source', 'approval_decision_refused')->count())->toBe(0)
+        ->and(count($refusals))->toBe(0);
 })->with([
     'consumed' => [ApprovalOutcome::Consumed],
     'mismatch' => [ApprovalOutcome::Mismatch],
     'expired' => [ApprovalOutcome::Expired],
     'not_found' => [ApprovalOutcome::NotFound],
     'invalid_state' => [ApprovalOutcome::InvalidState],
-    // Verdict 0.12's outcome when the host's required authorizer refuses. #6 adds the named
-    // refusal; the property the §2 invariant actually stands on -- that it never resumes -- is
-    // pinned in the PR that first makes the outcome reachable.
-    'unauthorized' => [ApprovalOutcome::Unauthorized],
+    // `unauthorized` is deliberately absent. It is the one non-approval outcome the console names
+    // rather than returns (ADR 0001 §4, #67): the tests below pin that it never resumes *and* that
+    // it raises the same refusal a Gate denial does, against the real refusing authorizer.
 ]);
 
 it('refuses an unauthorized approver before it can record or resume a decision', function (): void {
@@ -1543,11 +1611,210 @@ it('refuses an unauthorized approver before it can record or resume a decision',
     Http::fake(['*/chat/completions' => Http::sequence()->push($this->toolCallResponse(TOOL_CALL_ID, 'CancelOrderTool', ['order_id' => ORDER_ID]))]);
 
     pauseForApproval((new RoundTripAgent)->forParticipant(new RoundTripCustomer(7)));
+    $refusals = listenForRefusals();
 
     expect(fn () => app(ApprovalResolutionService::class)->approve(StoredPendingApproval::query()->sole(), new GenericUser(['id' => 'operator-1'])))
         ->toThrow(AuthorizationException::class);
     expect(app(RoundTripLedger::class)->executions)->toBe(0)
-        ->and(app(VerdictManager::class)->approvals()->challengeForToolCall(TOOL_CALL_ID))->not->toBeNull();
+        ->and(app(VerdictManager::class)->approvals()->challengeForToolCall(TOOL_CALL_ID))->not->toBeNull()
+        // The console's own layer said no; that is not the two-layer disagreement #67 announces.
+        ->and(count($refusals))->toBe(0)
+        ->and(Incident::query()->where('source', 'approval_decision_refused')->count())->toBe(0);
+});
+
+/**
+ * ADR 0001 §4 (amended for Verdict 0.12): approval authority is authorized twice, by the host both
+ * times. When the console's Gate lets a person click and the host's Verdict authorizer then refuses
+ * them, the two layers disagree — a misconfiguration or an attempt — and the console must name it,
+ * not present it as an unremarkable non-approval.
+ */
+it('names a decision the host authorizer refuses with the same refusal a Gate denial raises', function (bool $approve, ApprovalDecisionKind $kind): void {
+    RefusingDecisionAuthorizer::$consulted = [];
+    Http::fake(['*/chat/completions' => Http::sequence()->push($this->toolCallResponse(TOOL_CALL_ID, 'CancelOrderTool', ['order_id' => ORDER_ID]))]);
+    $toolCallId = pauseForApproval((new RoundTripAgent)->forParticipant(new RoundTripCustomer(7)));
+    $row = StoredPendingApproval::query()->sole();
+    $service = app(ApprovalResolutionService::class);
+    $decide = fn (): ?ApprovalTransition => $approve
+        ? $service->approve($row, new GenericUser(['id' => 'operator-1']))
+        : $service->reject($row, new GenericUser(['id' => 'operator-1']));
+    $refusals = listenForRefusals();
+
+    // The refusal a Gate denial raises, captured rather than re-typed: the two must be identical by
+    // construction, so that which layer refused cannot be learned by comparing error text.
+    Gate::define('approve-verdict-action', fn (): bool => false);
+    $gateRefusal = null;
+
+    try {
+        $decide();
+    } catch (AuthorizationException $e) {
+        $gateRefusal = $e;
+    }
+
+    expect($gateRefusal)->toBeInstanceOf(AuthorizationException::class)
+        // A Gate refusal is the console's own layer saying no; the two layers did not disagree.
+        ->and(Incident::query()->where('source', 'approval_decision_refused')->count())->toBe(0)
+        ->and(count($refusals))->toBe(0);
+
+    // Now the Gate permits and the host's Verdict authorizer refuses.
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    config()->set('verdict.approvals.authorizer', RefusingDecisionAuthorizer::class);
+    app()->instance(ApprovalNotificationRecipients::class, new class implements ApprovalNotificationRecipients
+    {
+        public function forApproval(StoredPendingApproval $approval, ApprovalNotificationKey $key): iterable
+        {
+            return [new RoundTripNotificationRecipient('operator-1')];
+        }
+    });
+    Notification::fake();
+
+    $failure = null;
+
+    try {
+        $decide();
+    } catch (Throwable $e) {
+        $failure = $e;
+    }
+
+    expect(RefusingDecisionAuthorizer::$consulted)->toBe([['kind' => $kind, 'decidedBy' => 'operator-1']],
+        'The refusal must come from Verdict consulting the host authorizer, not from a stub outcome.');
+
+    expect($failure)->toBeInstanceOf(AuthorizationException::class)
+        ->and($failure->getMessage())->toBe($gateRefusal->getMessage());
+
+    // Never resumes, never spends: the receipt is exactly as Verdict left it. The request count is
+    // the pause's single call — a continuation that bypassed the resume-attempt ledger would still
+    // have to talk to the gateway, and that would be a second request.
+    expect(app(RoundTripLedger::class)->executions)->toBe(0)
+        ->and(app(VerdictManager::class)->approvals()->challengeForToolCall($toolCallId))->not->toBeNull()
+        ->and(DB::table($this->approvalReceiptTable())->where('tool_call_id', $toolCallId)->value('status'))->toBe('pending')
+        ->and($row->fresh()->resume_attempts)->toBe(0);
+    Http::assertSentCount(1);
+
+    // Not a decision the console observed, so nothing to tell recipients about.
+    Notification::assertNothingSent();
+
+    // The disagreement between the two authorization layers is announced and kept. The event carries
+    // the row and the typed decision kind — the same shape as ApprovalIngestionIncident — so a host
+    // listener has what it needs without a second lookup.
+    expect(count($refusals))->toBe(1)
+        ->and($refusals[0]->pendingApproval->is($row))->toBeTrue()
+        ->and($refusals[0]->kind)->toBe($kind);
+
+    // The link to the row lives in `context`, not in the ledger's `pending_approval_id` column: that
+    // column sits under a `(source, pending_approval_id)` unique index, which makes it a one-per-row
+    // slot, and a refusal is a per-attempt observation (see the two-attempt test below).
+    $incident = Incident::query()->where('source', 'approval_decision_refused')->sole();
+
+    expect($incident->cause)->toBe(ApprovalOutcome::Unauthorized->value)
+        ->and($incident->context['decision'] ?? null)->toBe($kind->value)
+        ->and($incident->context['tool_call_id'] ?? null)->toBe($toolCallId)
+        ->and($incident->context['pending_approval_id'] ?? null)->toBe($row->id);
+})->with([
+    'approve' => [true, ApprovalDecisionKind::Approve],
+    'reject' => [false, ApprovalDecisionKind::Reject],
+]);
+
+it('records every refused attempt on a row as its own incident', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    // A second, differently named refusing authorizer: the console must react to Verdict's outcome,
+    // never to which class the host happened to configure.
+    config()->set('verdict.approvals.authorizer', ReceiptOwnershipAuthorizer::class);
+    Http::fake(['*/chat/completions' => Http::sequence()->push($this->toolCallResponse(TOOL_CALL_ID, 'CancelOrderTool', ['order_id' => ORDER_ID]))]);
+    pauseForApproval((new RoundTripAgent)->forParticipant(new RoundTripCustomer(7)));
+    $row = StoredPendingApproval::query()->sole();
+
+    ReceiptOwnershipAuthorizer::$consulted = 0;
+    $refusals = listenForRefusals();
+
+    // A refusal is an observation about an attempt, not a state of the row: the second attempt is
+    // the more interesting one to an operator, and it must neither vanish nor crash the console.
+    foreach ([1, 2] as $attempt) {
+        expect(fn () => app(ApprovalResolutionService::class)->approve($row, new GenericUser(['id' => 'operator-1'])))
+            ->toThrow(AuthorizationException::class);
+    }
+
+    $incidents = Incident::query()->where('source', 'approval_decision_refused')->get();
+
+    expect(ReceiptOwnershipAuthorizer::$consulted)->toBe(2, 'Each attempt is Verdict consulting the host, never a cached verdict.')
+        ->and(count($refusals))->toBe(2, 'Every attempt is announced, not only the first.')
+        ->and($refusals[1]->pendingApproval->is($row))->toBeTrue()
+        ->and($refusals[1]->kind)->toBe(ApprovalDecisionKind::Approve)
+        ->and($incidents)->toHaveCount(2)
+        // The relational column is a one-per-row slot under the ledger's unique index; a per-attempt
+        // observation links through context instead, on every row, not merely once the slot is taken.
+        ->and($incidents->pluck('pending_approval_id')->all())->toBe([null, null])
+        ->and($incidents->pluck('context.pending_approval_id')->all())->toBe([$row->id, $row->id])
+        ->and(app(RoundTripLedger::class)->executions)->toBe(0);
+});
+
+it('propagates a host authorizer that throws instead of relabelling it as a refusal', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    config()->set('verdict.approvals.authorizer', FailingDecisionAuthorizer::class);
+    Http::fake(['*/chat/completions' => Http::sequence()->push($this->toolCallResponse(TOOL_CALL_ID, 'CancelOrderTool', ['order_id' => ORDER_ID]))]);
+    $toolCallId = pauseForApproval((new RoundTripAgent)->forParticipant(new RoundTripCustomer(7)));
+    $row = StoredPendingApproval::query()->sole();
+    $refusals = listenForRefusals();
+    FailingDecisionAuthorizer::$thrown = null;
+
+    // Verdict does not catch an authorizer that throws, and neither may the console: a host bug is
+    // not "not yours to decide", and dressing it as one would send an operator to the wrong place.
+    $failure = null;
+
+    try {
+        app(ApprovalResolutionService::class)->approve($row, new GenericUser(['id' => 'operator-1']));
+    } catch (Throwable $e) {
+        $failure = $e;
+    }
+
+    // The very instance the host threw — not a copy, not a wrapper, not a relabelling.
+    expect($failure)->toBe(FailingDecisionAuthorizer::$thrown)
+        ->and($failure)->toBeInstanceOf(HostAuthorizerFailure::class);
+
+    expect(app(RoundTripLedger::class)->executions)->toBe(0)
+        ->and(app(VerdictManager::class)->approvals()->challengeForToolCall($toolCallId))->not->toBeNull()
+        ->and(Incident::query()->where('source', 'approval_decision_refused')->count())->toBe(0)
+        ->and(count($refusals))->toBe(0);
+});
+
+it('announces nothing when the host authorizer permits the decision', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->toolCallResponse(TOOL_CALL_ID, 'CancelOrderTool', ['order_id' => ORDER_ID]))
+            ->push($this->textResponse('Order cancelled.')),
+    ]);
+    pauseForApproval((new RoundTripAgent)->forParticipant(new RoundTripCustomer(7)));
+    $refusals = listenForRefusals();
+
+    // The base environment's allow-all authorizer permits. An implementation that recorded a refusal
+    // before asking Verdict, or announced every decision, would leave a trace here.
+    app(ApprovalResolutionService::class)->approve(StoredPendingApproval::query()->sole(), new GenericUser(['id' => 'operator-1']));
+
+    expect(app(RoundTripLedger::class)->executions)->toBe(1)
+        ->and(count($refusals))->toBe(0)
+        ->and(Incident::query()->where('source', 'approval_decision_refused')->count())->toBe(0);
+});
+
+it('lets a missing Verdict authorizer surface as the configuration error it is', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    config()->set('verdict.approvals.authorizer', null);
+    Http::fake(['*/chat/completions' => Http::sequence()->push($this->toolCallResponse(TOOL_CALL_ID, 'CancelOrderTool', ['order_id' => ORDER_ID]))]);
+    $toolCallId = pauseForApproval((new RoundTripAgent)->forParticipant(new RoundTripCustomer(7)));
+    $row = StoredPendingApproval::query()->sole();
+    $refusals = listenForRefusals();
+    Notification::fake();
+
+    // Nobody refused anything: no authorizer exists to consult. That is a deployment defect the
+    // doctor already prevents, and converting it into a refusal would hide it behind the message
+    // an operator reads as "not yours to decide".
+    expect(fn () => app(ApprovalResolutionService::class)->approve($row, new GenericUser(['id' => 'operator-1'])))
+        ->toThrow(ApprovalAuthorizerMissing::class);
+
+    expect(app(RoundTripLedger::class)->executions)->toBe(0)
+        ->and(app(VerdictManager::class)->approvals()->challengeForToolCall($toolCallId))->not->toBeNull()
+        ->and(Incident::query()->where('source', 'approval_decision_refused')->count())->toBe(0)
+        ->and(count($refusals))->toBe(0);
+    Notification::assertNothingSent();
 });
 
 it('refuses a known unresumable row before it can spend its live receipt', function (): void {


### PR DESCRIPTION
Closes #67.

## Summary
- `ApprovalResolutionService` now treats `ApprovalOutcome::Unauthorized` — the host's Verdict authorizer refusing a decision the console's Gate had already admitted — as a **named refusal**: the same non-disclosing `AuthorizationException` its Gate and scope refusals raise, from one shared constant, so which layer refused cannot be learned by comparing error text.
- A new `ApprovalDecisionRefused` event (row + typed `ApprovalDecisionKind`, the same shape as `ApprovalIngestionIncident`) is projected by `RecordAnomalyIncident` into the durable ledger: **one incident per refused attempt**, `source = approval_decision_refused`, `cause = unauthorized`, linked through `context.pending_approval_id` because the ledger's `(source, pending_approval_id)` unique index makes that column a one-per-row slot.
- Nothing else changes shape: every other non-approval outcome still returns its transition; `ApprovalAuthorizerMissing` and a throwing host authorizer propagate untouched; the receipt is never touched; nothing resumes.

## Why
ADR 0001 §4 (amended for Verdict 0.12) decided this and assigned it to VC-6, which had already closed — so the behaviour existed only in the ADR. #65 pinned the safety half (never resumes); this is the naming half: the two authorization layers disagreeing is a misconfiguration or an attempt, and an operator needs to see it rather than an unremarkable non-approval.

The `'unauthorized'` entry leaves the *never-resumes* dataset because that test asserts an ordinary returned transition and this outcome is now thrown; its never-resumes property is asserted in the new tests against a real refusing authorizer rather than a forced store.

## Test plan
- [x] `composer test` clean: phpstan OK, Pint OK, 100% type coverage, **200 passed / 865 assertions**.
- [x] New behaviour has tests: refusal identical to a Gate refusal for both approve and reject; never resumes, never spends, exactly one gateway request; event and ledger row with the stated shape; one incident and one event **per attempt**, host authorizer consulted per attempt; a permitted decision announces nothing; a Gate refusal and every other non-approval outcome announce nothing; `ApprovalAuthorizerMissing` propagates as itself; a throwing authorizer propagates **the same instance**.

## Notes
The ledger write is synchronous inside the refusal path, so a ledger fault would surface instead of the refusal — the same semantics `ApprovalIngestionIncident` has. Changing that is an operational-policy decision, not part of #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
