### PR TITLE
feat: doctor findings for the evidence-correlation preconditions (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Warns when the evidence-correlation surface is unavailable (#72).**
+  `verdict-console:doctor` now reports `evidence_correlation_middleware_missing` when a resumable
+  agent lacks `VerdictProvenanceMiddleware`, and `evidence_correlation_table_missing` when the
+  console's correlation migration has not run. They are warnings because approvals remain usable
+  while conversation-scoped decision evidence goes dark; a host that depends on that surface can
+  use `--strict` to make either finding fail its build. [#72](https://github.com/fissible/verdict-console/issues/72)
+
 - **Requires Verdict `^0.13`** (#74). `v0.13.0` is the first release carrying
   `ApprovalStatusReader` (Verdict ADR 0031), the read contract the gated approval work was designed
   against, and it mints every evidence timestamp in UTC (verdict#335), which `DatabaseEvidenceQuery`

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -298,19 +298,20 @@ Over `DecisionEvidence`, honoring ADR 0008 (fingerprints, not raw), surfacing `c
 - **Default recorder is `NullEvidenceRecorder`** — these surfaces are dark on a default install *by
   design*. The UI must detect it and say *"recording is off — blank by config,"* never render an
   empty table that reads as "nothing happened." [`config/verdict.php`]
-- **`DecisionEvidence` has `invocationId` but no `conversationId`.** [`src/Evidence/DecisionEvidence.php`]
-  "Filter evidence by conversation" is therefore **not native** — it depends on a console-owned
-  correlation projection (invocationId ↔ conversationId), captured at the `AgentPrompted` and
-  `AgentStreamed` completion boundaries. The approval events fire after those boundaries in the same
-  gateway call with the same response, so they only re-observe a correlation already recorded. The
-  host must run `VerdictProvenanceMiddleware`: it pushes the `InvocationContext` frame VerdictManager
-  reads when stamping `invocation_id` on decision evidence; without it every decision row carries
-  null and the join is empty. [#72](https://github.com/fissible/verdict-console/issues/72) adds doctor
-  findings for a missing `VerdictProvenanceMiddleware` and an unmigrated correlation table. Until the
-  migration runs, the listener logs an error for each completed turn and continues, and every
-  conversation reads as **Unknown**. The projection retains every remembered invocation, including one
-  that **produced no decision evidence**. A conversation with no remembered invocation is reported as
-  **Unknown**, never as empty.
+- **`DecisionEvidence` has `invocationId` but no `conversationId`.**
+  [`src/Evidence/DecisionEvidence.php`] "Filter evidence by conversation" is therefore **not native** —
+  it depends on a console-owned correlation projection (invocationId ↔ conversationId), captured at
+  the `AgentPrompted` and `AgentStreamed` completion boundaries. The approval events fire after those
+  boundaries in the same gateway call with the same response, so they only re-observe a correlation
+  already recorded. The host must run `VerdictProvenanceMiddleware`: it pushes the
+  `InvocationContext` frame VerdictManager reads when stamping `invocation_id` on decision evidence;
+  without it every decision row carries null and the join is empty.
+  [#72](https://github.com/fissible/verdict-console/issues/72) ships the `verdict-console:doctor`
+  findings `evidence_correlation_middleware_missing` and `evidence_correlation_table_missing`. Until
+  the migration runs, the listener logs an error for each completed turn and continues, and every
+  conversation reads as **Unknown**. The projection retains every remembered invocation, including
+  one that **produced no decision evidence**. A conversation with no remembered invocation is reported
+  as **Unknown**, never as empty.
 
 ### 6.7 Durable incident projection (for the ops health surface)
 A listener persists the ephemeral events into a console-owned incidents table, because they do not

--- a/src/Doctor/Doctor.php
+++ b/src/Doctor/Doctor.php
@@ -8,6 +8,7 @@ use Fissible\Verdict\Capabilities\CapabilityRegistry;
 use Fissible\Verdict\Contracts\ApprovalDecisionAuthorizer;
 use Fissible\Verdict\LaravelAi\BoundTool;
 use Fissible\Verdict\LaravelAi\VerdictApprovalMiddleware;
+use Fissible\Verdict\LaravelAi\VerdictProvenanceMiddleware;
 use Fissible\Verdict\Testing\AllowAllApprovalAuthorizer;
 use Fissible\VerdictConsole\Contracts\ResumableAgents;
 use Fissible\VerdictConsole\Exceptions\ResumableAgentFailure;
@@ -51,6 +52,7 @@ final readonly class Doctor
     {
         $findings = [
             ...$this->inspectPersistence(),
+            ...$this->inspectEvidenceCorrelation(),
             ...$this->inspectApprovalAuthorizer(),
             ...$this->inspectAgents(),
             ...$this->inspectCapabilities(),
@@ -169,6 +171,35 @@ final readonly class Doctor
         )];
     }
 
+    /**
+     * The table, not the listener binding. The listener is registered by this package's own service
+     * provider and cannot be unbound, so a binding check would always pass. What breaks a host is
+     * publishing the package and never migrating it: the listener resolves, but its projection write fails.
+     *
+     * **The default connection, not Verdict's evidence connection.** This projection is console-owned
+     * and written by the listener on the application's default connection.
+     * `verdict.evidence.connection` is where Verdict's evidence lives and where the read adapter looks;
+     * checking it would pass on the wrong database.
+     *
+     * @return list<Finding>
+     */
+    private function inspectEvidenceCorrelation(): array
+    {
+        if ($this->schema->hasTable('verdict_console_conversation_invocations')) {
+            return [];
+        }
+
+        return [new Finding(
+            code: FindingCode::EvidenceCorrelationTableMissing,
+            severity: Severity::Warning,
+            subject: 'verdict_console_conversation_invocations',
+            summary: 'The conversation-invocation correlation table is not migrated, so the correlation '
+                .'listener logs an error for every completed turn and every conversation-scoped evidence '
+                .'query reads as Unknown until it exists.',
+            fix: 'Run php artisan vendor:publish --tag=verdict-console-migrations, then php artisan migrate.',
+        )];
+    }
+
     /** @param  'conversations'|'messages'  $which */
     private function conversationTable(string $which): string
     {
@@ -247,6 +278,19 @@ final readonly class Doctor
             );
         }
 
+        if (! $agent instanceof HasMiddleware || ! $this->declaresProvenanceMiddleware($agent)) {
+            $findings[] = new Finding(
+                code: FindingCode::EvidenceCorrelationMiddlewareMissing,
+                severity: Severity::Warning,
+                subject: $subject,
+                summary: 'VerdictProvenanceMiddleware is not registered, so decision evidence rows carry a '
+                    .'null invocation_id and a conversation-scoped EvidenceQuery answers Known with zero '
+                    .'records — indistinguishable from "this conversation decided nothing".',
+                fix: 'Implement Laravel\Ai\Contracts\HasMiddleware and return a '
+                    .'VerdictProvenanceMiddleware from middleware() alongside the approval middleware.',
+            );
+        }
+
         if (! $this->hasBoundTool($agent)) {
             $findings[] = new Finding(
                 code: FindingCode::AgentHasNoBoundTool,
@@ -292,6 +336,17 @@ final readonly class Doctor
     {
         foreach ($agent->middleware() as $middleware) {
             if ($middleware instanceof VerdictApprovalMiddleware) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function declaresProvenanceMiddleware(HasMiddleware $agent): bool
+    {
+        foreach ($agent->middleware() as $middleware) {
+            if ($middleware instanceof VerdictProvenanceMiddleware) {
                 return true;
             }
         }

--- a/src/Doctor/FindingCode.php
+++ b/src/Doctor/FindingCode.php
@@ -24,6 +24,26 @@ enum FindingCode: string
     /** Not auto-registered — without it `ApprovalExecutionContext::allows()` is false for every call. */
     case ApprovalMiddlewareMissing = 'approval_middleware_missing';
 
+    /**
+     * The approval loop still works, but Verdict cannot stamp `invocation_id` onto decision evidence.
+     *
+     * This is deliberately a **warning**: approvals remain usable, while the evidence correlation
+     * surface goes dark. Detected by **identity, not behaviour**: this recognises a
+     * `VerdictProvenanceMiddleware` instance and cannot prove that another middleware reproduces its
+     * invocation-context behaviour. A clean result means the shipped middleware is present, not that
+     * arbitrary host middleware records equivalent provenance.
+     */
+    case EvidenceCorrelationMiddlewareMissing = 'evidence_correlation_middleware_missing';
+
+    /**
+     * The approval loop is unaffected, but without this projection table correlation writes fail and
+     * conversation-scoped evidence is unavailable.
+     *
+     * This is deliberately a **warning**: the evidence surface is what goes dark; an approval can
+     * still be issued, decided, and resumed.
+     */
+    case EvidenceCorrelationTableMissing = 'evidence_correlation_table_missing';
+
     /** A resumable agent with no Verdict-bound tool can never produce a receipt-backed approval. */
     case AgentHasNoBoundTool = 'agent_has_no_bound_tool';
 

--- a/tests/Feature/DocumentationCorrectionsTest.php
+++ b/tests/Feature/DocumentationCorrectionsTest.php
@@ -60,6 +60,13 @@ it('records in the design which boundaries feed the conversation correlation and
         ->not->toContain('at the `ToolApprovalRequested` boundary');
 });
 
+/** #72 shipped the doctor findings the VC-14 design text promised; the design must name them, not the promise. */
+it('names the evidence-correlation doctor findings in the design of record', function (): void {
+    expect(documentation('docs/design/0001-verdict-console-design.md'))
+        ->toContain('`evidence_correlation_middleware_missing`')
+        ->toContain('`evidence_correlation_table_missing`');
+});
+
 /** Folded in from the VC-13 review: the UTC reading is a contract from verdict#335 onward, not a hope. */
 it('cites the Verdict change that makes the evidence timestamp reading a UTC contract', function (): void {
     expect(documentation('src/Evidence/DatabaseEvidenceQuery.php'))->toContain('fissible/verdict#335');

--- a/tests/Integration/DoctorTest.php
+++ b/tests/Integration/DoctorTest.php
@@ -10,10 +10,14 @@ use Fissible\Verdict\Approvals\ApprovalExecutionContext;
 use Fissible\Verdict\Approvals\ApprovalReceipt;
 use Fissible\Verdict\Capabilities\Capability;
 use Fissible\Verdict\Capabilities\CapabilityRegistry;
+use Fissible\Verdict\Context\DataClass;
+use Fissible\Verdict\Context\Trust;
 use Fissible\Verdict\Contracts\ApprovalDecisionAuthorizer;
 use Fissible\Verdict\Contracts\CapabilityAuthorizer;
 use Fissible\Verdict\Decisions\Decision;
+use Fissible\Verdict\Evidence\ProvenanceLedger;
 use Fissible\Verdict\LaravelAi\VerdictApprovalMiddleware;
+use Fissible\Verdict\LaravelAi\VerdictProvenanceMiddleware;
 use Fissible\Verdict\Targets\ExecutionTargetPolicy;
 use Fissible\Verdict\Testing\AllowAllApprovalAuthorizer;
 use Fissible\Verdict\VerdictManager;
@@ -61,7 +65,14 @@ final class DoctorApprovalAuthorizer implements ApprovalDecisionAuthorizer
     }
 }
 
-/** Wired correctly: conversational, remembers, declares the middleware, binds a tool. */
+/**
+ * Wired correctly: conversational, remembers, declares both middlewares, binds a tool.
+ *
+ * Both middlewares, because they guard different things. `VerdictApprovalMiddleware` is what lets an
+ * approved receipt execute; `VerdictProvenanceMiddleware` is what stamps `invocation_id` on the
+ * decision evidence the VC-14 correlation joins against. The approval round trip works without the
+ * second one, which is exactly why a healthy install must be shown declaring it.
+ */
 final class HealthyAgent implements Agent, HasMiddleware, HasTools, RemembersConversationsContract
 {
     use Promptable;
@@ -70,6 +81,36 @@ final class HealthyAgent implements Agent, HasMiddleware, HasTools, RemembersCon
     public function instructions(): Stringable|string
     {
         return 'healthy';
+    }
+
+    /** @return array<int, Tool> */
+    public function tools(): array
+    {
+        return [doctorBoundTool()];
+    }
+
+    /** @return array<int, object> */
+    public function middleware(): array
+    {
+        return [
+            new VerdictApprovalMiddleware(new ApprovalExecutionContext),
+            new VerdictProvenanceMiddleware(app(ProvenanceLedger::class), Trust::Untrusted, DataClass::Internal),
+        ];
+    }
+}
+
+/**
+ * The approval loop works, the evidence join is empty. Everything `HealthyAgent` has except the
+ * provenance middleware — so the only thing the doctor can say about it is the correlation gap.
+ */
+final class UncorrelatedAgent implements Agent, HasMiddleware, HasTools, RemembersConversationsContract
+{
+    use Promptable;
+    use RemembersConversationsTrait;
+
+    public function instructions(): Stringable|string
+    {
+        return 'uncorrelated';
     }
 
     /** @return array<int, Tool> */
@@ -251,6 +292,9 @@ function doctorFor(array $agents = []): Doctor
 beforeEach(function (): void {
     // The conversation tables are a real precondition; migrate them so the default run is clean.
     (require dirname(__DIR__, 2).'/vendor/laravel/ai/database/migrations/2026_01_11_000001_create_agent_conversations_table.php')->up();
+
+    // So is the correlation projection's table: without it every completed turn logs a failed write.
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_conversation_invocations_table.php.stub')->up();
 
     // Verdict leaves the authorizer to the application, so nothing binds one by default and
     // VerdictManager cannot build without it. The doctor never asks it to decide anything; this is
@@ -488,6 +532,110 @@ it('does not report a confirmation gate that declares an execution target', func
     $codes = array_map(fn ($f) => $f->code, doctorFor()->run());
 
     expect($codes)->not->toContain(FindingCode::ConfirmationGateCannotPause);
+});
+
+/**
+ * The VC-14 join has a host-side precondition the approval loop does not: `VerdictProvenanceMiddleware`
+ * pushes the invocation frame Verdict reads when it stamps `invocation_id` on decision evidence.
+ * Without it every decision row carries null, the projection still records the conversation, and a
+ * conversation-scoped evidence query answers **Known with zero records** — indistinguishable from
+ * "this conversation decided nothing". A warning, not an error: the approval loop is unaffected.
+ */
+it('warns per agent when the provenance middleware that stamps evidence is not declared', function (): void {
+    $findings = doctorFor(['a' => new UncorrelatedAgent, 'b' => new HealthyAgent, 'c' => new UncorrelatedAgent])->run();
+
+    expect($findings)->toHaveCount(2, 'One finding per uncorrelated agent; the healthy agent is not reported.');
+
+    foreach ($findings as $finding) {
+        expect($finding->code)->toBe(FindingCode::EvidenceCorrelationMiddlewareMissing)
+            ->and($finding->severity)->toBe(Severity::Warning)
+            ->and($finding->subject)->toBe(UncorrelatedAgent::class)
+            // The summary must say what the operator would otherwise see: a conversation that looks decided-nothing.
+            ->and($finding->summary)->toContain('invocation_id')
+            // The fix names the host action, not just the class.
+            ->and($finding->fix)->toContain('VerdictProvenanceMiddleware')
+            ->and($finding->fix)->toContain('middleware()');
+    }
+});
+
+/**
+ * The other precondition, checked as a table for the same reason the conversation tables are: the
+ * listener is registered by this package's own provider and can never be "unbound", but a host that
+ * published the package and never ran the new migration gets a logged error per completed turn and
+ * every conversation reported Unknown — correct, and easy to miss in a log stream.
+ */
+it('warns once, not per agent, when the correlation table is not migrated', function (): void {
+    Schema::drop('verdict_console_conversation_invocations');
+
+    $findings = doctorFor(['a' => new HealthyAgent, 'b' => new HealthyAgent])->run();
+    $tables = array_values(array_filter($findings, fn ($f) => $f->code === FindingCode::EvidenceCorrelationTableMissing));
+
+    expect($tables)->toHaveCount(1)
+        ->and($tables[0]->severity)->toBe(Severity::Warning)
+        ->and($tables[0]->subject)->toBe('verdict_console_conversation_invocations')
+        ->and($tables[0]->summary)->toContain('Unknown')
+        ->and($tables[0]->fix)->toContain('vendor:publish')
+        ->and($tables[0]->fix)->toContain('verdict-console-migrations')
+        ->and($tables[0]->fix)->toContain('migrate')
+        ->and(array_map(fn ($f) => $f->code, $findings))->not->toContain(FindingCode::EvidenceCorrelationMiddlewareMissing);
+});
+
+/** The table is a package-global precondition: it is reported with no agents registered at all. */
+it('reports the missing correlation table with no resumable agents registered', function (): void {
+    Schema::drop('verdict_console_conversation_invocations');
+
+    $findings = doctorFor()->run();
+
+    expect($findings)->toHaveCount(1)
+        ->and($findings[0]->code)->toBe(FindingCode::EvidenceCorrelationTableMissing);
+});
+
+/** Both prerequisites absent is two findings with two remedies; neither may hide the other. */
+it('reports both correlation prerequisites when both are absent', function (): void {
+    Schema::drop('verdict_console_conversation_invocations');
+
+    $findings = doctorFor(['a' => new UncorrelatedAgent])->run();
+    $byCode = [];
+
+    foreach ($findings as $finding) {
+        $byCode[$finding->code->value] = $finding;
+    }
+
+    expect($findings)->toHaveCount(2)
+        ->and($byCode)->toHaveCount(2)
+        ->and($byCode)->toHaveKeys([FindingCode::EvidenceCorrelationMiddlewareMissing->value, FindingCode::EvidenceCorrelationTableMissing->value])
+        ->and($byCode[FindingCode::EvidenceCorrelationMiddlewareMissing->value]->severity)->toBe(Severity::Warning)
+        ->and($byCode[FindingCode::EvidenceCorrelationTableMissing->value]->severity)->toBe(Severity::Warning)
+        ->and($byCode[FindingCode::EvidenceCorrelationMiddlewareMissing->value]->fix)
+        ->not->toBe($byCode[FindingCode::EvidenceCorrelationTableMissing->value]->fix);
+});
+
+/**
+ * The projection is the console's own table on the application's default connection — not on
+ * `verdict.evidence.connection`, which is where Verdict's evidence lives and where the evidence
+ * query adapter reads. A check that borrowed the evidence connection would pass on a host whose
+ * evidence database happens to hold a same-named table and miss the one the listener writes to.
+ */
+it('checks the correlation table on the default connection, not the evidence connection', function (): void {
+    config()->set('database.connections.evidence_elsewhere', ['driver' => 'sqlite', 'database' => ':memory:', 'prefix' => '']);
+    config()->set('verdict.evidence.connection', 'evidence_elsewhere');
+    Schema::connection('evidence_elsewhere')->create('verdict_console_conversation_invocations', function ($table): void {
+        $table->string('invocation_id')->primary();
+        $table->string('conversation_id')->index();
+    });
+    Schema::drop('verdict_console_conversation_invocations');
+
+    $codes = array_map(fn ($f) => $f->code, doctorFor(['a' => new HealthyAgent])->run());
+
+    expect($codes)->toContain(FindingCode::EvidenceCorrelationTableMissing);
+});
+
+/** A missing approval middleware and a missing provenance middleware are two findings, two fixes. */
+it('reports the provenance gap separately from a missing approval middleware', function (): void {
+    $codes = array_map(fn ($f) => $f->code, doctorFor(['a' => new MiddlewarelessAgent])->run());
+
+    expect($codes)->toContain(FindingCode::ApprovalMiddlewareMissing)
+        ->and($codes)->toContain(FindingCode::EvidenceCorrelationMiddlewareMissing);
 });
 
 it('returns findings as data a UI can render', function (): void {


### PR DESCRIPTION
## Summary

Two new `verdict-console:doctor` findings for the host-side preconditions of the VC-14 evidence correlation (#73), both **warnings** — the approval loop is unaffected; what goes dark is the conversation-scoped evidence surface. `--strict` promotes them for a host that depends on it.

- **`evidence_correlation_middleware_missing`** — per resolved resumable agent whose `middleware()` carries no `VerdictProvenanceMiddleware`. That middleware pushes the `InvocationContext` frame `VerdictManager` reads when stamping `invocation_id` on decision evidence; without it rows carry null and a conversation-scoped `EvidenceQuery` answers **Known with zero records** — indistinguishable from "this conversation decided nothing". The approval round trip works without it, so a host can have a working console and an empty correlation. Detected by identity (the shipped class), not behaviour.
- **`evidence_correlation_table_missing`** — once per run, with or without agents registered, when `verdict_console_conversation_invocations` is absent on the application's **default** connection (the projection is console-owned and written there; `verdict.evidence.connection` is where Verdict's evidence lives — a check against it would pass on the wrong database, and a test pins that). Until migrated, the listener logs an error per completed turn and every conversation reads `Unknown`.

`DoctorTest`'s `HealthyAgent` now declares both middlewares and the suite migrates the correlation table, so "clean" means both preconditions are met.

## Linked issue

Closes #72

## Trust and failure behavior

- Inspection only: reads `middleware()` on host-resolved agents and `Schema::hasTable()` on the default connection; executes nothing, writes nothing.
- Resolver failures continue to surface as `resolver_key_unresolvable` before any per-agent check; a missing approval middleware and a missing provenance middleware are two findings with two remedies (each names its own consequence).
- No new exit-code behaviour: warnings fail only under `--strict`, as before.

## Evidence and data handling

- Findings carry an agent class name or a table name as subject; no configuration values, prompts, or identifiers are recorded or printed.

## Verification

- [x] Success, denial, and relevant failure paths are tested.
- [x] Security containment and legitimate utility are both covered where applicable.
- [x] Documentation and `CHANGELOG.md` are updated.
- [x] `composer test` passes locally — phpstan clean, pint passed, type coverage 100%, **228 passed (1002 assertions)**.
- [x] No credentials, real customer data, or unredacted evidence are included.

Covered in `tests/Integration/DoctorTest.php`: per-agent reporting (two uncorrelated + one healthy → exactly two), once-per-run table reporting with and without agents, both-absent → two findings with distinct remedies, the default-vs-evidence connection discriminator, separation from `approval_middleware_missing`, and the clean baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
