### PR TITLE
feat: inspect-only configuration read-models over Verdict's capability registry (VC-17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Configuration inspection read-models (VC-17).** `ConfigurationInspection` now projects
+  declared capabilities with Verdict's own fingerprint, rate limits, and approval rules for an
+  operator surface. It is inspect-only because the fingerprint is recorded in every decision
+  record: the displayed value can be matched against evidence rows'
+  `configuration_fingerprint`, while a config write would change what already-recorded evidence
+  means. No write path exists by design.
+
 - **Warns when the evidence-correlation surface is unavailable (#72).**
   `verdict-console:doctor` now reports `evidence_correlation_middleware_missing` when a resumable
   agent lacks `VerdictProvenanceMiddleware`, and `evidence_correlation_table_missing` when the

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -327,6 +327,8 @@ Verdict policy is application *code*. This surface shows capabilities/limits/app
 writes only genuinely-data parts. Read-only in v1, for the sharper reason: the capability-
 configuration fingerprint is recorded in every decision record, so a config write changes what the
 evidence trail *means* — any future write surface must announce that, not just save a value.
+`ConfigurationInspection` is the shipped read boundary for capabilities with their fingerprints,
+rate limits, and approval rules; it deliberately has no write path.
 
 ## 7. Cross-cutting
 - **Who may approve is the host's call** — Laravel `Gate` evaluates the configured

--- a/src/Configuration/ApprovalRules.php
+++ b/src/Configuration/ApprovalRules.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Configuration;
+
+/**
+ * Approval rules read together from Verdict's configuration and the console's gate.
+ * Display-safe declared configuration: names, limits, and postures, never closures or resolved targets.
+ */
+final readonly class ApprovalRules
+{
+    public function __construct(
+        public ?int $ttlSeconds,
+        public ?string $authorizer,
+        public bool $strictProvenance,
+        public string $gateAbility,
+    ) {}
+
+    /** @return array{ttl_seconds: ?int, authorizer: ?string, strict_provenance: bool, gate_ability: string} */
+    public function toArray(): array
+    {
+        return [
+            'ttl_seconds' => $this->ttlSeconds,
+            'authorizer' => $this->authorizer,
+            'strict_provenance' => $this->strictProvenance,
+            'gate_ability' => $this->gateAbility,
+        ];
+    }
+}

--- a/src/Configuration/CapabilityInspection.php
+++ b/src/Configuration/CapabilityInspection.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Configuration;
+
+/**
+ * One capability as declared by Verdict.
+ * Display-safe declared configuration: names, limits, and postures, never closures or resolved targets.
+ */
+final readonly class CapabilityInspection
+{
+    public function __construct(
+        public string $name,
+        public string $ability,
+        public string $configurationFingerprint,
+        public ?string $configurationVersion,
+        public bool $confirmationRequired,
+        public ?string $confirmationReason,
+        public ?int $confirmationTtlSeconds,
+        public ?string $executionTargetPolicy,
+        public ?string $executionTargetStrategy,
+        public ?RateLimitInspection $rateLimit,
+        public ?string $executionClaimPolicy,
+        public ?bool $requiresIntentRecord,
+        public bool $consequential,
+    ) {}
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'ability' => $this->ability,
+            'configuration_fingerprint' => $this->configurationFingerprint,
+            'configuration_version' => $this->configurationVersion,
+            'confirmation_required' => $this->confirmationRequired,
+            'confirmation_reason' => $this->confirmationReason,
+            'confirmation_ttl_seconds' => $this->confirmationTtlSeconds,
+            'execution_target_policy' => $this->executionTargetPolicy,
+            'execution_target_strategy' => $this->executionTargetStrategy,
+            'rate_limit' => $this->rateLimit?->toArray(),
+            'execution_claim_policy' => $this->executionClaimPolicy,
+            'requires_intent_record' => $this->requiresIntentRecord,
+            'consequential' => $this->consequential,
+        ];
+    }
+}

