### PR TITLE
build: require Verdict ^0.13, the release carrying ApprovalStatusReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Requires Verdict `^0.13`** (#74). `v0.13.0` is the first release carrying
+  `ApprovalStatusReader` (Verdict ADR 0031), the read contract the gated approval work was designed
+  against, and it mints every evidence timestamp in UTC (verdict#335), which `DatabaseEvidenceQuery`
+  previously had to state as an assumption. The bound is `^0.13` alone for the same reason `^0.12`
+  was: a `0.x` disjunction would pin the `prefer-lowest` cell to a minor nobody runs. Nothing in this
+  package needed to change for 0.13 itself; the evidence-query fixture now applies Verdict's new
+  `add_intent_id_to_verdict_evidence_table` stub, and a test holds that fixture equal to every
+  evidence-table stub the installed Verdict publishes, so the next additive column cannot leave the
+  fixture behind the real table. **Upgrading:** require `fissible/verdict:^0.13` and publish and run
+  Verdict's `add_intent_id_to_verdict_evidence_table` migration if you record evidence to the database.
+
 - **Evidence-to-conversation correlation projection (VC-14).** The console now records each
   remembered Laravel AI `invocation_id` against its `conversation_id` and can scope the VC-13
   evidence query by either. `AgentPrompted` and `AgentStreamed` are the capture boundaries: approval

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ the shipped authority **fails closed** until you do.
 - PHP 8.3+
 - Laravel 12 or 13
 - `laravel/ai` ^0.11
-- `fissible/verdict` ^0.12
+- `fissible/verdict` ^0.13
 
 ## Development
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "illuminate/contracts": "^12.0||^13.0",
     "illuminate/database": "^12.0||^13.0",
     "illuminate/support": "^12.0||^13.0",
-    "fissible/verdict": "^0.12",
+    "fissible/verdict": "^0.13",
     "laravel/ai": "^0.11.0"
   },
   "require-dev": {
@@ -83,7 +83,7 @@
   "extra": {
     "verdict-console": {
       "dependency_constraints": {
-        "fissible/verdict": "^0.12 only: Verdict 0.12 requires a decision authorizer and ^0.x disjunctions make prefer-lowest skip the supported current minor."
+        "fissible/verdict": "^0.13 only: 0.13 is the first release carrying ApprovalStatusReader (ADR 0031), and ^0.x disjunctions make prefer-lowest skip the supported current minor."
       }
     },
     "laravel": {

--- a/src/Evidence/DatabaseEvidenceQuery.php
+++ b/src/Evidence/DatabaseEvidenceQuery.php
@@ -146,10 +146,10 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
 
     private function date(string $value): DateTimeImmutable
     {
-        // The published schema is timezone-naive. This adapter treats its values as UTC under
-        // Laravel's shipped UTC default. fissible/verdict#335 shipped this as Verdict 0.13.0's
-        // write-side contract; this package supports ^0.12, so a 0.12 host that writes in another
-        // application timezone owns a custom query.
+        // The published schema is timezone-naive, and Verdict 0.13 (fissible/verdict#335) mints
+        // every evidence timestamp in UTC, so reading as UTC is the write side's own contract. Rows
+        // written by an earlier Verdict on a non-UTC application timezone predate that contract; a
+        // host with such history owns a custom query rather than this adapter guessing an offset.
         return new DateTimeImmutable($value, new DateTimeZone('UTC'));
     }
 }

--- a/tests/Feature/EvidenceQueryTest.php
+++ b/tests/Feature/EvidenceQueryTest.php
@@ -15,24 +15,37 @@ use Fissible\VerdictConsole\Evidence\EvidenceRecordingState;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
+/**
+ * Verdict's published evidence-table migrations, in the order a host runs them.
+ *
+ * Listed explicitly because order matters and the adapter reads the *resulting* schema; a test
+ * below holds this list equal to what the installed Verdict actually publishes, so a new stub in
+ * a Verdict release fails here instead of leaving the fixture quietly behind the real table.
+ */
+const VERDICT_EVIDENCE_STUBS = [
+    'create_verdict_evidence_table.php.stub',
+    'add_provenance_to_verdict_evidence_table.php.stub',
+    'add_invocation_id_to_verdict_evidence_table.php.stub',
+    'add_tool_kind_to_verdict_evidence_table.php.stub',
+    'add_configuration_fingerprint_to_verdict_evidence_table.php.stub',
+    'add_actor_and_subject_fingerprints_to_verdict_evidence_table.php.stub',
+    'add_target_source_to_verdict_evidence_table.php.stub',
+    'add_tool_description_fingerprints_to_verdict_evidence_table.php.stub',
+    'add_record_identity_to_verdict_evidence_table.php.stub',
+    'add_intent_id_to_verdict_evidence_table.php.stub',
+];
+
+function verdictMigrationsPath(): string
+{
+    return dirname(__DIR__, 2).'/vendor/fissible/verdict/database/migrations';
+}
+
 beforeEach(function (): void {
     config()->set('verdict.evidence.table', 'console_test_evidence');
     config()->set('verdict.evidence.recorder', NullEvidenceRecorder::class);
 
-    $migrations = dirname(__DIR__, 2).'/vendor/fissible/verdict/database/migrations';
-
-    foreach ([
-        'create_verdict_evidence_table.php.stub',
-        'add_provenance_to_verdict_evidence_table.php.stub',
-        'add_invocation_id_to_verdict_evidence_table.php.stub',
-        'add_tool_kind_to_verdict_evidence_table.php.stub',
-        'add_configuration_fingerprint_to_verdict_evidence_table.php.stub',
-        'add_actor_and_subject_fingerprints_to_verdict_evidence_table.php.stub',
-        'add_target_source_to_verdict_evidence_table.php.stub',
-        'add_tool_description_fingerprints_to_verdict_evidence_table.php.stub',
-        'add_record_identity_to_verdict_evidence_table.php.stub',
-    ] as $migration) {
-        (require $migrations.'/'.$migration)->up();
+    foreach (VERDICT_EVIDENCE_STUBS as $migration) {
+        (require verdictMigrationsPath().'/'.$migration)->up();
     }
 
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_conversation_invocations_table.php.stub')->up();
@@ -41,6 +54,18 @@ beforeEach(function (): void {
 afterEach(function (): void {
     Schema::dropIfExists('console_test_evidence');
     Schema::dropIfExists('verdict_console_conversation_invocations');
+});
+
+it('builds the evidence fixture from every evidence-table stub the installed Verdict publishes', function (): void {
+    $published = array_map(basename(...), glob(verdictMigrationsPath().'/*verdict_evidence_table.php.stub') ?: []);
+    $listed = VERDICT_EVIDENCE_STUBS;
+    sort($published);
+    sort($listed);
+
+    // Verdict adds columns to this table by additive stub; the adapter is only tested against the
+    // real schema if the fixture applies all of them. A mismatch means a Verdict upgrade changed
+    // the table and this file did not follow.
+    expect($listed)->toBe($published);
 });
 
 it('exposes recording being off separately from an empty enabled evidence table', function (): void {


### PR DESCRIPTION
Closes #74.

## Summary
- `fissible/verdict: ^0.13` — the first tag carrying `ApprovalStatusReader` (Verdict ADR 0031). This unblocks #45, #68, #69, and VC-10's deferred durable retry.
- The evidence-query fixture applies Verdict 0.13's new `add_intent_id_to_verdict_evidence_table` stub, and a new test holds the fixture's stub list equal to every `*verdict_evidence_table.php.stub` the installed Verdict publishes — a future additive column fails that test rather than leaving the fixture behind the real table.
- `DatabaseEvidenceQuery`'s timestamp comment now states the fact: 0.13 mints evidence timestamps in UTC (verdict#335), so reading as UTC is the write side's contract; only pre-0.13 rows on a non-UTC host are a custom-query concern.
- README requirement, `composer.json` constraint note, and CHANGELOG updated to match.

## Why
`^0.12` on a `0.x` caret excludes 0.13, so the four gated tickets could not start against a released Verdict. The bound is `^0.13` alone, not a disjunction: `prefer-lowest` tests only the bottom of a range, and `^0.12 || ^0.13` would pin that cell to 0.12 while every adopter moves on.

Nothing in the package's own code needed to change for 0.13. Of its upgrade notes, only the evidence table's new column reaches this package (via the test fixture); `InvocationContext`'s namespace move is unreferenced here, and the rate-limit index rename is not a console table.

## Test plan
- [x] `composer test` clean against Verdict 0.13.0: phpstan OK, Pint OK, 100% type coverage, **222 passed / 968 assertions**.
- [x] New test: the evidence fixture's stub list equals the installed Verdict's published evidence-table stubs (fails without the `add_intent_id` entry).
- [x] `composer update --prefer-lowest --dry-run` resolves `fissible/verdict` to 0.13.0 — both ends of the range are the same tag today, so the matrix exercises the version adopters run.

## Notes
Verdict's generated compatibility matrix (`compatibility/laravel-ai-matrix-facts.json`) records console v0.2.0 against Verdict v0.12.0; the next row is theirs to regenerate once this ships in a console release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
