### PR TITLE
feat: correlate decision evidence with conversations through a console-owned invocation projection (VC-14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Evidence-to-conversation correlation projection (VC-14).** The console now records each
+  remembered Laravel AI `invocation_id` against its `conversation_id` and can scope the VC-13
+  evidence query by either. `AgentPrompted` and `AgentStreamed` are the capture boundaries: approval
+  events fire afterward in the same gateway call with the same response, so they would only
+  re-observe the completed invocation. This requires the host to run
+  `VerdictProvenanceMiddleware`, which places the invocation context Verdict reads when stamping
+  decision evidence; without it the evidence-side join is empty. A conversation with no remembered
+  invocation is returned as **Unknown**, never mistaken for empty evidence. [#72](https://github.com/fissible/verdict-console/issues/72)
+  tracks doctor findings for a missing middleware or correlation-table migration. **Upgrading:**
+  publish `verdict-console-migrations` and run the new migration; before then, the listener logs an
+  error for each completed turn and continues, and conversations read as **Unknown**.
+
 - **Names a Verdict authorization refusal without spending its receipt (#67).** When Verdict's
   required host `ApprovalDecisionAuthorizer` returns `unauthorized` after the console's own Gate
   permitted an approver, the console now raises the same non-disclosing authorization refusal as

--- a/database/migrations/create_verdict_console_conversation_invocations_table.php.stub
+++ b/database/migrations/create_verdict_console_conversation_invocations_table.php.stub
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Console-owned invocation-to-conversation correlation projection (VC-14, design §6.6).
+ *
+ * **This projects every remembered completion, not pause state.** A deny never pauses, and a resume
+ * is a second invocation; the pause table's invocation_id can therefore record only a pause, not
+ * every completion. This table keeps every invocation that belongs to its remembered conversation,
+ * including one that produced no approval or decision evidence.
+ *
+ * **The invocation id is the primary key because one invocation belongs to one conversation.** A
+ * redelivery therefore collides instead of duplicating the observation, so the first observation
+ * stands. There is no foreign key: an invocation that never paused still belongs to a conversation.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('verdict_console_conversation_invocations', function (Blueprint $table): void {
+            $table->string('invocation_id')->primary();
+            $table->string('conversation_id')->index();
+            $table->timestamp('observed_at');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('verdict_console_conversation_invocations');
+    }
+};

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -300,8 +300,17 @@ Over `DecisionEvidence`, honoring ADR 0008 (fingerprints, not raw), surfacing `c
   empty table that reads as "nothing happened." [`config/verdict.php`]
 - **`DecisionEvidence` has `invocationId` but no `conversationId`.** [`src/Evidence/DecisionEvidence.php`]
   "Filter evidence by conversation" is therefore **not native** — it depends on a console-owned
-  correlation projection (invocationId ↔ conversationId), captured at the `ToolApprovalRequested`
-  boundary where both are present.
+  correlation projection (invocationId ↔ conversationId), captured at the `AgentPrompted` and
+  `AgentStreamed` completion boundaries. The approval events fire after those boundaries in the same
+  gateway call with the same response, so they only re-observe a correlation already recorded. The
+  host must run `VerdictProvenanceMiddleware`: it pushes the `InvocationContext` frame VerdictManager
+  reads when stamping `invocation_id` on decision evidence; without it every decision row carries
+  null and the join is empty. [#72](https://github.com/fissible/verdict-console/issues/72) adds doctor
+  findings for a missing `VerdictProvenanceMiddleware` and an unmigrated correlation table. Until the
+  migration runs, the listener logs an error for each completed turn and continues, and every
+  conversation reads as **Unknown**. The projection retains every remembered invocation, including one
+  that **produced no decision evidence**. A conversation with no remembered invocation is reported as
+  **Unknown**, never as empty.
 
 ### 6.7 Durable incident projection (for the ops health surface)
 A listener persists the ephemeral events into a console-owned incidents table, because they do not

--- a/docs/planning/ISSUES.md
+++ b/docs/planning/ISSUES.md
@@ -338,8 +338,10 @@ from "no rows"; the contract does not import Verdict recorder internals; tested.
 ### VC-14 · Evidence ↔ conversation correlation projection · M · `type:feature` `area:evidence`
 **Deps:** VC-5, VC-13. **Context:** `DecisionEvidence` has `invocationId` but **no** `conversationId`
 (design §6.6), so conversation-scoped evidence is not native.
-**Scope:** capture `invocationId ↔ conversationId` at the `ToolApprovalRequested` boundary into a
-console-owned projection; expose conversation-scoped queries through VC-13.
+**Scope:** capture `invocationId ↔ conversationId` at the `AgentPrompted` and `AgentStreamed`
+completion boundaries into a console-owned projection; expose conversation-scoped queries through
+VC-13. Approval events follow those completions with the same response, so they do not add a new
+correlation observation.
 **Acceptance:** evidence for a conversation is retrievable; a missing mapping degrades explicitly.
 **Refs:** design §6.6; verdict `src/Evidence/DecisionEvidence.php`.
 
@@ -386,6 +388,16 @@ fixture rather than a re-typed literal; exactly one incident row; receipt stays 
 never-resumes dataset stays green.
 **Waiting on Verdict:** nothing.
 ([#67](https://github.com/fissible/verdict-console/issues/67))
+
+### #72 · Doctor correlation-projection prerequisites · S · `type:feature` `area:evidence`
+**Deps:** VC-3, VC-14. **Context:** a missing `VerdictProvenanceMiddleware` leaves Verdict decision
+evidence unstamped, and an unmigrated correlation table makes the completion listener log an error
+per turn while conversations read as `Unknown`.
+**Scope:** add distinct doctor findings for the missing middleware and the unpublished/unmigrated
+correlation-table migration, each naming the corrective host action.
+**Acceptance:** each missing prerequisite produces its own actionable finding; both present is clean.
+**Waiting on Verdict:** nothing.
+([#72](https://github.com/fissible/verdict-console/issues/72))
 
 ### VC-42 · Approval item read-model — live challenge over persisted presentation · M · `type:feature` `area:runtime`
 **Deps:** VC-6, VC-41. **Context:** ADR 0001 §5 — the item renders the ADR 0026 payload **live** from

--- a/src/Evidence/ConversationCorrelation.php
+++ b/src/Evidence/ConversationCorrelation.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Evidence;
+
+/** Whether the console remembers any invocation belonging to the requested conversation. */
+enum ConversationCorrelation: string
+{
+    case Known = 'known';
+    case Unknown = 'unknown';
+}

--- a/src/Evidence/ConversationInvocation.php
+++ b/src/Evidence/ConversationInvocation.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Evidence;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * A row is one remembered Laravel AI invocation and its conversation for evidence correlation.
+ * Rows are never updated: the store preserves the first observation.
+ *
+ * @property string $invocation_id
+ * @property string $conversation_id
+ */
+final class ConversationInvocation extends Model
+{
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $primaryKey = 'invocation_id';
+
+    protected $table = 'verdict_console_conversation_invocations';
+
+    protected $guarded = [];
+}

--- a/src/Evidence/ConversationInvocationStore.php
+++ b/src/Evidence/ConversationInvocationStore.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Evidence;
+
+use Illuminate\Database\UniqueConstraintViolationException;
+
+/** Writes the console's immutable invocation-to-conversation projection without operator scoping. */
+final class ConversationInvocationStore
+{
+    /**
+     * Record an observation, or return the first observation already recorded for the invocation.
+     *
+     * The primary key, rather than a check-then-insert, arbitrates concurrent redelivery. A later
+     * conflicting conversation is evidence of an upstream inconsistency, not permission to rewrite
+     * the historical observation, so the first row always stands.
+     */
+    public function record(string $invocationId, string $conversationId): ConversationInvocation
+    {
+        $now = now();
+
+        try {
+            ConversationInvocation::query()->insert([
+                'invocation_id' => $invocationId,
+                'conversation_id' => $conversationId,
+                'observed_at' => $now,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        } catch (UniqueConstraintViolationException $e) {
+            $existing = ConversationInvocation::query()->whereKey($invocationId)->first();
+
+            if ($existing === null) {
+                throw $e;
+            }
+
+            return $existing;
+        }
+
+        return ConversationInvocation::query()->whereKey($invocationId)->sole();
+    }
+
+    /** @return list<string> */
+    public function invocationIdsFor(string $conversationId): array
+    {
+        return array_values(ConversationInvocation::query()
+            ->where('conversation_id', $conversationId)
+            ->pluck('invocation_id')
+            ->map(static fn (mixed $invocationId): string => (string) $invocationId)
+            ->all());
+    }
+}

--- a/src/Evidence/DatabaseEvidenceQuery.php
+++ b/src/Evidence/DatabaseEvidenceQuery.php
@@ -27,14 +27,27 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
     public function __construct(
         private DatabaseManager $database,
         private Config $config,
+        private ConversationInvocationStore $invocations,
     ) {}
 
     public function search(EvidenceFilter $filter): EvidenceQueryResult
     {
+        $invocationIds = $filter->conversationId === null
+            ? []
+            : $this->invocations->invocationIdsFor($filter->conversationId);
+        // Materialize console-owned ids before querying evidence: verdict.evidence.connection may be
+        // a different connection, across which a SQL subquery cannot be composed.
+        $conversation = $filter->conversationId === null
+            ? null
+            : ($invocationIds === [] ? ConversationCorrelation::Unknown : ConversationCorrelation::Known);
         $recording = $this->recording();
 
         if ($recording['state'] !== EvidenceRecordingState::On) {
-            return new EvidenceQueryResult($recording['state'], [], $recording['writer']);
+            return new EvidenceQueryResult($recording['state'], [], $recording['writer'], $conversation);
+        }
+
+        if ($conversation === ConversationCorrelation::Unknown) {
+            return new EvidenceQueryResult(EvidenceRecordingState::On, [], null, $conversation);
         }
 
         $connection = $this->config->get('verdict.evidence.connection');
@@ -60,6 +73,14 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
             $query->where('recorded_at', '<=', $filter->recordedUntil->setTimezone(new DateTimeZone('UTC')));
         }
 
+        if ($conversation === ConversationCorrelation::Known) {
+            $query->whereIn('invocation_id', $invocationIds);
+        }
+
+        if ($filter->invocationId !== null) {
+            $query->where('invocation_id', $filter->invocationId);
+        }
+
         $records = [];
 
         foreach ($query->orderBy('recorded_at')->orderBy('id')->get() as $row) {
@@ -81,12 +102,13 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
                 rateLimitKeyFingerprint: $this->nullableString($row->rate_limit_key_fingerprint),
                 executionClaimFingerprint: $this->nullableString($row->execution_claim_fingerprint),
                 executionClaimBindingFingerprint: $this->nullableString($row->execution_claim_binding_fingerprint),
+                invocationId: $this->nullableString($row->invocation_id),
                 rateLimitResetAt: $this->nullableDate($row->rate_limit_reset_at),
                 recordedAt: $this->date((string) $row->recorded_at),
             );
         }
 
-        return new EvidenceQueryResult(EvidenceRecordingState::On, $records);
+        return new EvidenceQueryResult(EvidenceRecordingState::On, $records, null, $conversation);
     }
 
     /** @return array{state: EvidenceRecordingState, writer: ?string} */
@@ -125,8 +147,9 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
     private function date(string $value): DateTimeImmutable
     {
         // The published schema is timezone-naive. This adapter treats its values as UTC under
-        // Laravel's shipped UTC default; Verdict 0.12 itself does not normalize every writer to
-        // UTC, so a host that writes this table in another application timezone owns a custom query.
+        // Laravel's shipped UTC default. fissible/verdict#335 shipped this as Verdict 0.13.0's
+        // write-side contract; this package supports ^0.12, so a 0.12 host that writes in another
+        // application timezone owns a custom query.
         return new DateTimeImmutable($value, new DateTimeZone('UTC'));
     }
 }

--- a/src/Evidence/EvidenceFilter.php
+++ b/src/Evidence/EvidenceFilter.php
@@ -14,5 +14,7 @@ final readonly class EvidenceFilter
         public ?string $capability = null,
         public ?DateTimeImmutable $recordedFrom = null,
         public ?DateTimeImmutable $recordedUntil = null,
+        public ?string $conversationId = null,
+        public ?string $invocationId = null,
     ) {}
 }

--- a/src/Evidence/EvidenceQueryResult.php
+++ b/src/Evidence/EvidenceQueryResult.php
@@ -13,5 +13,7 @@ final readonly class EvidenceQueryResult
         public array $records,
         /** The configured writer when evidence is retained somewhere this table adapter cannot read. */
         public ?string $recordedBy = null,
+        /** Null means no conversation filter was requested. */
+        public ?ConversationCorrelation $conversation = null,
     ) {}
 }

--- a/src/Evidence/EvidenceRecord.php
+++ b/src/Evidence/EvidenceRecord.php
@@ -34,6 +34,7 @@ final readonly class EvidenceRecord
         public ?string $rateLimitKeyFingerprint,
         public ?string $executionClaimFingerprint,
         public ?string $executionClaimBindingFingerprint,
+        public ?string $invocationId,
         public ?DateTimeImmutable $rateLimitResetAt,
         public DateTimeImmutable $recordedAt,
     ) {}

--- a/src/Listeners/RecordConversationInvocation.php
+++ b/src/Listeners/RecordConversationInvocation.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Listeners;
+
+use Fissible\VerdictConsole\Evidence\ConversationInvocationStore;
+use Laravel\Ai\Events\AgentPrompted;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Projects remembered completion invocations for evidence correlation.
+ *
+ * `AgentPrompted` and `AgentStreamed` are the boundaries: approval events fire later in the same
+ * gateway call with the same response, so observing them would only repeat a completion already
+ * recorded here. Completion also covers invocations that never pause and therefore never emit one.
+ */
+final readonly class RecordConversationInvocation
+{
+    public function __construct(
+        private ConversationInvocationStore $invocations,
+        private LoggerInterface $logger,
+    ) {}
+
+    public function handle(AgentPrompted $event): void
+    {
+        $conversationId = $event->response->conversationId;
+
+        if ($conversationId === null) {
+            return;
+        }
+
+        try {
+            $row = $this->invocations->record($event->invocationId, $conversationId);
+        } catch (Throwable $e) {
+            // This is a read-model write: losing it must never change the agent's response.
+            $this->logger->error('Verdict Console could not record an invocation conversation correlation.', [
+                'invocation_id' => $event->invocationId,
+                'exception' => $e::class,
+            ]);
+
+            return;
+        }
+
+        if ($row->conversation_id !== $conversationId) {
+            $this->logger->warning('Verdict Console observed conflicting conversations for an invocation.', [
+                'invocation_id' => $event->invocationId,
+                'recorded_conversation_id' => $row->conversation_id,
+                'observed_conversation_id' => $conversationId,
+            ]);
+        }
+    }
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -29,11 +29,14 @@ use Fissible\VerdictConsole\Listeners\IngestToolApprovalRequests;
 use Fissible\VerdictConsole\Listeners\LogApprovalIngestionIncident;
 use Fissible\VerdictConsole\Listeners\NotifyApprovalResumeOutcome;
 use Fissible\VerdictConsole\Listeners\RecordAnomalyIncident;
+use Fissible\VerdictConsole\Listeners\RecordConversationInvocation;
 use Fissible\VerdictConsole\Notifications\UnconfiguredApprovalNotificationRecipients;
 use Fissible\VerdictConsole\Participants\UnconfiguredConversationParticipants;
 use Fissible\VerdictConsole\Presentation\DefaultApprovalPresenter;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Ai\Events\AgentPrompted;
+use Laravel\Ai\Events\AgentStreamed;
 use Laravel\Ai\Events\ToolApprovalRequested;
 use Laravel\Ai\Events\ToolApprovalResolved;
 
@@ -82,6 +85,10 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         // It must precede the console-only guard: approvals are ingested on ordinary web requests.
         $events->listen(ToolApprovalRequested::class, IngestToolApprovalRequests::class);
         $events->listen(ToolApprovalResolved::class, NotifyApprovalResumeOutcome::class);
+        // Laravel's dispatcher matches an event's class and interfaces, not its parent classes, so
+        // AgentStreamed must be explicit despite extending AgentPrompted.
+        $events->listen(AgentPrompted::class, RecordConversationInvocation::class);
+        $events->listen(AgentStreamed::class, RecordConversationInvocation::class);
 
         $events->listen(ConsequentialActionUnrecorded::class, RecordAnomalyIncident::class);
         $events->listen(EvidenceWriteFailed::class, RecordAnomalyIncident::class);
@@ -130,6 +137,9 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
             ),
             __DIR__.'/../database/migrations/create_verdict_console_incidents_table.php.stub' => database_path(
                 'migrations/2026_08_25_000004_create_verdict_console_incidents_table.php',
+            ),
+            __DIR__.'/../database/migrations/create_verdict_console_conversation_invocations_table.php.stub' => database_path(
+                'migrations/2026_08_29_000001_create_verdict_console_conversation_invocations_table.php',
             ),
         ], ['verdict-console', 'verdict-console-migrations']);
     }

--- a/tests/EndToEnd/EvidenceCorrelationTest.php
+++ b/tests/EndToEnd/EvidenceCorrelationTest.php
@@ -1,0 +1,379 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Actions\ActionContext;
+use Fissible\Verdict\Actions\ActionEnvelope;
+use Fissible\Verdict\Actions\AuthorizedAction;
+use Fissible\Verdict\Capabilities\Capability;
+use Fissible\Verdict\Capabilities\CapabilityRegistry;
+use Fissible\Verdict\Context\DataClass;
+use Fissible\Verdict\Context\Trust;
+use Fissible\Verdict\Contracts\CapabilityAuthorizer;
+use Fissible\Verdict\Decisions\Decision;
+use Fissible\Verdict\Evidence\DatabaseEvidenceRecorder;
+use Fissible\Verdict\Evidence\ProvenanceLedger;
+use Fissible\Verdict\LaravelAi\VerdictApprovalMiddleware;
+use Fissible\Verdict\LaravelAi\VerdictProvenanceMiddleware;
+use Fissible\Verdict\Targets\ExecutionTargetPolicy;
+use Fissible\Verdict\VerdictManager;
+use Fissible\VerdictConsole\Contracts\EvidenceQuery;
+use Fissible\VerdictConsole\Evidence\ConversationCorrelation;
+use Fissible\VerdictConsole\Evidence\ConversationInvocationStore;
+use Fissible\VerdictConsole\Evidence\EvidenceFilter;
+use Fissible\VerdictConsole\Evidence\EvidenceRecord;
+use Fissible\VerdictConsole\Evidence\EvidenceRecordingState;
+use Fissible\VerdictConsole\Tests\EndToEndTestCase;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Approvals\Decision as AiDecision;
+use Laravel\Ai\Approvals\Decisions;
+use Laravel\Ai\Concerns\RemembersConversations as RemembersConversationsTrait;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasMiddleware;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Contracts\RemembersConversations as RemembersConversationsContract;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Tools\Request;
+
+/**
+ * The positive control for VC-14.
+ *
+ * The Feature suite proves the listener handles events it is handed. This file proves the events
+ * Laravel AI actually dispatches carry both ids at the moment they fire, and that the invocation id
+ * Verdict stamps on decision evidence is the same one those events publish — the two facts the
+ * whole projection rests on, and neither is provable from a constructed event.
+ *
+ * Fixtures are deliberately separate from the approval round trip's: a test file must not depend
+ * on classes another test file happens to have declared first.
+ */
+const CORRELATION_ORDER_ID = 4242;
+
+final class CorrelationLedger
+{
+    public int $executions = 0;
+}
+
+final readonly class CorrelationOrder
+{
+    public function __construct(public int $id) {}
+}
+
+final readonly class CorrelationCustomer
+{
+    public function __construct(public int $id) {}
+}
+
+final class CorrelationCancelOrderTool implements Tool
+{
+    public function description(): Stringable|string
+    {
+        return 'Cancel an order by id.';
+    }
+
+    public function handle(Request $request): Stringable|string
+    {
+        return 'The Verdict-bound tool handles this.';
+    }
+
+    /** @return array<string, Type> */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}
+
+/** The execution-target policy is what makes `requiresConfirmation()` pause rather than return null. */
+function correlationBoundTool(): Tool
+{
+    $verdict = app(VerdictManager::class);
+
+    if (! app(CapabilityRegistry::class)->has('orders.cancel')) {
+        $verdict->capability(
+            Capability::usingPolicy(
+                name: 'orders.cancel',
+                ability: 'update',
+                resolveTarget: fn (ActionEnvelope $e): CorrelationOrder => new CorrelationOrder(
+                    (int) $e->proposal->arguments['order_id'],
+                ),
+            )
+                ->executionTarget(ExecutionTargetPolicy::acceptStaleSnapshot(
+                    name: 'correlation-target',
+                    identityUsing: fn (ActionEnvelope $e, CorrelationOrder $t): array => ['id' => $t->id],
+                ))
+                ->requiresConfirmation(fn (ActionEnvelope $e, CorrelationOrder $t): array => ['order_id' => $t->id])
+                ->executeUsing(function (AuthorizedAction $a): string {
+                    app(CorrelationLedger::class)->executions++;
+
+                    return 'Order cancelled.';
+                }),
+        );
+    }
+
+    return $verdict->bound(new CorrelationCancelOrderTool, 'orders.cancel', new ActionContext('customer-7'));
+}
+
+/**
+ * `VerdictProvenanceMiddleware` is the declaration this projection depends on and the approval round
+ * trip does not need: it is what pushes the invocation frame `VerdictManager` reads when it stamps
+ * `invocation_id` on decision evidence. Without it every decision row carries null there, and a
+ * correlated conversation has nothing to join.
+ */
+final class CorrelationAgent implements Agent, HasMiddleware, HasTools, RemembersConversationsContract
+{
+    use Promptable;
+    use RemembersConversationsTrait;
+
+    public function instructions(): Stringable|string
+    {
+        return 'Cancel orders when asked.';
+    }
+
+    /** @return array<int, Tool> */
+    public function tools(): array
+    {
+        return [correlationBoundTool()];
+    }
+
+    /** @return array<int, object> */
+    public function middleware(): array
+    {
+        return [
+            app(VerdictApprovalMiddleware::class),
+            new VerdictProvenanceMiddleware(app(ProvenanceLedger::class), Trust::Untrusted, DataClass::Internal),
+        ];
+    }
+
+    public function provider(): string
+    {
+        return EndToEndTestCase::PROVIDER;
+    }
+
+    public function maxSteps(): int
+    {
+        return 3;
+    }
+}
+
+beforeEach(function (): void {
+    $this->migrateRoundTripTables();
+
+    $console = dirname(__DIR__, 2).'/database/migrations';
+    (require $console.'/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require $console.'/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require $console.'/create_verdict_console_approval_notifications_table.php.stub')->up();
+    (require $console.'/create_verdict_console_approval_reconciliations_table.php.stub')->up();
+    (require $console.'/create_verdict_console_conversation_invocations_table.php.stub')->up();
+
+    $verdict = dirname(__DIR__, 2).'/vendor/fissible/verdict/database/migrations';
+    foreach ([
+        'create_verdict_evidence_table.php.stub',
+        'add_provenance_to_verdict_evidence_table.php.stub',
+        'add_invocation_id_to_verdict_evidence_table.php.stub',
+        'add_tool_kind_to_verdict_evidence_table.php.stub',
+        'add_configuration_fingerprint_to_verdict_evidence_table.php.stub',
+        'add_actor_and_subject_fingerprints_to_verdict_evidence_table.php.stub',
+        'add_target_source_to_verdict_evidence_table.php.stub',
+        'add_tool_description_fingerprints_to_verdict_evidence_table.php.stub',
+        'add_record_identity_to_verdict_evidence_table.php.stub',
+        'create_verdict_provenance_derivations_table.php.stub',
+    ] as $migration) {
+        (require $verdict.'/'.$migration)->up();
+    }
+
+    // A real durable recorder, so the join has a right-hand side. Verdict's default records nothing.
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+
+    $this->app->instance(CorrelationLedger::class, new CorrelationLedger);
+    $this->app->instance(CapabilityAuthorizer::class, new class implements CapabilityAuthorizer
+    {
+        public function decide(Capability $capability, ActionEnvelope $envelope, mixed $target): Decision
+        {
+            return Decision::permit('test');
+        }
+    });
+});
+
+/** @return list<string> */
+function correlationDispositions(EvidenceRecord ...$records): array
+{
+    return array_values(array_unique(array_map(fn (EvidenceRecord $record): string => $record->disposition, $records)));
+}
+
+/** @return list<EvidenceRecord> */
+function correlationRecordsUnder(string $invocationId, EvidenceRecord ...$records): array
+{
+    return array_values(array_filter($records, fn (EvidenceRecord $record): bool => $record->invocationId === $invocationId));
+}
+
+/**
+ * What Verdict itself wrote, read raw: the invocation ids on its decision rows. The projection is
+ * only as good as this column, and a query that fabricated or over-supplied ids would still return
+ * records — so the join's right-hand side is asserted directly, not inferred from a result.
+ *
+ * @return list<string|null>
+ */
+function rawDecisionInvocationIds(): array
+{
+    return DB::table('verdict_evidence')->where('record_type', 'decision')->distinct()->pluck('invocation_id')->all();
+}
+
+/**
+ * A Chat Completions SSE body: one streamed tool call, or one streamed text reply.
+ *
+ * @param  array<string, mixed>|null  $toolCall  ['id' => ..., 'name' => ..., 'arguments' => [...]]
+ */
+function correlationStreamBody(?array $toolCall, ?string $text = null): string
+{
+    $delta = $toolCall === null
+        ? ['content' => $text]
+        : ['tool_calls' => [['index' => 0, 'id' => $toolCall['id'], 'type' => 'function', 'function' => ['name' => $toolCall['name'], 'arguments' => json_encode($toolCall['arguments'])]]]];
+    $finish = $toolCall === null ? 'stop' : 'tool_calls';
+
+    $chunks = [
+        ['model' => EndToEndTestCase::MODEL, 'choices' => [['index' => 0, 'delta' => $delta, 'finish_reason' => null]]],
+        ['model' => EndToEndTestCase::MODEL, 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => $finish]]],
+        ['model' => EndToEndTestCase::MODEL, 'choices' => [], 'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2]],
+    ];
+
+    return implode('', array_map(fn (array $chunk): string => 'data: '.json_encode($chunk)."\n\n", $chunks))."data: [DONE]\n\n";
+}
+
+it('correlates the pause and the resume of an approved action with their conversation', function (): void {
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->toolCallResponse('call_correlated', 'CorrelationCancelOrderTool', ['order_id' => CORRELATION_ORDER_ID]))
+            ->push($this->textResponse('Order cancelled.')),
+    ]);
+
+    $agent = new CorrelationAgent;
+
+    $paused = $agent->prompt('Please cancel order '.CORRELATION_ORDER_ID.'.');
+
+    expect($paused->hasPendingApprovals())->toBeTrue('A confirmation-gated capability must pause the run.')
+        ->and($paused->conversationId)->not->toBeNull('A paused turn is always remembered, so the pause carries a conversation.');
+
+    $approvals = app(VerdictManager::class)->approvals();
+    $challenge = $approvals->challengeForToolCall($paused->pendingApprovals->first()->id);
+
+    expect($challenge)->not->toBeNull();
+
+    $approvals->approve($challenge->receiptId, $challenge->toolCallId, 'operator-1');
+
+    $resumed = $agent->prompt(Decisions::from([$challenge->toolCallId => AiDecision::approve()]));
+
+    expect(app(CorrelationLedger::class)->executions)->toBe(1)
+        ->and($resumed->conversationId)->toBe($paused->conversationId)
+        ->and($resumed->invocationId)->not->toBe($paused->invocationId, 'Laravel AI mints a fresh invocation id for the resume; the projection must hold both.');
+
+    expect(app(ConversationInvocationStore::class)->invocationIdsFor($paused->conversationId))
+        ->toEqualCanonicalizing([$paused->invocationId, $resumed->invocationId]);
+
+    $result = app(EvidenceQuery::class)->search(new EvidenceFilter(conversationId: $paused->conversationId));
+
+    expect(rawDecisionInvocationIds())->toEqualCanonicalizing([$paused->invocationId, $resumed->invocationId]);
+
+    $underResume = correlationRecordsUnder($resumed->invocationId, ...$result->records);
+
+    expect($result->recording)->toBe(EvidenceRecordingState::On)
+        ->and($result->conversation)->toBe(ConversationCorrelation::Known)
+        ->and($result->records)->toHaveCount(count(DB::table('verdict_evidence')->where('record_type', 'decision')->get()))
+        ->and(correlationDispositions(...correlationRecordsUnder($paused->invocationId, ...$result->records)))
+        ->toContain('require_confirmation', 'The pause decision is recorded under the invocation that paused.')
+        ->and($underResume)->not->toBeEmpty('The approved execution is decided under the resume\'s invocation id; a conversation view that omitted it would omit the decision the approval was about.')
+        ->and(array_filter($underResume, fn (EvidenceRecord $record): bool => $record->stage === 'execution' && $record->disposition === 'permit'))
+        ->not->toBeEmpty('The execution-stage permit is the decision the approval was for.');
+
+    foreach ($result->records as $record) {
+        expect($record->invocationId)->toBeIn([$paused->invocationId, $resumed->invocationId]);
+    }
+
+    $unseen = app(EvidenceQuery::class)->search(new EvidenceFilter(conversationId: 'conversation-never-seen'));
+
+    expect($unseen->recording)->toBe(EvidenceRecordingState::On)
+        ->and($unseen->conversation)->toBe(ConversationCorrelation::Unknown)
+        ->and($unseen->records)->toBe([]);
+});
+
+/**
+ * A Deny never pauses, so it never reaches the approval events. If the ordinary completion were not
+ * a capture boundary, the one disposition an auditor most wants to see per conversation would be
+ * the one a conversation view could never show.
+ */
+it('correlates a denied action that never paused with the conversation it was refused in', function (): void {
+    $this->app->instance(CapabilityAuthorizer::class, new class implements CapabilityAuthorizer
+    {
+        public function decide(Capability $capability, ActionEnvelope $envelope, mixed $target): Decision
+        {
+            return Decision::deny('Not this customer\'s order.');
+        }
+    });
+
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->toolCallResponse('call_refused', 'CorrelationCancelOrderTool', ['order_id' => CORRELATION_ORDER_ID]))
+            ->push($this->textResponse('I cannot cancel that order.')),
+    ]);
+
+    // A participant makes the turn remembered without a pause, which is what gives it a conversation.
+    $response = (new CorrelationAgent)->forParticipant(new CorrelationCustomer(7))->prompt('Please cancel order '.CORRELATION_ORDER_ID.'.');
+
+    expect($response->hasPendingApprovals())->toBeFalse()
+        ->and(app(CorrelationLedger::class)->executions)->toBe(0)
+        ->and($response->conversationId)->not->toBeNull();
+
+    $result = app(EvidenceQuery::class)->search(new EvidenceFilter(conversationId: $response->conversationId));
+
+    expect(rawDecisionInvocationIds())->toBe([$response->invocationId])
+        ->and($result->conversation)->toBe(ConversationCorrelation::Known)
+        ->and(correlationDispositions(...$result->records))->toContain('deny');
+
+    foreach ($result->records as $record) {
+        expect($record->invocationId)->toBe($response->invocationId);
+    }
+});
+
+/**
+ * Streaming is the flagship surface's path (design §8), and it reports completion through
+ * `AgentStreamed`, a subclass Laravel's dispatcher does not fold into `AgentPrompted`. The event
+ * fires from a completion callback registered after the conversation middleware's own, on the same
+ * response object — this proves that ordering against the real stream rather than from a reading
+ * of it, and that Verdict's streamed invocation frame stamps the decision made during iteration.
+ */
+it('correlates a streamed run through its own completion event', function (): void {
+    $this->app->instance(CapabilityAuthorizer::class, new class implements CapabilityAuthorizer
+    {
+        public function decide(Capability $capability, ActionEnvelope $envelope, mixed $target): Decision
+        {
+            return Decision::deny('Not this customer\'s order.');
+        }
+    });
+
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push(correlationStreamBody(['id' => 'call_streamed', 'name' => 'CorrelationCancelOrderTool', 'arguments' => ['order_id' => CORRELATION_ORDER_ID]]))
+            ->push(correlationStreamBody(null, 'I cannot cancel that order.')),
+    ]);
+
+    $stream = (new CorrelationAgent)->forParticipant(new CorrelationCustomer(7))->stream('Please cancel order '.CORRELATION_ORDER_ID.'.');
+
+    foreach ($stream as $event) {
+        // Consume; the completion callbacks fire only once the stream has been iterated.
+    }
+
+    expect($stream->conversationId)->not->toBeNull('A remembered streamed turn carries its conversation once complete.')
+        ->and(app(CorrelationLedger::class)->executions)->toBe(0)
+        ->and(rawDecisionInvocationIds())->toBe([$stream->invocationId]);
+
+    $result = app(EvidenceQuery::class)->search(new EvidenceFilter(conversationId: $stream->conversationId));
+
+    expect($result->conversation)->toBe(ConversationCorrelation::Known)
+        ->and(correlationDispositions(...$result->records))->toContain('deny');
+
+    foreach ($result->records as $record) {
+        expect($record->invocationId)->toBe($stream->invocationId);
+    }
+});

--- a/tests/EndToEnd/EvidenceCorrelationTest.php
+++ b/tests/EndToEnd/EvidenceCorrelationTest.php
@@ -166,7 +166,6 @@ beforeEach(function (): void {
     (require $console.'/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
     (require $console.'/create_verdict_console_approval_notifications_table.php.stub')->up();
     (require $console.'/create_verdict_console_approval_reconciliations_table.php.stub')->up();
-    (require $console.'/create_verdict_console_conversation_invocations_table.php.stub')->up();
 
     $verdict = dirname(__DIR__, 2).'/vendor/fissible/verdict/database/migrations';
     foreach ([
@@ -281,8 +280,9 @@ it('correlates the pause and the resume of an approved action with their convers
     expect($result->recording)->toBe(EvidenceRecordingState::On)
         ->and($result->conversation)->toBe(ConversationCorrelation::Known)
         ->and($result->records)->toHaveCount(count(DB::table('verdict_evidence')->where('record_type', 'decision')->get()))
+        // The pause decision is recorded under the invocation that paused.
         ->and(correlationDispositions(...correlationRecordsUnder($paused->invocationId, ...$result->records)))
-        ->toContain('require_confirmation', 'The pause decision is recorded under the invocation that paused.')
+        ->toContain('require_confirmation')
         ->and($underResume)->not->toBeEmpty('The approved execution is decided under the resume\'s invocation id; a conversation view that omitted it would omit the decision the approval was about.')
         ->and(array_filter($underResume, fn (EvidenceRecord $record): bool => $record->stage === 'execution' && $record->disposition === 'permit'))
         ->not->toBeEmpty('The execution-stage permit is the decision the approval was for.');

--- a/tests/EndToEndTestCase.php
+++ b/tests/EndToEndTestCase.php
@@ -71,7 +71,10 @@ abstract class EndToEndTestCase extends IntegrationTestCase
      *
      * Verdict's shipped default approval store is the *database* one, and Laravel AI reconstructs a
      * paused tool call from conversation history — so both sets of tables are preconditions of the
-     * round trip, not test scaffolding.
+     * round trip, not test scaffolding. The console's own projections that listen to every run —
+     * incidents, and the invocation ↔ conversation correlation — belong here for the same reason: a
+     * completed prompt writes to them, and a suite that forgot one would log a projection failure on
+     * every turn.
      */
     protected function migrateRoundTripTables(): void
     {
@@ -83,6 +86,7 @@ abstract class EndToEndTestCase extends IntegrationTestCase
         (require $verdict.'/add_approval_context_to_verdict_approval_receipts_table.php.stub')->up();
         (require $ai.'/2026_01_11_000001_create_agent_conversations_table.php')->up();
         (require dirname(__DIR__).'/database/migrations/create_verdict_console_incidents_table.php.stub')->up();
+        (require dirname(__DIR__).'/database/migrations/create_verdict_console_conversation_invocations_table.php.stub')->up();
     }
 
     /**

--- a/tests/Feature/ConversationInvocationListenerTest.php
+++ b/tests/Feature/ConversationInvocationListenerTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\VerdictConsole\Contracts\EvidenceQuery;
+use Fissible\VerdictConsole\Evidence\ConversationCorrelation;
+use Fissible\VerdictConsole\Evidence\EvidenceFilter;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Events\AgentPrompted;
+use Laravel\Ai\Events\AgentStreamed;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Prompts\AgentPrompt;
+use Laravel\Ai\Responses\AgentResponse;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\StreamedAgentResponse;
+
+const CORRELATION_TABLE = 'verdict_console_conversation_invocations';
+
+/**
+ * Every event here is dispatched for real, through the application's dispatcher. Nothing else in
+ * this package listens to `AgentPrompted` or `AgentStreamed`, so a recorded row proves both that the
+ * listener is registered for that event and that it handled it; the approval events are not
+ * registered at all, because both fire after the completion event in the same gateway call with
+ * the same response, and would only observe what was already recorded.
+ */
+beforeEach(function (): void {
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_conversation_invocations_table.php.stub')->up();
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists(CORRELATION_TABLE);
+});
+
+/** Never prompted: the events below are constructed, not produced, so the agent is only an identity. */
+function correlationFixtureAgent(): Agent
+{
+    return new class implements Agent
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'A correlation fixture.';
+        }
+    };
+}
+
+function correlationFixturePrompt(Agent $agent): AgentPrompt
+{
+    return new AgentPrompt($agent, 'Cancel the order.', [], Mockery::mock(TextProvider::class), 'fixture-model');
+}
+
+function correlationFixtureResponse(string $invocationId, ?string $conversationId): AgentResponse
+{
+    $response = new AgentResponse($invocationId, 'Done.', new Usage, new Meta);
+
+    return $conversationId === null ? $response : $response->withinConversation($conversationId);
+}
+
+/** @return array<string, string> invocation id => conversation id, in invocation order */
+function recordedCorrelations(): array
+{
+    return DB::table(CORRELATION_TABLE)->orderBy('invocation_id')->pluck('conversation_id', 'invocation_id')->all();
+}
+
+/**
+ * The ordinary completion is the boundary that makes the projection complete: a denied or permitted
+ * action never pauses, so an approval-only capture would leave every Deny in a conversation
+ * uncorrelated. A redelivery of the same completion is the same fact.
+ */
+it('records the conversation an ordinary prompt completed in, once per invocation', function (): void {
+    Log::spy();
+    $agent = correlationFixtureAgent();
+
+    event(new AgentPrompted('invocation-1', correlationFixturePrompt($agent), correlationFixtureResponse('invocation-1', 'conversation-a')));
+    event(new AgentPrompted('invocation-1', correlationFixturePrompt($agent), correlationFixtureResponse('invocation-1', 'conversation-a')));
+
+    expect(recordedCorrelations())->toBe(['invocation-1' => 'conversation-a']);
+    Log::shouldNotHaveReceived('warning');
+    Log::shouldNotHaveReceived('error');
+});
+
+/**
+ * `AgentStreamed extends AgentPrompted`, and Laravel's dispatcher resolves listeners by the event's
+ * own class and its interfaces — never its parents. A listener registered for `AgentPrompted` alone
+ * would leave every streamed conversation uncorrelated while every test that constructs the parent
+ * event stayed green. This is the test that notices.
+ */
+it('records a streamed completion, which Laravel AI reports through a subclass', function (): void {
+    $agent = correlationFixtureAgent();
+    $response = (new StreamedAgentResponse('invocation-2', collect(), new Meta))->withinConversation('conversation-a');
+
+    event(new AgentStreamed('invocation-2', correlationFixturePrompt($agent), $response));
+
+    expect(recordedCorrelations())->toBe(['invocation-2' => 'conversation-a']);
+});
+
+/** An agent that does not remember conversations has nothing to correlate, and that is routine. */
+it('records nothing and reports nothing when an invocation has no conversation', function (): void {
+    Log::spy();
+    $agent = correlationFixtureAgent();
+
+    event(new AgentPrompted('invocation-3', correlationFixturePrompt($agent), correlationFixtureResponse('invocation-3', null)));
+    event(new AgentStreamed('invocation-4', correlationFixturePrompt($agent), new StreamedAgentResponse('invocation-4', collect(), new Meta)));
+
+    expect(recordedCorrelations())->toBe([]);
+    Log::shouldNotHaveReceived('warning');
+    Log::shouldNotHaveReceived('error');
+});
+
+it('keeps the first conversation and warns when a later event disagrees about an invocation', function (): void {
+    Log::spy();
+    $agent = correlationFixtureAgent();
+
+    event(new AgentPrompted('invocation-5', correlationFixturePrompt($agent), correlationFixtureResponse('invocation-5', 'conversation-a')));
+    event(new AgentPrompted('invocation-5', correlationFixturePrompt($agent), correlationFixtureResponse('invocation-5', 'conversation-b')));
+
+    expect(recordedCorrelations())->toBe(['invocation-5' => 'conversation-a']);
+    Log::shouldHaveReceived('warning')
+        ->once()
+        ->withArgs(fn (string $message, array $context): bool => in_array('invocation-5', $context, true)
+            && in_array('conversation-a', $context, true)
+            && in_array('conversation-b', $context, true));
+});
+
+/**
+ * The projection is a read-model, not authority. A host that has not published this migration, or
+ * whose console database is unreachable, must still get its agent's answer. What it gets later is
+ * the explicit degradation: the conversation is reported as unknown, never as empty.
+ */
+it('logs an error, lets the run continue, and later reports the conversation as unknown when the projection cannot be written', function (): void {
+    Schema::drop(CORRELATION_TABLE);
+    Log::spy();
+    $agent = correlationFixtureAgent();
+
+    event(new AgentPrompted('invocation-6', correlationFixturePrompt($agent), correlationFixtureResponse('invocation-6', 'conversation-a')));
+
+    Log::shouldHaveReceived('error')
+        ->once()
+        ->withArgs(fn (string $message, array $context): bool => in_array('invocation-6', $context, true));
+
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_conversation_invocations_table.php.stub')->up();
+
+    expect(app(EvidenceQuery::class)->search(new EvidenceFilter(conversationId: 'conversation-a'))->conversation)
+        ->toBe(ConversationCorrelation::Unknown);
+});

--- a/tests/Feature/ConversationInvocationStoreTest.php
+++ b/tests/Feature/ConversationInvocationStoreTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\VerdictConsole\Evidence\ConversationInvocation;
+use Fissible\VerdictConsole\Evidence\ConversationInvocationStore;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function (): void {
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_conversation_invocations_table.php.stub')->up();
+
+    $this->store = new ConversationInvocationStore;
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists('verdict_console_conversation_invocations');
+});
+
+it('records which conversation an invocation belonged to', function (): void {
+    $row = $this->store->record('invocation-1', 'conversation-a');
+
+    expect($row)->toBeInstanceOf(ConversationInvocation::class)
+        ->and($row->invocation_id)->toBe('invocation-1')
+        ->and($row->conversation_id)->toBe('conversation-a')
+        ->and(DB::table('verdict_console_conversation_invocations')->count())->toBe(1);
+});
+
+/**
+ * The schema is the projection's whole invariant: one row per invocation, findable by conversation.
+ * Publishing a migration proves nothing about what it creates, so the constraint is exercised with
+ * a raw duplicate rather than trusted, and the lookup index is read back rather than assumed.
+ */
+it('constrains the table to one row per invocation and indexes the conversation lookup', function (): void {
+    $this->store->record('invocation-1', 'conversation-a');
+
+    /** @var array<string, mixed> $standing */
+    $standing = (array) DB::table('verdict_console_conversation_invocations')->sole();
+
+    expect(fn () => DB::table('verdict_console_conversation_invocations')->insert([...$standing, 'conversation_id' => 'conversation-b']))
+        ->toThrow(UniqueConstraintViolationException::class);
+
+    $indexes = collect(Schema::getIndexes('verdict_console_conversation_invocations'));
+
+    expect($indexes->contains(fn (array $index): bool => $index['columns'] === ['invocation_id'] && ($index['primary'] || $index['unique'])))
+        ->toBeTrue('invocation_id must be the primary or a unique key; it is what makes a second observation collide.')
+        ->and($indexes->contains(fn (array $index): bool => ($index['columns'][0] ?? null) === 'conversation_id'))
+        ->toBeTrue('conversation lookups must not scan the table.');
+});
+
+/**
+ * Laravel AI publishes the same invocation more than once — a streamed and a non-streamed
+ * completion each fire once, but a queue can redeliver — and every observation of one fact is one
+ * row. This is sequential redelivery, not a race: the atomicity argument is the unique key the
+ * previous test pins, and a genuine multi-process race is outside this suite.
+ */
+it('keeps one row when the same invocation is observed again under the same conversation', function (): void {
+    $first = $this->store->record('invocation-1', 'conversation-a');
+    $again = $this->store->record('invocation-1', 'conversation-a');
+
+    expect($again->conversation_id)->toBe($first->conversation_id)
+        ->and(DB::table('verdict_console_conversation_invocations')->count())->toBe(1);
+});
+
+/**
+ * An invocation belongs to exactly one conversation. A later observation that disagrees is an
+ * upstream inconsistency the store surfaces rather than resolves: it hands back the row that
+ * already stands, so the caller can see the disagreement, and never overwrites the first
+ * observation with the second.
+ */
+it('keeps the first conversation when a later observation names a different one', function (): void {
+    $this->store->record('invocation-1', 'conversation-a');
+
+    $row = $this->store->record('invocation-1', 'conversation-b');
+
+    expect($row->conversation_id)->toBe('conversation-a')
+        ->and(DB::table('verdict_console_conversation_invocations')->pluck('conversation_id')->all())->toBe(['conversation-a']);
+});
+
+it('lists every invocation observed for a conversation and nothing for an unknown one', function (): void {
+    $this->store->record('invocation-1', 'conversation-a');
+    $this->store->record('invocation-2', 'conversation-a');
+    $this->store->record('invocation-3', 'conversation-b');
+
+    expect($this->store->invocationIdsFor('conversation-a'))->toEqualCanonicalizing(['invocation-1', 'invocation-2'])
+        ->and($this->store->invocationIdsFor('conversation-b'))->toBe(['invocation-3'])
+        ->and($this->store->invocationIdsFor('conversation-never-seen'))->toBe([]);
+});

--- a/tests/Feature/DocumentationCorrectionsTest.php
+++ b/tests/Feature/DocumentationCorrectionsTest.php
@@ -35,6 +35,36 @@ it('distinguishes durable presentation from live challenge rendering', function 
         ->toContain('does not initiate a second context release');
 });
 
+/**
+ * Design §6.6 placed the correlation capture at the `ToolApprovalRequested` boundary. Building it
+ * showed that boundary alone omits every decision that never paused and the resume's own
+ * invocation; that the completion events precede every approval event with the same response, so
+ * they are the boundary; that the join is empty unless the host runs the middleware that stamps
+ * invocation ids on Verdict's evidence; and that the projection therefore retains every remembered
+ * invocation, decision or not. The design of record must say all four.
+ */
+it('records in the design which boundaries feed the conversation correlation and what it depends on', function (): void {
+    $design = documentation('docs/design/0001-verdict-console-design.md');
+
+    expect($design)
+        ->toContain('`AgentPrompted`')
+        ->toContain('`AgentStreamed`')
+        ->toContain('`VerdictProvenanceMiddleware`')
+        ->toContain('produced no decision evidence')
+        ->not->toContain('captured at the `ToolApprovalRequested`');
+
+    // The issue plan is what an implementer reads first; it must not still prescribe the boundary
+    // the design has corrected.
+    expect(documentation('docs/planning/ISSUES.md'))
+        ->toContain('`AgentPrompted`')
+        ->not->toContain('at the `ToolApprovalRequested` boundary');
+});
+
+/** Folded in from the VC-13 review: the UTC reading is a contract from verdict#335 onward, not a hope. */
+it('cites the Verdict change that makes the evidence timestamp reading a UTC contract', function (): void {
+    expect(documentation('src/Evidence/DatabaseEvidenceQuery.php'))->toContain('fissible/verdict#335');
+});
+
 it('tells adopters that require_review awaits its gated Verdict substrate', function (): void {
     expect(documentation('README.md'))
         ->toContain('`require_review` is a separate, gated review lane')

--- a/tests/Feature/EvidenceQueryTest.php
+++ b/tests/Feature/EvidenceQueryTest.php
@@ -6,6 +6,8 @@ use Fissible\Verdict\Evidence\AttestEvidenceRecorder;
 use Fissible\Verdict\Evidence\DatabaseEvidenceRecorder;
 use Fissible\Verdict\Evidence\NullEvidenceRecorder;
 use Fissible\VerdictConsole\Contracts\EvidenceQuery;
+use Fissible\VerdictConsole\Evidence\ConversationCorrelation;
+use Fissible\VerdictConsole\Evidence\ConversationInvocationStore;
 use Fissible\VerdictConsole\Evidence\DatabaseEvidenceQuery;
 use Fissible\VerdictConsole\Evidence\EvidenceFilter;
 use Fissible\VerdictConsole\Evidence\EvidenceQueryResult;
@@ -32,10 +34,13 @@ beforeEach(function (): void {
     ] as $migration) {
         (require $migrations.'/'.$migration)->up();
     }
+
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_conversation_invocations_table.php.stub')->up();
 });
 
 afterEach(function (): void {
     Schema::dropIfExists('console_test_evidence');
+    Schema::dropIfExists('verdict_console_conversation_invocations');
 });
 
 it('exposes recording being off separately from an empty enabled evidence table', function (): void {
@@ -47,8 +52,10 @@ it('exposes recording being off separately from an empty enabled evidence table'
 
     expect($off->recording)->toBe(EvidenceRecordingState::Off)
         ->and($off->records)->toBe([])
+        ->and($off->conversation)->toBeNull('No conversation was asked about, so none is reported on.')
         ->and($empty->recording)->toBe(EvidenceRecordingState::On)
-        ->and($empty->records)->toBe([]);
+        ->and($empty->records)->toBe([])
+        ->and($empty->conversation)->toBeNull();
 });
 
 it('uses Verdicts narrow writer before the legacy recorder and distinguishes an unreadable writer', function (): void {
@@ -107,6 +114,7 @@ it('reads only decision evidence from Verdicts shipped schema without exposing r
         'rate_limit_key_fingerprint' => str_repeat('3', 64),
         'execution_claim_fingerprint' => str_repeat('4', 64),
         'execution_claim_binding_fingerprint' => str_repeat('5', 64),
+        'invocation_id' => 'invocation-1',
         'rate_limit_reset_at' => '2026-08-25 12:30:00',
         'recorded_at' => '2026-08-25 12:00:00',
     ]);
@@ -142,6 +150,7 @@ it('reads only decision evidence from Verdicts shipped schema without exposing r
             'rateLimitKeyFingerprint' => str_repeat('3', 64),
             'executionClaimFingerprint' => str_repeat('4', 64),
             'executionClaimBindingFingerprint' => str_repeat('5', 64),
+            'invocationId' => 'invocation-1',
             'rateLimitResetAt' => new DateTimeImmutable('2026-08-25 12:30:00 UTC'),
             'recordedAt' => new DateTimeImmutable('2026-08-25 12:00:00 UTC'),
         ])
@@ -165,6 +174,110 @@ it('filters decision evidence by disposition, capability, and inclusive recorded
     ))->records;
 
     expect(array_map(fn ($record) => $record->id, $records))->toBe(['first-deny']);
+});
+
+it('filters decision evidence by invocation without needing a conversation mapping', function (): void {
+    insertEvidence(['id' => 'in-scope', 'record_type' => 'decision', 'stage' => 'proposal', 'disposition' => 'permit', 'invocation_id' => 'invocation-1', 'recorded_at' => '2026-08-25 10:00:00']);
+    insertEvidence(['id' => 'other-invocation', 'record_type' => 'decision', 'stage' => 'proposal', 'disposition' => 'permit', 'invocation_id' => 'invocation-2', 'recorded_at' => '2026-08-25 10:01:00']);
+    insertEvidence(['id' => 'outside-any-invocation', 'record_type' => 'decision', 'stage' => 'proposal', 'disposition' => 'permit', 'recorded_at' => '2026-08-25 10:02:00']);
+
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+
+    $result = app(EvidenceQuery::class)->search(new EvidenceFilter(invocationId: 'invocation-1'));
+
+    expect(array_map(fn ($record) => $record->id, $result->records))->toBe(['in-scope'])
+        ->and($result->conversation)->toBeNull();
+});
+
+/**
+ * "Evidence for a conversation" is not native: `DecisionEvidence` carries an invocation id and no
+ * conversation id (design §6.6). The console's own projection supplies the join, and it must span
+ * every invocation the conversation had — a pause and its resume are two — while a decision made
+ * outside any Laravel AI invocation can never belong to one.
+ */
+it('returns evidence across every invocation the console observed for a conversation', function (): void {
+    $correlations = new ConversationInvocationStore;
+    $correlations->record('invocation-pause', 'conversation-a');
+    $correlations->record('invocation-resume', 'conversation-a');
+    $correlations->record('invocation-other', 'conversation-b');
+
+    insertEvidence(['id' => 'pause', 'record_type' => 'decision', 'stage' => 'proposal', 'disposition' => 'require_confirmation', 'invocation_id' => 'invocation-pause', 'recorded_at' => '2026-08-25 10:00:00']);
+    insertEvidence(['id' => 'resume', 'record_type' => 'decision', 'stage' => 'execution', 'disposition' => 'permit', 'invocation_id' => 'invocation-resume', 'recorded_at' => '2026-08-25 10:05:00']);
+    insertEvidence(['id' => 'other-conversation', 'record_type' => 'decision', 'stage' => 'proposal', 'disposition' => 'permit', 'invocation_id' => 'invocation-other', 'recorded_at' => '2026-08-25 10:06:00']);
+    insertEvidence(['id' => 'outside-any-invocation', 'record_type' => 'decision', 'stage' => 'proposal', 'disposition' => 'permit', 'recorded_at' => '2026-08-25 10:07:00']);
+
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+
+    $result = app(EvidenceQuery::class)->search(new EvidenceFilter(conversationId: 'conversation-a'));
+
+    expect($result->recording)->toBe(EvidenceRecordingState::On)
+        ->and($result->conversation)->toBe(ConversationCorrelation::Known)
+        ->and(array_map(fn ($record) => $record->id, $result->records))->toBe(['pause', 'resume']);
+});
+
+/**
+ * The acceptance criterion's second half: a missing mapping degrades explicitly. An empty result
+ * for a conversation the console never saw would read as "nothing was decided," when the honest
+ * statement is "this console cannot say" — the conversation may predate the projection, or have
+ * run without the boundaries that feed it.
+ */
+it('reports a conversation the console never observed as unknown rather than as empty evidence', function (): void {
+    (new ConversationInvocationStore)->record('invocation-1', 'conversation-a');
+    insertEvidence(['id' => 'decided', 'record_type' => 'decision', 'stage' => 'proposal', 'disposition' => 'permit', 'invocation_id' => 'invocation-1', 'recorded_at' => '2026-08-25 10:00:00']);
+
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+
+    $unknown = app(EvidenceQuery::class)->search(new EvidenceFilter(conversationId: 'conversation-never-seen'));
+    $known = app(EvidenceQuery::class)->search(new EvidenceFilter(conversationId: 'conversation-a'));
+
+    expect($unknown->recording)->toBe(EvidenceRecordingState::On)
+        ->and($unknown->conversation)->toBe(ConversationCorrelation::Unknown)
+        ->and($unknown->records)->toBe([])
+        ->and($known->conversation)->toBe(ConversationCorrelation::Known)
+        ->and($known->records)->toHaveCount(1);
+});
+
+/**
+ * The mapping is console-owned; whether Verdict retained anything to join it to is a separate fact,
+ * and it is answered the same way whether recording is off or happening somewhere this adapter
+ * cannot read.
+ */
+it('reports the conversation mapping independently of whether Verdict is recording', function (): void {
+    (new ConversationInvocationStore)->record('invocation-1', 'conversation-a');
+
+    $off = app(EvidenceQuery::class)->search(new EvidenceFilter(conversationId: 'conversation-a'));
+
+    config()->set('verdict.evidence.writer', 'App\\Evidence\\ExternalWriter');
+
+    $elsewhere = app(EvidenceQuery::class)->search(new EvidenceFilter(conversationId: 'conversation-a'));
+    $elsewhereUnknown = app(EvidenceQuery::class)->search(new EvidenceFilter(conversationId: 'conversation-never-seen'));
+
+    expect($off->recording)->toBe(EvidenceRecordingState::Off)
+        ->and($off->conversation)->toBe(ConversationCorrelation::Known)
+        ->and($off->records)->toBe([])
+        ->and($elsewhere->recording)->toBe(EvidenceRecordingState::Elsewhere)
+        ->and($elsewhere->conversation)->toBe(ConversationCorrelation::Known)
+        ->and($elsewhere->records)->toBe([])
+        ->and($elsewhereUnknown->recording)->toBe(EvidenceRecordingState::Elsewhere)
+        ->and($elsewhereUnknown->conversation)->toBe(ConversationCorrelation::Unknown);
+});
+
+it('narrows a conversation filter by invocation rather than widening it', function (): void {
+    $correlations = new ConversationInvocationStore;
+    $correlations->record('invocation-1', 'conversation-a');
+    $correlations->record('invocation-2', 'conversation-b');
+
+    insertEvidence(['id' => 'row-1', 'record_type' => 'decision', 'stage' => 'proposal', 'disposition' => 'permit', 'invocation_id' => 'invocation-1', 'recorded_at' => '2026-08-25 10:00:00']);
+    insertEvidence(['id' => 'row-2', 'record_type' => 'decision', 'stage' => 'proposal', 'disposition' => 'permit', 'invocation_id' => 'invocation-2', 'recorded_at' => '2026-08-25 10:01:00']);
+
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+
+    $inside = app(EvidenceQuery::class)->search(new EvidenceFilter(conversationId: 'conversation-a', invocationId: 'invocation-1'));
+    $outside = app(EvidenceQuery::class)->search(new EvidenceFilter(conversationId: 'conversation-a', invocationId: 'invocation-2'));
+
+    expect(array_map(fn ($record) => $record->id, $inside->records))->toBe(['row-1'])
+        ->and($outside->records)->toBe([])
+        ->and($outside->conversation)->toBe(ConversationCorrelation::Known);
 });
 
 it('keeps the read boundary independent of Verdicts writer and recorder implementations', function (): void {
@@ -215,6 +328,7 @@ function insertEvidence(array $attributes): void
         'subject_fingerprint' => $attributes['subject_fingerprint'] ?? null,
         'claim_type' => $attributes['claim_type'] ?? null,
         'record_digest' => $attributes['record_digest'] ?? null,
+        'invocation_id' => $attributes['invocation_id'] ?? null,
         'rate_limit_reset_at' => $attributes['rate_limit_reset_at'] ?? null,
         'recorded_at' => $attributes['recorded_at'],
     ]);

--- a/tests/Feature/MigrationPublishingTest.php
+++ b/tests/Feature/MigrationPublishingTest.php
@@ -49,7 +49,7 @@ it('publishes every migration, in an order that can actually run', function (): 
         ->sort()
         ->values();
 
-    expect($published)->toHaveCount(5);
+    expect($published)->toHaveCount(6);
 
     $position = fn (string $fragment): int => $published->search(fn (string $name): bool => str_contains($name, $fragment));
 
@@ -79,8 +79,32 @@ it('leaves the released create migration alone and adds operational state separa
 
     expect($create)->not->toContain('resume_attempts', 'v0.1.0 shipped without this column; adding it here reaches new installs only.')
         ->and($create)->not->toContain('last_resume_attempt_at')
+        ->and($create)->not->toContain('conversation_invocations', 'The correlation projection is its own table in its own migration, not a fold-in.')
         ->and($added)->toContain('resume_attempts')
         ->and($added)->toContain('last_resume_attempt_at');
+});
+
+/**
+ * The conversation-invocation projection (VC-14) has no foreign key to the pause table: an
+ * invocation that never paused still belongs to a conversation. It therefore publishes without an
+ * ordering constraint, but it must publish.
+ */
+it('publishes the conversation-invocations migration under the same tag', function (): void {
+    $target = database_path('migrations');
+
+    File::exists($target) && File::cleanDirectory($target);
+
+    $this->artisan('vendor:publish', ['--tag' => 'verdict-console-migrations', '--force' => true])
+        ->assertSuccessful();
+
+    $published = collect(File::files($target))
+        ->map(fn ($file): string => $file->getFilename())
+        ->filter(fn (string $name): bool => str_contains($name, 'create_verdict_console_conversation_invocations_table'));
+
+    expect($published)->toHaveCount(1)
+        ->and($published->first())->toEndWith('.php');
+
+    File::cleanDirectory($target);
 });
 
 /** The package must not run its own migrations behind the host's back. */


### PR DESCRIPTION
## Summary

`DecisionEvidence` carries an `invocationId` but no `conversationId`, so "evidence for a conversation" needs a join the console owns. This adds it:

- **`verdict_console_conversation_invocations`** — a projection of every remembered Laravel AI invocation against its conversation (`invocation_id` primary key, `conversation_id` indexed, no FK to the pause table). First observation stands; a redelivery collides on the key rather than duplicating.
- **`RecordConversationInvocation`** listens to **`AgentPrompted` and `AgentStreamed`** — not the `ToolApprovalRequested` boundary the issue named. Three reasons, each verified against `vendor/laravel/ai` and covered by a test:
  1. a **Deny never pauses**, so an approval-only capture would leave every refused action in a conversation uncorrelated (`EvidenceCorrelationTest` "denied action that never paused");
  2. a **resume is a second `prompt()` with a fresh invocation id**, and the approved execution's `execution/permit` decision is recorded under *that* id (`GeneratesText.php:50`; "pause and the resume");
  3. both approval events fire **after** the completion event in the same gateway call with the same response (`GeneratesText.php:117-137`, `StreamsText.php:119-142`), so registering for them would only re-observe what was already recorded. `AgentStreamed extends AgentPrompted` and Laravel's dispatcher matches interfaces, not parents, so it is registered explicitly.
- **`EvidenceQuery`** gains `conversationId` / `invocationId` filters; `EvidenceRecord` exposes `invocationId`; `EvidenceQueryResult->conversation` reports **`Known` / `Unknown`** (null when no conversation was asked about), computed independently of the recording state — so an unknown conversation is never rendered as "nothing was decided", under `On`, `Off`, or `Elsewhere`.
- **Host precondition:** the join is only populated when the agent declares `VerdictProvenanceMiddleware` — it pushes the `InvocationContext` frame `VerdictManager` reads when stamping `invocation_id` (the approval round trip works without it, so a host can have a working console and an empty correlation). Documented in design §6.6 and the CHANGELOG; doctor findings for this and for an unmigrated table are filed as #72.
- Fold-in from the VC-13 review: `DatabaseEvidenceQuery::date()` now cites fissible/verdict#335 (Verdict 0.13.0) as the write-side UTC contract, with the `^0.12` caveat kept accurate.

## Linked issue

Closes #14

## Trust and failure behavior

- **Inputs:** the two identifiers on framework-produced events (`$event->invocationId`, `$event->response->conversationId`). Nothing model- or user-controlled is persisted.
- **Write failure** (table not migrated, DB unreachable): the listener logs an error with the invocation id and returns — a read-model write must never change the agent's answer. The read side then reports the conversation as `Unknown`. Until the migration runs this logs once per completed turn (called out in the upgrade note).
- **Conflicting conversation for a known invocation:** the first observation is kept and a warning carries the invocation id and both conversation ids.
- **Concurrency:** insert-then-catch on the primary key, no check-then-act (mirrors `PendingApprovalStore` / `IncidentStore`). The unique key is pinned by a raw-duplicate test and schema introspection; the redelivery test is sequential and says so. A multi-process race test was considered and not built — this repo has no concurrency harness (CONTRIBUTING's reference is inherited from Verdict) and the atomicity argument is the key itself.
- **Scoping:** correlation reads are not subject to `ApprovalScope` (design §7); evidence audience governance is unchanged from VC-13.
- Cross-connection safety: the conversation's invocation ids are materialized and passed via `whereIn` rather than a subquery, because `verdict.evidence.connection` may differ from the console's connection.

## Evidence and data handling

- The projection stores only `invocation_id`, `conversation_id`, and timestamps — no prompt text, arguments, participants, or presentation.
- `EvidenceRecord` adds `invocationId`, an identifier Verdict's published schema already exposes; reasons and raw arguments remain excluded.

## Verification

- [x] Success, denial, and relevant failure paths are tested.
- [x] Security containment and legitimate utility are both covered where applicable.
- [x] Documentation and `CHANGELOG.md` are updated.
- [x] `composer test` passes locally — phpstan clean, pint passed, type coverage 100%, **216 passed (885 assertions)**.
- [x] No credentials, real customer data, or unredacted evidence are included.

Positive control (`tests/EndToEnd/EvidenceCorrelationTest.php`) drives the real Laravel AI + Verdict stack over `Http::fake()` for pause→approve→resume, a Deny that never pauses, and a **streamed** Deny over an SSE body, and asserts the raw `verdict_evidence.invocation_id` values as well as the query result — so the join's right-hand side is proven, not inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