--- a/src/Configuration/RateLimitInspection.php
+++ b/src/Configuration/RateLimitInspection.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Configuration;
+
+/**
+ * One rate-limit policy with the capability it guards.
+ * Display-safe declared configuration: names, limits, and postures, never closures or resolved targets.
+ */
+final readonly class RateLimitInspection
+{
+    public function __construct(
+        public string $capability,
+        public string $name,
+        public int $limit,
+        public int $windowSeconds,
+        public ?string $reason,
+    ) {}
+
+    /** @return array{capability: string, name: string, limit: int, window_seconds: int, reason: ?string} */
+    public function toArray(): array
+    {
+        return [
+            'capability' => $this->capability,
+            'name' => $this->name,
+            'limit' => $this->limit,
+            'window_seconds' => $this->windowSeconds,
+            'reason' => $this->reason,
+        ];
+    }
+}

--- a/src/Configuration/VerdictConfigurationInspection.php
+++ b/src/Configuration/VerdictConfigurationInspection.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Configuration;
+
+use Fissible\Verdict\Capabilities\Capability;
+use Fissible\Verdict\Capabilities\CapabilityRegistry;
+use Fissible\VerdictConsole\Contracts\ConfigurationInspection;
+use Illuminate\Contracts\Config\Repository as Config;
+
+/**
+ * An inspect-only projection of the configuration Verdict has already been given, with no write
+ * path.
+ *
+ * Verdict policy is application code, and each capability's
+ * configuration fingerprint is recorded in every capability-resolved decision record, so
+ * a configuration write changes what already-recorded evidence means: a row would no longer
+ * describe the capability that produced it. The console therefore shows declared state only —
+ * names, limits, postures, and the fingerprint itself, which an operator can match against evidence
+ * rows' `configuration_fingerprint`. Closures are never invoked: evaluating a resolver would turn
+ * inspection into an action rather than a display-safe read.
+ */
+final readonly class VerdictConfigurationInspection implements ConfigurationInspection
+{
+    public function __construct(
+        private CapabilityRegistry $capabilities,
+        private Config $config,
+    ) {}
+
+    /** @return list<CapabilityInspection> */
+    public function capabilities(): array
+    {
+        $inspections = array_map(
+            fn (Capability $capability): CapabilityInspection => $this->inspect($capability),
+            array_values($this->capabilities->all()),
+        );
+
+        usort($inspections, fn (CapabilityInspection $left, CapabilityInspection $right): int => $left->name <=> $right->name);
+
+        return $inspections;
+    }
+
+    /** @return list<RateLimitInspection> */
+    public function rateLimits(): array
+    {
+        $limits = array_values(array_filter(
+            array_map(fn (CapabilityInspection $capability): ?RateLimitInspection => $capability->rateLimit, $this->capabilities()),
+        ));
+
+        // This order is inherited from the name-sorted capability inspections.
+
+        return $limits;
+    }
+
+    public function approvalRules(): ApprovalRules
+    {
+        $ttl = $this->config->get('verdict.approvals.ttl_seconds');
+        $authorizer = $this->config->get('verdict.approvals.authorizer');
+        $strictProvenance = $this->config->get('verdict.approvals.strict_provenance', false);
+        $gate = $this->config->get('verdict-console.approvals.gate', 'approve-verdict-action');
+
+        return new ApprovalRules(
+            ttlSeconds: is_int($ttl) ? $ttl : null,
+            authorizer: is_string($authorizer) ? $authorizer : null,
+            strictProvenance: is_bool($strictProvenance) ? $strictProvenance : false,
+            gateAbility: is_string($gate) ? $gate : 'approve-verdict-action',
+        );
+    }
+
+    private function inspect(Capability $capability): CapabilityInspection
+    {
+        $rateLimit = $capability->rateLimitPolicy();
+        $executionTarget = $capability->executionTargetPolicy();
+        $executionClaim = $capability->executionClaimPolicy();
+        $declared = $capability->declaredConfiguration();
+
+        return new CapabilityInspection(
+            name: $capability->name,
+            ability: $capability->ability,
+            configurationFingerprint: $capability->configurationFingerprint(),
+            configurationVersion: is_string($declared['configuration_version'] ?? null) ? $declared['configuration_version'] : null,
+            confirmationRequired: $capability->confirmationRequired(),
+            confirmationReason: $capability->confirmationReason(),
+            confirmationTtlSeconds: $capability->confirmationTtlSeconds(),
+            executionTargetPolicy: $executionTarget?->name,
+            executionTargetStrategy: $executionTarget?->strategy->value,
+            rateLimit: $rateLimit === null ? null : new RateLimitInspection(
+                capability: $capability->name,
+                name: $rateLimit->name,
+                limit: $rateLimit->limit,
+                windowSeconds: $rateLimit->windowSeconds,
+                reason: $rateLimit->reason,
+            ),
+            executionClaimPolicy: $executionClaim?->name,
+            requiresIntentRecord: $capability->intentRecordRequirement(),
+            consequential: $capability->isConsequential(),
+        );
+    }
+}

--- a/src/Contracts/ConfigurationInspection.php
+++ b/src/Contracts/ConfigurationInspection.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Contracts;
+
+use Fissible\VerdictConsole\Configuration\ApprovalRules;
+use Fissible\VerdictConsole\Configuration\CapabilityInspection;
+use Fissible\VerdictConsole\Configuration\RateLimitInspection;
+
+/**
+ * Console-owned, host-replaceable read boundary for Verdict's declared configuration.
+ *
+ * Hosts that assemble capabilities or approval policy differently can bind this contract to their
+ * own read model without making an operator surface depend on Verdict's registry implementation.
+ */
+interface ConfigurationInspection
+{
+    /** @return list<CapabilityInspection> */
+    public function capabilities(): array;
+
+    /** @return list<RateLimitInspection> */
+    public function rateLimits(): array;
+
+    public function approvalRules(): ApprovalRules;
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -13,11 +13,13 @@ use Fissible\VerdictConsole\Approvals\ApprovalChallengeReader;
 use Fissible\VerdictConsole\Approvals\GateApproverAuthority;
 use Fissible\VerdictConsole\Approvals\UnscopedApprovalScope;
 use Fissible\VerdictConsole\Approvals\VerdictApprovalChallengeReader;
+use Fissible\VerdictConsole\Configuration\VerdictConfigurationInspection;
 use Fissible\VerdictConsole\Console\Commands\DoctorCommand;
 use Fissible\VerdictConsole\Contracts\ApprovalNotificationRecipients;
 use Fissible\VerdictConsole\Contracts\ApprovalPresenter;
 use Fissible\VerdictConsole\Contracts\ApprovalScope;
 use Fissible\VerdictConsole\Contracts\ApproverAuthority;
+use Fissible\VerdictConsole\Contracts\ConfigurationInspection;
 use Fissible\VerdictConsole\Contracts\ConversationParticipants;
 use Fissible\VerdictConsole\Contracts\EvidenceQuery;
 use Fissible\VerdictConsole\Contracts\ResumableAgents;
@@ -75,6 +77,8 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         $this->app->singleton(ApprovalNotificationRecipients::class, UnconfiguredApprovalNotificationRecipients::class);
 
         $this->app->singleton(EvidenceQuery::class, DatabaseEvidenceQuery::class);
+
+        $this->app->singleton(ConfigurationInspection::class, VerdictConfigurationInspection::class);
 
         $this->app->singleton(IncidentStore::class);
     }

--- a/tests/Feature/ConfigurationInspectionTest.php
+++ b/tests/Feature/ConfigurationInspectionTest.php
@@ -66,6 +66,10 @@ function inspectionOver(Capability ...$capabilities): ConfigurationInspection
 }
 
 /**
+ * Properties are compared through get_object_vars(): Pest's toMatchArray() prefers an object's
+ * toArray(), whose keys are the snake_case rendering, and these assertions name the declared
+ * properties.
+ *
  * The fingerprint is the point of the surface: every decision record carries the
  * `configuration_fingerprint` of the capability as it stood when the decision was made, so an
  * operator reading evidence can tell whether a row was decided under the configuration they are
@@ -83,7 +87,7 @@ it('lists every registered capability with its declared configuration and Verdic
 
     [$close, $read, $refund] = $capabilities;
 
-    expect($refund)->toMatchArray([
+    expect(get_object_vars($refund))->toMatchArray([
         'name' => 'orders.refund',
         'ability' => 'update',
         'configurationFingerprint' => $full->configurationFingerprint(),
@@ -98,8 +102,8 @@ it('lists every registered capability with its declared configuration and Verdic
         'consequential' => true,
     ])
         ->and($refund->rateLimit)->toBeInstanceOf(RateLimitInspection::class)
-        ->and($refund->rateLimit)->toMatchArray(['capability' => 'orders.refund', 'name' => 'refund-rate', 'limit' => 5, 'windowSeconds' => 3600, 'reason' => 'Five refunds an hour.'])
-        ->and($read)->toMatchArray([
+        ->and(get_object_vars($refund->rateLimit))->toMatchArray(['capability' => 'orders.refund', 'name' => 'refund-rate', 'limit' => 5, 'windowSeconds' => 3600, 'reason' => 'Five refunds an hour.'])
+        ->and(get_object_vars($read))->toMatchArray([
             'name' => 'billing.read',
             'ability' => 'view',
             'configurationFingerprint' => $bare->configurationFingerprint(),
@@ -114,7 +118,7 @@ it('lists every registered capability with its declared configuration and Verdic
             'requiresIntentRecord' => null,
             'consequential' => false,
         ])
-        ->and($close)->toMatchArray([
+        ->and(get_object_vars($close))->toMatchArray([
             'name' => 'accounts.close',
             'ability' => 'delete',
             'configurationFingerprint' => $sparse->configurationFingerprint(),
@@ -128,7 +132,7 @@ it('lists every registered capability with its declared configuration and Verdic
             'requiresIntentRecord' => false,
             'consequential' => true,
         ])
-        ->and($close->rateLimit)->toMatchArray(['capability' => 'accounts.close', 'name' => 'close-rate', 'limit' => 1, 'windowSeconds' => 86400, 'reason' => null]);
+        ->and(get_object_vars($close->rateLimit))->toMatchArray(['capability' => 'accounts.close', 'name' => 'close-rate', 'limit' => 1, 'windowSeconds' => 86400, 'reason' => null]);
 });
 
 it('lists rate limits only for capabilities that declare one, by capability name', function (): void {
@@ -154,7 +158,7 @@ it('reads the approval rules from Verdicts configuration and the consoles gate',
     $rules = inspectionOver()->approvalRules();
 
     expect($rules)->toBeInstanceOf(ApprovalRules::class)
-        ->and($rules)->toMatchArray([
+        ->and(get_object_vars($rules))->toMatchArray([
             'ttlSeconds' => 1200,
             'authorizer' => 'App\\Approvals\\TenantAuthorizer',
             'strictProvenance' => true,
@@ -165,7 +169,7 @@ it('reads the approval rules from Verdicts configuration and the consoles gate',
     // strict provenance, and a projection that inferred one from the other would be wrong here.
     config()->set('verdict.approvals.strict_provenance', false);
 
-    expect(inspectionOver()->approvalRules())->toMatchArray([
+    expect(get_object_vars(inspectionOver()->approvalRules()))->toMatchArray([
         'authorizer' => 'App\\Approvals\\TenantAuthorizer',
         'strictProvenance' => false,
     ]);

--- a/tests/Feature/ConfigurationInspectionTest.php
+++ b/tests/Feature/ConfigurationInspectionTest.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Capabilities\Capability;
+use Fissible\Verdict\Capabilities\CapabilityRegistry;
+use Fissible\Verdict\ExecutionClaims\ExecutionClaimPolicy;
+use Fissible\Verdict\RateLimits\RateLimitPolicy;
+use Fissible\Verdict\Targets\ExecutionTargetPolicy;
+use Fissible\VerdictConsole\Configuration\ApprovalRules;
+use Fissible\VerdictConsole\Configuration\CapabilityInspection;
+use Fissible\VerdictConsole\Configuration\RateLimitInspection;
+use Fissible\VerdictConsole\Configuration\VerdictConfigurationInspection;
+use Fissible\VerdictConsole\Contracts\ConfigurationInspection;
+
+/**
+ * Every closure a capability can hold throws. Inspection is a read of what was *declared*; if any
+ * test here trips one of these, the read-model has started evaluating policy, which is the one thing
+ * an inspect-only surface must never do.
+ */
+function inspectionNeverCalled(): Closure
+{
+    return fn (): never => throw new LogicException('Configuration inspection must not invoke capability code.');
+}
+
+function inspectionFullCapability(): Capability
+{
+    return Capability::usingPolicy('orders.refund', 'update', inspectionNeverCalled())
+        ->executionTarget(ExecutionTargetPolicy::acceptStaleSnapshot(name: 'refund-target', identityUsing: inspectionNeverCalled()))
+        ->requiresConfirmation(inspectionNeverCalled(), reason: 'Refunds move money.', ttlSeconds: 600)
+        ->rateLimit(RateLimitPolicy::fixedWindow('refund-rate', 5, 3600, inspectionNeverCalled(), 'Five refunds an hour.'))
+        ->atMostOnce(ExecutionClaimPolicy::named('refund-once', inspectionNeverCalled()))
+        ->configurationVersion('2026-08')
+        ->requiresIntentRecord(true)
+        ->executeUsing(inspectionNeverCalled());
+}
+
+function inspectionBareCapability(): Capability
+{
+    return Capability::usingPolicy('billing.read', 'view', inspectionNeverCalled());
+}
+
+/**
+ * The discriminating third shape: confirmation with no reason and no TTL, a refresh-strategy target,
+ * an explicitly *declined* intent posture, and a second rate limit — so a projection that derived
+ * fields from the wrong source, or reported only the first policy it met, cannot pass.
+ */
+function inspectionSparseCapability(): Capability
+{
+    return Capability::usingPolicy('accounts.close', 'delete', inspectionNeverCalled())
+        ->executionTarget(ExecutionTargetPolicy::refresh(name: 'close-target', identityUsing: inspectionNeverCalled(), refreshUsing: inspectionNeverCalled()))
+        ->requiresConfirmation(inspectionNeverCalled())
+        ->rateLimit(RateLimitPolicy::fixedWindow('close-rate', 1, 86400, inspectionNeverCalled()))
+        ->requiresIntentRecord(false);
+}
+
+function inspectionOver(Capability ...$capabilities): ConfigurationInspection
+{
+    $registry = new CapabilityRegistry;
+
+    foreach ($capabilities as $capability) {
+        $registry->register($capability);
+    }
+
+    return new VerdictConfigurationInspection($registry, app('config'));
+}
+
+/**
+ * The fingerprint is the point of the surface: every decision record carries the
+ * `configuration_fingerprint` of the capability as it stood when the decision was made, so an
+ * operator reading evidence can tell whether a row was decided under the configuration they are
+ * looking at now. It must be Verdict's own value, never one this package recomputes.
+ */
+it('lists every registered capability with its declared configuration and Verdicts fingerprint', function (): void {
+    $full = inspectionFullCapability();
+    $bare = inspectionBareCapability();
+    $sparse = inspectionSparseCapability();
+
+    $capabilities = inspectionOver($full, $bare, $sparse)->capabilities();
+
+    expect($capabilities)->toHaveCount(3)
+        ->and(array_map(fn (CapabilityInspection $c): string => $c->name, $capabilities))->toBe(['accounts.close', 'billing.read', 'orders.refund'], 'Sorted by name, not registration order.');
+
+    [$close, $read, $refund] = $capabilities;
+
+    expect($refund)->toMatchArray([
+        'name' => 'orders.refund',
+        'ability' => 'update',
+        'configurationFingerprint' => $full->configurationFingerprint(),
+        'configurationVersion' => '2026-08',
+        'confirmationRequired' => true,
+        'confirmationReason' => 'Refunds move money.',
+        'confirmationTtlSeconds' => 600,
+        'executionTargetPolicy' => 'refund-target',
+        'executionTargetStrategy' => 'accept_stale_snapshot',
+        'executionClaimPolicy' => 'refund-once',
+        'requiresIntentRecord' => true,
+        'consequential' => true,
+    ])
+        ->and($refund->rateLimit)->toBeInstanceOf(RateLimitInspection::class)
+        ->and($refund->rateLimit)->toMatchArray(['capability' => 'orders.refund', 'name' => 'refund-rate', 'limit' => 5, 'windowSeconds' => 3600, 'reason' => 'Five refunds an hour.'])
+        ->and($read)->toMatchArray([
+            'name' => 'billing.read',
+            'ability' => 'view',
+            'configurationFingerprint' => $bare->configurationFingerprint(),
+            'configurationVersion' => null,
+            'confirmationRequired' => false,
+            'confirmationReason' => null,
+            'confirmationTtlSeconds' => null,
+            'executionTargetPolicy' => null,
+            'executionTargetStrategy' => null,
+            'rateLimit' => null,
+            'executionClaimPolicy' => null,
+            'requiresIntentRecord' => null,
+            'consequential' => false,
+        ])
+        ->and($close)->toMatchArray([
+            'name' => 'accounts.close',
+            'ability' => 'delete',
+            'configurationFingerprint' => $sparse->configurationFingerprint(),
+            'configurationVersion' => null,
+            'confirmationRequired' => true,
+            'confirmationReason' => null,
+            'confirmationTtlSeconds' => null,
+            'executionTargetPolicy' => 'close-target',
+            'executionTargetStrategy' => 'refresh',
+            'executionClaimPolicy' => null,
+            'requiresIntentRecord' => false,
+            'consequential' => true,
+        ])
+        ->and($close->rateLimit)->toMatchArray(['capability' => 'accounts.close', 'name' => 'close-rate', 'limit' => 1, 'windowSeconds' => 86400, 'reason' => null]);
+});
+
+it('lists rate limits only for capabilities that declare one, by capability name', function (): void {
+    $limits = inspectionOver(inspectionFullCapability(), inspectionBareCapability(), inspectionSparseCapability())->rateLimits();
+
+    expect($limits)->toHaveCount(2)
+        ->and($limits[0])->toBeInstanceOf(RateLimitInspection::class)
+        ->and(array_map(fn (RateLimitInspection $l): array => [$l->capability, $l->name, $l->limit, $l->windowSeconds], $limits))
+        ->toBe([['accounts.close', 'close-rate', 1, 86400], ['orders.refund', 'refund-rate', 5, 3600]]);
+});
+
+/**
+ * Approval rules are two packages' configuration read together: Verdict's receipt TTL, authorizer,
+ * and strict-provenance posture, and this console's own Gate ability — the rule for *who may
+ * approve*, which is the host's decision delegated through config (design §7).
+ */
+it('reads the approval rules from Verdicts configuration and the consoles gate', function (): void {
+    config()->set('verdict.approvals.ttl_seconds', 1200);
+    config()->set('verdict.approvals.authorizer', 'App\\Approvals\\TenantAuthorizer');
+    config()->set('verdict.approvals.strict_provenance', true);
+    config()->set('verdict-console.approvals.gate', 'approve-refunds');
+
+    $rules = inspectionOver()->approvalRules();
+
+    expect($rules)->toBeInstanceOf(ApprovalRules::class)
+        ->and($rules)->toMatchArray([
+            'ttlSeconds' => 1200,
+            'authorizer' => 'App\\Approvals\\TenantAuthorizer',
+            'strictProvenance' => true,
+            'gateAbility' => 'approve-refunds',
+        ]);
+
+    // The two postures are independent settings; an authorizer being configured says nothing about
+    // strict provenance, and a projection that inferred one from the other would be wrong here.
+    config()->set('verdict.approvals.strict_provenance', false);
+
+    expect(inspectionOver()->approvalRules())->toMatchArray([
+        'authorizer' => 'App\\Approvals\\TenantAuthorizer',
+        'strictProvenance' => false,
+    ]);
+});
+
+/**
+ * Absent Verdict keys read as absent, never as a default this package invented on Verdict's behalf.
+ * This tier boots only the console's provider, so Verdict's config is genuinely not merged here —
+ * asserted first, so the test cannot pass by forcing the state it claims to observe.
+ */
+it('reports unset approval rules as unset rather than inventing Verdicts defaults', function (): void {
+    expect(config('verdict.approvals'))->toBeNull('Verdict is not booted in the Feature tier; its config must be absent, not nulled by this test.');
+
+    $rules = inspectionOver()->approvalRules();
+
+    expect($rules->ttlSeconds)->toBeNull()
+        ->and($rules->authorizer)->toBeNull()
+        ->and($rules->strictProvenance)->toBeFalse()
+        ->and($rules->gateAbility)->toBe('approve-verdict-action', 'The console ships this default itself.');
+});
+
+/**
+ * The acceptance criterion's second half: no write path exists. Enforced at the surface a host
+ * programs against — the contract exposes exactly the three reads; the shipped implementation adds
+ * no public surface beyond it, holds no mutable state, and hands out neither the registry nor the
+ * config repository; the projections hold no mutable state. Whether the implementation writes
+ * *internally* is not something a test can prove; that stays a review guarantee, which is why the
+ * class docblock has to state the reason writes are excluded.
+ */
+it('exposes no write path', function (): void {
+    $publicMethods = fn (string $class): array => array_values(array_map(
+        fn (ReflectionMethod $m): string => $m->getName(),
+        array_filter((new ReflectionClass($class))->getMethods(ReflectionMethod::IS_PUBLIC), fn (ReflectionMethod $m): bool => ! $m->isConstructor()),
+    ));
+    $sorted = function (array $names): array {
+        sort($names);
+
+        return $names;
+    };
+
+    expect($sorted($publicMethods(ConfigurationInspection::class)))->toBe(['approvalRules', 'capabilities', 'rateLimits'])
+        ->and($sorted($publicMethods(VerdictConfigurationInspection::class)))->toBe($sorted($publicMethods(ConfigurationInspection::class)), 'The contract is the whole public surface.');
+
+    foreach ([VerdictConfigurationInspection::class, CapabilityInspection::class, RateLimitInspection::class, ApprovalRules::class] as $class) {
+        expect((new ReflectionClass($class))->isReadOnly())->toBeTrue($class.' must hold no mutable state.');
+    }
+
+    expect((new ReflectionClass(VerdictConfigurationInspection::class))->getProperties(ReflectionProperty::IS_PUBLIC))
+        ->toBe([], 'The registry and config repository must not be reachable through the inspection.');
+});
+
+it('projects to arrays a UI can render and encode', function (): void {
+    $inspection = inspectionOver(inspectionFullCapability());
+
+    $capability = $inspection->capabilities()[0]->toArray();
+    $rules = $inspection->approvalRules()->toArray();
+
+    expect($capability)->toHaveKeys(['name', 'ability', 'configuration_fingerprint', 'confirmation_required', 'rate_limit', 'consequential'])
+        ->and($capability['rate_limit'])->toBeArray()
+        ->and($capability['rate_limit'])->toHaveKeys(['name', 'limit', 'window_seconds'])
+        ->and($rules)->toHaveKeys(['ttl_seconds', 'authorizer', 'strict_provenance', 'gate_ability'])
+        ->and(json_encode($capability, JSON_THROW_ON_ERROR))->toBeString();
+});
+
+it('binds the shipped inspection as a singleton, to a contract a host may replace', function (): void {
+    expect(app(ConfigurationInspection::class))->toBeInstanceOf(VerdictConfigurationInspection::class)
+        ->and(app(ConfigurationInspection::class))->toBe(app(ConfigurationInspection::class));
+
+    $replacement = new class implements ConfigurationInspection
+    {
+        public function capabilities(): array
+        {
+            return [];
+        }
+
+        public function rateLimits(): array
+        {
+            return [];
+        }
+
+        public function approvalRules(): ApprovalRules
+        {
+            return new ApprovalRules(null, null, false, 'approve-verdict-action');
+        }
+    };
+
+    app()->instance(ConfigurationInspection::class, $replacement);
+
+    expect(app(ConfigurationInspection::class))->toBe($replacement);
+});

--- a/tests/Feature/DocumentationCorrectionsTest.php
+++ b/tests/Feature/DocumentationCorrectionsTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Fissible\VerdictConsole\Configuration\VerdictConfigurationInspection;
 use Fissible\VerdictConsole\Presentation\DefaultApprovalPresenter;
 
 function documentation(string $path): string
@@ -65,6 +66,25 @@ it('names the evidence-correlation doctor findings in the design of record', fun
     expect(documentation('docs/design/0001-verdict-console-design.md'))
         ->toContain('`evidence_correlation_middleware_missing`')
         ->toContain('`evidence_correlation_table_missing`');
+});
+
+/**
+ * Inspect-only is a decision with a reason, and the reason has to travel with the code: the
+ * capability-configuration fingerprint is recorded in every decision record, so a config write
+ * changes what the evidence trail means. The class that could grow a write path must say so.
+ */
+it('documents why configuration inspection has no write path', function (): void {
+    $docblock = (string) (new ReflectionClass(VerdictConfigurationInspection::class))->getDocComment();
+
+    // The causal statement, not keywords: the fingerprint travels with every capability-resolved
+    // decision record, so a configuration write changes what already-recorded evidence means.
+    expect($docblock)->toContain('inspect-only')
+        ->and($docblock)->toContain('configuration fingerprint is recorded in every capability-resolved decision record')
+        ->and($docblock)->toContain('a configuration write changes what already-recorded evidence means');
+
+    expect(documentation('docs/design/0001-verdict-console-design.md'))
+        ->toContain('`ConfigurationInspection`')
+        ->toContain('recorded in every decision record');
 });
 
 /** Folded in from the VC-13 review: the UTC reading is a contract from verdict#335 onward, not a hope. */

--- a/tests/Integration/ConfigurationInspectionWiringTest.php
+++ b/tests/Integration/ConfigurationInspectionWiringTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Actions\ActionEnvelope;
+use Fissible\Verdict\Capabilities\Capability;
+use Fissible\Verdict\Contracts\CapabilityAuthorizer;
+use Fissible\Verdict\Decisions\Decision;
+use Fissible\Verdict\VerdictManager;
+use Fissible\VerdictConsole\Configuration\CapabilityInspection;
+use Fissible\VerdictConsole\Contracts\ConfigurationInspection;
+
+/**
+ * The Feature suite proves the projection over a hand-built registry. This proves the container
+ * hands the shipped inspection Verdict's *real* registry — the one `VerdictManager::capability()`
+ * writes to — rather than a fresh, empty one that would make every host's console show nothing.
+ */
+it('inspects the capabilities the application registered through Verdict', function (): void {
+    app()->instance(CapabilityAuthorizer::class, new class implements CapabilityAuthorizer
+    {
+        public function decide(Capability $capability, ActionEnvelope $envelope, mixed $target): Decision
+        {
+            return Decision::permit('wiring test');
+        }
+    });
+
+    $capability = Capability::usingPolicy('wiring.probe', 'update', fn (ActionEnvelope $e): object => new stdClass);
+    app(VerdictManager::class)->capability($capability);
+
+    $inspected = array_values(array_filter(
+        app(ConfigurationInspection::class)->capabilities(),
+        fn (CapabilityInspection $c): bool => $c->name === 'wiring.probe',
+    ));
+
+    expect($inspected)->toHaveCount(1)
+        ->and($inspected[0]->configurationFingerprint)->toBe($capability->configurationFingerprint())
+        ->and(app(ConfigurationInspection::class)->approvalRules()->ttlSeconds)->toBe(config('verdict.approvals.ttl_seconds'), 'Verdict\'s merged config is what a real host reads.');
+});


### PR DESCRIPTION
## Summary

Inspect-only read-models over Verdict's declared configuration (design §6.8, §13), for the operator surfaces that follow:

- **`ConfigurationInspection`** — a console-owned, host-replaceable contract with exactly three reads: `capabilities()` (sorted by name), `rateLimits()` (only capabilities declaring a policy), `approvalRules()`.
- **`VerdictConfigurationInspection`** — the shipped implementation over `CapabilityRegistry` + config. It reads getters only and **never invokes a capability's closures** (every fixture closure throws to prove it).
- **Projections** (`CapabilityInspection`, `RateLimitInspection`, `ApprovalRules`) — `final readonly`, display-safe declared configuration with snake_case `toArray()`.
- The useful bit is the **fingerprint**: it is Verdict's own `Capability::configurationFingerprint()`, the value every capability-resolved decision row carries as `configuration_fingerprint`, so an operator can tell whether evidence was decided under the configuration they are looking at.
- **Approval rules** read two packages together: Verdict's `ttl_seconds` / `authorizer` / `strict_provenance`, and the console's own Gate ability. Absent Verdict keys read as absent (null / false) — the console does not invent Verdict's defaults.

**No write path, by design and by test:** the contract is the entire public surface of the implementation, every class is readonly, no public property exposes the registry or config, and the class docblock states the reason (a configuration write changes what already-recorded evidence means).

## Linked issue

Closes #17

## Trust and failure behavior

- Reads only; no untrusted input; nothing resolved or executed. Capability closures (target resolvers, executors, binding/key resolvers) are never called — inspection cannot become an action.
- No fail-closed path is needed because nothing can be decided or mutated here.

## Evidence and data handling

- Exposes names, limits, postures, and Verdict's fingerprint; never closures, resolved targets, or raw evidence. Confirmation/rate-limit reasons are the capability author's code-level text, not user or model content.

## Verification

- [x] Success, denial, and relevant failure paths are tested.
- [x] Security containment and legitimate utility are both covered where applicable.
- [x] Documentation and `CHANGELOG.md` are updated.
- [x] `composer test` passes locally — phpstan clean, pint passed, type coverage 100%, **238 passed (1154 assertions)**.
- [x] No credentials, real customer data, or unredacted evidence are included.

Three fixture shapes (fully declared, bare, and a sparse refresh-strategy/no-reason/intent-declined one), independent authorizer vs strict-provenance assertions, an Integration test proving the container hands the shipped inspection Verdict's real registry, and a docs test pinning the causal reason for inspect-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
