### PR TITLE
feat: execution-claim read-model and authorized reconciliation over Verdict's manager (VC-16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Execution-claim read model and authorized reconciliation (VC-16).** `ExecutionClaimService`
+  lists Verdict's unresolved claims and resolves them through its `ExecutionClaimManager`; its
+  fail-closed authority uses the host-configured `verdict-console.execution_claims.gate` ability.
+  Still-active claims require an explicit force after investigation, each item carries Verdict's
+  evidence-correlation fingerprint, and a successful call returns Verdict's own outcome rather
+  than treating the requested resolution as fact.
+
 - **Configuration inspection read-models (VC-17).** `ConfigurationInspection` now projects
   declared capabilities with Verdict's own fingerprint, rate limits, and approval rules for an
   operator surface. It is inspect-only because the fingerprint is recorded in every decision

--- a/config/verdict-console.php
+++ b/config/verdict-console.php
@@ -34,6 +34,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Execution-claim authority
+    |--------------------------------------------------------------------------
+    | Who may reconcile a claim is the HOST's decision, delegated to a Laravel
+    | Gate. The console names the ability but does not own that authority.
+    | (Design §7.)
+    */
+    'execution_claims' => [
+        'gate' => 'resolve-verdict-execution-claim',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Ephemeral ingestion incidents
     |--------------------------------------------------------------------------
     |

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -358,7 +358,9 @@ free.
   1. **Unresolved execution claims** — an indeterminate claim = executor threw after admission; the
      one queue where a human's action is genuinely required. Higher urgency than the evidence
      browser. [`src/Console/Commands/ListExecutionClaimsCommand.php` → `verdict:execution-claims`],
-     [`ResolveExecutionClaimCommand.php` → `verdict:resolve-execution-claim`]
+     [`ResolveExecutionClaimCommand.php` → `verdict:resolve-execution-claim`]. The headless
+     `ExecutionClaimService` behind that surface lists and authorizes resolution through
+     `ExecutionClaimManager`, checking the `verdict-console.execution_claims.gate` ability.
   2. **`verdict:validate` as a screen** — surfaces the #230 dead gate: `requiresConfirmation()` with
      no `executionTarget()` → `requestConfirmation()` returns `null`, so it never pauses and never
      reaches the inbox; execution later denies. [`src/Console/Commands/ValidateVerdictCommand.php`],

--- a/src/Contracts/ExecutionClaimAuthority.php
+++ b/src/Contracts/ExecutionClaimAuthority.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Contracts;
+
+use Fissible\VerdictConsole\Exceptions\ApproverNotIdentified;
+use Fissible\VerdictConsole\ExecutionClaims\ExecutionClaimItem;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+/**
+ * Who may reconcile an execution claim, and what name that reconciliation is recorded under.
+ *
+ * Both answers belong to the host. The Gate receives the item so a host policy can scope by
+ * capability or tenant, while the package never invents an identity convention for Verdict's
+ * reconciliation audit trail.
+ */
+interface ExecutionClaimAuthority
+{
+    /** Whether this operator may reconcile this claim. */
+    public function allows(ExecutionClaimItem $claim, ?Authenticatable $operator): bool;
+
+    /**
+     * The audit label Verdict records as the person who resolved this claim.
+     *
+     * @throws ApproverNotIdentified when there is no operator to name
+     */
+    public function actorKeyFor(?Authenticatable $operator): string;
+}

--- a/src/Exceptions/ExecutionClaimNotFound.php
+++ b/src/Exceptions/ExecutionClaimNotFound.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Exceptions;
+
+use RuntimeException;
+
+/** The authenticated operator named a claim Verdict no longer has. */
+final class ExecutionClaimNotFound extends RuntimeException
+{
+    public static function forClaim(string $claimId): self
+    {
+        return new self('Execution claim ['.$claimId.'] was not found.');
+    }
+}

--- a/src/Exceptions/ExecutionClaimResolutionFailed.php
+++ b/src/Exceptions/ExecutionClaimResolutionFailed.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Exceptions;
+
+use Fissible\Verdict\ExecutionClaims\ExecutionClaimOutcome;
+use RuntimeException;
+
+/** Verdict declined to make the requested terminal reconciliation transition. */
+final class ExecutionClaimResolutionFailed extends RuntimeException
+{
+    public function __construct(
+        public readonly ExecutionClaimOutcome $outcome,
+        string $message,
+    ) {
+        parent::__construct($message);
+    }
+
+    public static function forClaim(string $claimId, ExecutionClaimOutcome $outcome): self
+    {
+        return new self($outcome, 'Execution claim ['.$claimId.'] resolution failed with outcome ['.$outcome->value.'].');
+    }
+}

--- a/src/Exceptions/ExecutionClaimStillActive.php
+++ b/src/Exceptions/ExecutionClaimStillActive.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Exceptions;
+
+use LogicException;
+
+/** A claimed row may still be executing and therefore needs an explicit override. */
+final class ExecutionClaimStillActive extends LogicException
+{
+    public static function forClaim(string $claimId): self
+    {
+        return new self('Execution claim ['.$claimId.'] is still active; investigate, then repeat with force.');
+    }
+}

--- a/src/ExecutionClaims/ExecutionClaimItem.php
+++ b/src/ExecutionClaims/ExecutionClaimItem.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\ExecutionClaims;
+
+use DateTimeImmutable;
+use Fissible\Verdict\ExecutionClaims\ExecutionClaim;
+
+/**
+ * The safe claim projection an operator surface may render and authorize.
+ *
+ * Verdict records `hash('sha256', $claim->id)` as `execution_claim_fingerprint` on decision
+ * evidence. Keeping that value here makes the evidence correlation described in design §6.2 a
+ * direct join rather than a Console-owned claim record.
+ */
+final readonly class ExecutionClaimItem
+{
+    public function __construct(
+        public string $id,
+        public string $fingerprint,
+        public string $capability,
+        public string $policy,
+        public string $bindingFingerprint,
+        public string $status,
+        public int $attemptCount,
+        public DateTimeImmutable $claimedAt,
+        public ?DateTimeImmutable $indeterminateAt,
+        public DateTimeImmutable $updatedAt,
+    ) {}
+
+    public static function fromClaim(ExecutionClaim $claim): self
+    {
+        return new self(
+            id: $claim->id,
+            fingerprint: hash('sha256', $claim->id),
+            capability: $claim->capability,
+            policy: $claim->policy,
+            bindingFingerprint: $claim->bindingFingerprint,
+            status: $claim->status->value,
+            attemptCount: $claim->attemptCount,
+            claimedAt: $claim->claimedAt,
+            indeterminateAt: $claim->indeterminateAt,
+            updatedAt: $claim->updatedAt,
+        );
+    }
+
+    /**
+     * @return array<string, int|string|null>
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'fingerprint' => $this->fingerprint,
+            'capability' => $this->capability,
+            'policy' => $this->policy,
+            'binding_fingerprint' => $this->bindingFingerprint,
+            'status' => $this->status,
+            'attempt_count' => $this->attemptCount,
+            'claimed_at' => $this->claimedAt->format(DATE_ATOM),
+            'indeterminate_at' => $this->indeterminateAt?->format(DATE_ATOM),
+            'updated_at' => $this->updatedAt->format(DATE_ATOM),
+        ];
+    }
+}

--- a/src/ExecutionClaims/ExecutionClaimService.php
+++ b/src/ExecutionClaims/ExecutionClaimService.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\ExecutionClaims;
+
+use Fissible\Verdict\ExecutionClaims\ExecutionClaimManager;
+use Fissible\Verdict\ExecutionClaims\ExecutionClaimOutcome;
+use Fissible\Verdict\ExecutionClaims\ExecutionClaimResolution;
+use Fissible\Verdict\ExecutionClaims\ExecutionClaimStatus;
+use Fissible\Verdict\ExecutionClaims\ExecutionClaimTransition;
+use Fissible\VerdictConsole\Contracts\ExecutionClaimAuthority;
+use Fissible\VerdictConsole\Exceptions\ExecutionClaimNotFound;
+use Fissible\VerdictConsole\Exceptions\ExecutionClaimResolutionFailed;
+use Fissible\VerdictConsole\Exceptions\ExecutionClaimStillActive;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Auth\Authenticatable;
+use InvalidArgumentException;
+
+/**
+ * Lists and reconciles Verdict execution claims without creating Console claim state.
+ *
+ * An indeterminate claim is the one queue where a human is genuinely required (design §8). Verdict
+ * retains the resolution's actor and reason; this service records nothing of its own, and returns
+ * Verdict's outcome rather than treating the caller's intended resolution as what happened.
+ */
+final readonly class ExecutionClaimService
+{
+    private const string AUTHORIZATION_REFUSAL_MESSAGE = 'This operator may not resolve this execution claim.';
+
+    public function __construct(
+        private ExecutionClaimManager $claims,
+        private ExecutionClaimAuthority $authority,
+    ) {}
+
+    /** @return list<ExecutionClaimItem> */
+    public function unresolved(): array
+    {
+        return array_map(ExecutionClaimItem::fromClaim(...), $this->claims->unresolved());
+    }
+
+    public function resolve(
+        string $claimId,
+        ExecutionClaimResolution $resolution,
+        ?Authenticatable $operator,
+        string $reason,
+        bool $force = false,
+    ): ExecutionClaimTransition {
+        // This boundary precedes lookup so an anonymous caller cannot use the service as an id
+        // oracle, even if a host's Gate deliberately has guest-permissive callbacks.
+        if ($operator === null) {
+            throw new AuthorizationException(self::AUTHORIZATION_REFUSAL_MESSAGE);
+        }
+
+        $claim = $this->claims->find($claimId);
+
+        if ($claim === null) {
+            throw ExecutionClaimNotFound::forClaim($claimId);
+        }
+
+        $item = ExecutionClaimItem::fromClaim($claim);
+
+        if (! $this->authority->allows($item, $operator)) {
+            throw new AuthorizationException(self::AUTHORIZATION_REFUSAL_MESSAGE);
+        }
+
+        if (trim($reason) === '') {
+            throw new InvalidArgumentException('A reconciliation reason is required.');
+        }
+
+        if ($claim->status === ExecutionClaimStatus::Claimed && ! $force) {
+            throw ExecutionClaimStillActive::forClaim($claimId);
+        }
+
+        $transition = $this->claims->resolve(
+            $claimId,
+            $resolution,
+            $this->authority->actorKeyFor($operator),
+            $reason,
+        );
+
+        if (! in_array($transition->outcome, [ExecutionClaimOutcome::Completed, ExecutionClaimOutcome::Released], true)) {
+            throw ExecutionClaimResolutionFailed::forClaim($claimId, $transition->outcome);
+        }
+
+        return $transition;
+    }
+}

--- a/src/ExecutionClaims/GateExecutionClaimAuthority.php
+++ b/src/ExecutionClaims/GateExecutionClaimAuthority.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\ExecutionClaims;
+
+use Fissible\VerdictConsole\Contracts\ExecutionClaimAuthority;
+use Fissible\VerdictConsole\Exceptions\ApproverNotIdentified;
+use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Config\Repository as Config;
+
+/**
+ * The shipped fail-closed authority: a Laravel Gate ability and the operator's own identifier.
+ *
+ * The ability comes from `verdict-console.execution_claims.gate`; a host with another authority
+ * model replaces this binding instead of making reconciliation policy a package decision.
+ */
+final readonly class GateExecutionClaimAuthority implements ExecutionClaimAuthority
+{
+    public function __construct(
+        private Gate $gate,
+        private Config $config,
+    ) {}
+
+    public function allows(ExecutionClaimItem $claim, ?Authenticatable $operator): bool
+    {
+        // A host may intentionally grant a Gate ability to guests. Reconciliation must not expose
+        // that escape hatch: an unauthenticated call cannot be an attributable human resolution.
+        if ($operator === null) {
+            return false;
+        }
+
+        return $this->gate->forUser($operator)->allows($this->ability(), $claim);
+    }
+
+    public function actorKeyFor(?Authenticatable $operator): string
+    {
+        if ($operator === null) {
+            throw ApproverNotIdentified::make();
+        }
+
+        $key = $operator->getAuthIdentifier();
+
+        if ($key === null || (is_string($key) && trim($key) === '')) {
+            throw ApproverNotIdentified::make();
+        }
+
+        return (string) $key;
+    }
+
+    private function ability(): string
+    {
+        $ability = $this->config->get('verdict-console.execution_claims.gate');
+
+        return is_string($ability) && $ability !== '' ? $ability : 'resolve-verdict-execution-claim';
+    }
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -22,10 +22,12 @@ use Fissible\VerdictConsole\Contracts\ApproverAuthority;
 use Fissible\VerdictConsole\Contracts\ConfigurationInspection;
 use Fissible\VerdictConsole\Contracts\ConversationParticipants;
 use Fissible\VerdictConsole\Contracts\EvidenceQuery;
+use Fissible\VerdictConsole\Contracts\ExecutionClaimAuthority;
 use Fissible\VerdictConsole\Contracts\ResumableAgents;
 use Fissible\VerdictConsole\Events\ApprovalDecisionRefused;
 use Fissible\VerdictConsole\Events\ApprovalIngestionIncident;
 use Fissible\VerdictConsole\Evidence\DatabaseEvidenceQuery;
+use Fissible\VerdictConsole\ExecutionClaims\GateExecutionClaimAuthority;
 use Fissible\VerdictConsole\Incidents\IncidentStore;
 use Fissible\VerdictConsole\Listeners\IngestToolApprovalRequests;
 use Fissible\VerdictConsole\Listeners\LogApprovalIngestionIncident;
@@ -66,6 +68,10 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         // Bound to the Gate-backed authority, which denies until the host defines the ability. A
         // host whose authority model is not a Gate rebinds this contract.
         $this->app->singleton(ApproverAuthority::class, GateApproverAuthority::class);
+
+        // Reconciliation authority is host policy too. The shipped Gate authority denies until its
+        // ability is defined; hosts with tenant or ownership rules can replace this contract.
+        $this->app->singleton(ExecutionClaimAuthority::class, GateExecutionClaimAuthority::class);
 
         // A singleton because registrations must survive resolution: a host registers its resolvers
         // once at boot, and every later resolve() must see them. Bound to the shipped registry so

--- a/tests/Feature/DocumentationCorrectionsTest.php
+++ b/tests/Feature/DocumentationCorrectionsTest.php
@@ -87,6 +87,13 @@ it('documents why configuration inspection has no write path', function (): void
         ->toContain('recorded in every decision record');
 });
 
+/** Design §8's first ops surface now has a headless service; the design must name it beside the commands it mirrors. */
+it('names the execution-claim service in the design of record', function (): void {
+    expect(documentation('docs/design/0001-verdict-console-design.md'))
+        ->toContain('`ExecutionClaimService`')
+        ->toContain('`verdict-console.execution_claims.gate`');
+});
+
 /** Folded in from the VC-13 review: the UTC reading is a contract from verdict#335 onward, not a hope. */
 it('cites the Verdict change that makes the evidence timestamp reading a UTC contract', function (): void {
     expect(documentation('src/Evidence/DatabaseEvidenceQuery.php'))->toContain('fissible/verdict#335');

--- a/tests/Integration/ExecutionClaimServiceTest.php
+++ b/tests/Integration/ExecutionClaimServiceTest.php
@@ -200,7 +200,8 @@ it('lists unresolved claims with the fingerprint evidence records them under', f
 
     // Evidence keeps only hash('sha256', id) as execution_claim_fingerprint (design §6.2); the item
     // carries that value so an operator can join a claim to the decision rows it produced.
-    expect($indeterminate)->toMatchArray([
+    // Properties compared through get_object_vars(): toMatchArray() would read toArray()'s snake_case.
+    expect(get_object_vars($indeterminate))->toMatchArray([
         'id' => 'claim-indeterminate',
         'fingerprint' => hash('sha256', 'claim-indeterminate'),
         'capability' => 'orders.refund',

--- a/tests/Integration/ExecutionClaimServiceTest.php
+++ b/tests/Integration/ExecutionClaimServiceTest.php
@@ -1,0 +1,408 @@
+<?php
+
+declare(strict_types=1);
+
+use DateTimeImmutable as ClaimTime;
+use Fissible\Verdict\Contracts\Clock;
+use Fissible\Verdict\Contracts\ExecutionClaimStore;
+use Fissible\Verdict\ExecutionClaims\ExecutionClaim;
+use Fissible\Verdict\ExecutionClaims\ExecutionClaimManager;
+use Fissible\Verdict\ExecutionClaims\ExecutionClaimOutcome;
+use Fissible\Verdict\ExecutionClaims\ExecutionClaimResolution;
+use Fissible\Verdict\ExecutionClaims\ExecutionClaimStatus;
+use Fissible\Verdict\ExecutionClaims\ExecutionClaimTransition;
+use Fissible\VerdictConsole\Contracts\ExecutionClaimAuthority;
+use Fissible\VerdictConsole\Exceptions\ExecutionClaimNotFound;
+use Fissible\VerdictConsole\Exceptions\ExecutionClaimResolutionFailed;
+use Fissible\VerdictConsole\Exceptions\ExecutionClaimStillActive;
+use Fissible\VerdictConsole\ExecutionClaims\ExecutionClaimItem;
+use Fissible\VerdictConsole\ExecutionClaims\ExecutionClaimService;
+use Fissible\VerdictConsole\ExecutionClaims\GateExecutionClaimAuthority;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\GenericUser;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Claims are created through Verdict's own store, exactly as an executor would leave them, so the
+ * rows under test are the rows an operator would meet. The console adds no claim state of its own.
+ */
+beforeEach(function (): void {
+    (require dirname(__DIR__, 2).'/vendor/fissible/verdict/database/migrations/create_verdict_execution_claims_table.php.stub')->up();
+});
+
+function claimRow(string $id, string $capability = 'orders.refund', ExecutionClaimStatus $status = ExecutionClaimStatus::Claimed): ExecutionClaim
+{
+    $now = new ClaimTime('2026-08-29 12:00:00', new DateTimeZone('UTC'));
+
+    return new ExecutionClaim(
+        id: $id,
+        capability: $capability,
+        policy: 'refund-once',
+        bindingFingerprint: hash('sha256', $id.'-binding'),
+        status: $status,
+        attemptCount: 1,
+        claimedAt: $now,
+        completedAt: null,
+        indeterminateAt: null,
+        releasedAt: null,
+        resolvedBy: null,
+        resolutionReason: null,
+        createdAt: $now,
+        updatedAt: $now,
+    );
+}
+
+/** An admitted claim whose executor then threw: the one state that genuinely needs a person. */
+function indeterminateClaim(string $id, string $capability = 'orders.refund'): ExecutionClaim
+{
+    $store = app(ExecutionClaimStore::class);
+    $store->claim(claimRow($id, $capability));
+    $transition = $store->markIndeterminate($id, new ClaimTime('2026-08-29 12:01:00', new DateTimeZone('UTC')));
+
+    expect($transition->outcome)->toBe(ExecutionClaimOutcome::Indeterminate, 'Fixture: Verdict must have marked the claim indeterminate.');
+
+    return $transition->claim;
+}
+
+/** An admitted claim still marked active — possibly executing right now. */
+function activeClaim(string $id, string $capability = 'orders.refund'): ExecutionClaim
+{
+    $transition = app(ExecutionClaimStore::class)->claim(claimRow($id, $capability));
+
+    expect($transition->outcome)->toBe(ExecutionClaimOutcome::Claimed, 'Fixture: Verdict must have admitted the claim.');
+
+    return $transition->claim;
+}
+
+/** A claim the executor finished: the transition Verdict itself takes, not a terminal-shaped row. */
+function completedClaim(string $id): void
+{
+    activeClaim($id);
+    $transition = app(ExecutionClaimStore::class)->complete($id, new ClaimTime('2026-08-29 12:02:00', new DateTimeZone('UTC')));
+
+    expect($transition->outcome)->toBe(ExecutionClaimOutcome::Completed, 'Fixture: Verdict must have completed the claim.');
+}
+
+/** A claim an operator already released for retry: resolved, so no longer anyone's to reconcile. */
+function releasedClaim(string $id): void
+{
+    indeterminateClaim($id);
+    $transition = app(ExecutionClaimStore::class)->resolve($id, ExecutionClaimResolution::Retryable, 'earlier-operator', 'Released earlier.', new ClaimTime('2026-08-29 12:03:00', new DateTimeZone('UTC')));
+
+    expect($transition->outcome)->toBe(ExecutionClaimOutcome::Released, 'Fixture: Verdict must have released the claim.');
+}
+
+/**
+ * Wraps the real store and records every resolve() it is asked for, so a test can prove the service
+ * reached Verdict's transition rather than updating the table itself and describing the result.
+ */
+final class RecordingExecutionClaimStore implements ExecutionClaimStore
+{
+    /** @var list<array{claimId: string, resolution: ExecutionClaimResolution, resolvedBy: string, reason: string, at: ClaimTime}> */
+    public array $resolutions = [];
+
+    public ?ExecutionClaimTransition $lastTransition = null;
+
+    public function __construct(private readonly ExecutionClaimStore $inner) {}
+
+    public function claim(ExecutionClaim $claim): ExecutionClaimTransition
+    {
+        return $this->inner->claim($claim);
+    }
+
+    public function complete(string $claimId, ClaimTime $at): ExecutionClaimTransition
+    {
+        return $this->inner->complete($claimId, $at);
+    }
+
+    public function markIndeterminate(string $claimId, ClaimTime $at): ExecutionClaimTransition
+    {
+        return $this->inner->markIndeterminate($claimId, $at);
+    }
+
+    public function resolve(string $claimId, ExecutionClaimResolution $resolution, string $resolvedBy, string $reason, ClaimTime $at): ExecutionClaimTransition
+    {
+        $this->resolutions[] = ['claimId' => $claimId, 'resolution' => $resolution, 'resolvedBy' => $resolvedBy, 'reason' => $reason, 'at' => $at];
+
+        return $this->lastTransition = $this->inner->resolve($claimId, $resolution, $resolvedBy, $reason, $at);
+    }
+
+    public function find(string $claimId): ?ExecutionClaim
+    {
+        return $this->inner->find($claimId);
+    }
+
+    /** @return list<ExecutionClaim> */
+    public function unresolved(): array
+    {
+        return $this->inner->unresolved();
+    }
+}
+
+/**
+ * The instant a private clock hands to one manager instance. That clock is never bound in the
+ * container, so nothing but a call through *this* `ExecutionClaimManager::resolve()` can reach the
+ * store carrying it: a service that resolved Verdict's Clock itself and called the store directly
+ * would stamp the system time instead. The store spy records what arrived.
+ */
+const RESOLVED_AT = '2026-08-29 15:30:00';
+
+function recordingStore(): RecordingExecutionClaimStore
+{
+    $store = new RecordingExecutionClaimStore(app(ExecutionClaimStore::class));
+    $privateClock = new class implements Clock
+    {
+        public function now(): ClaimTime
+        {
+            return new ClaimTime(RESOLVED_AT, new DateTimeZone('UTC'));
+        }
+    };
+
+    app()->instance(ExecutionClaimStore::class, $store);
+    app()->instance(ExecutionClaimManager::class, new ExecutionClaimManager($store, $privateClock));
+
+    return $store;
+}
+
+function operator(string $id = 'operator-1'): Authenticatable
+{
+    return new GenericUser(['id' => $id]);
+}
+
+function allowEveryone(): void
+{
+    Gate::define('resolve-verdict-execution-claim', fn (Authenticatable $user, ExecutionClaimItem $claim): bool => true);
+}
+
+/** @return array<string, mixed>|null */
+function storedClaim(string $id): ?array
+{
+    $row = DB::table('verdict_execution_claims')->where('id', $id)->first();
+
+    return $row === null ? null : (array) $row;
+}
+
+it('lists unresolved claims with the fingerprint evidence records them under', function (): void {
+    indeterminateClaim('claim-indeterminate');
+    activeClaim('claim-active', 'billing.charge');
+    completedClaim('claim-completed');
+    releasedClaim('claim-released');
+
+    $items = app(ExecutionClaimService::class)->unresolved();
+
+    expect($items)->toHaveCount(2)
+        ->and($items)->each->toBeInstanceOf(ExecutionClaimItem::class)
+        ->and(array_map(fn (ExecutionClaimItem $i): string => $i->id, $items))->toEqualCanonicalizing(['claim-indeterminate', 'claim-active']);
+
+    $indeterminate = current(array_filter($items, fn (ExecutionClaimItem $i): bool => $i->id === 'claim-indeterminate'));
+
+    // Evidence keeps only hash('sha256', id) as execution_claim_fingerprint (design §6.2); the item
+    // carries that value so an operator can join a claim to the decision rows it produced.
+    expect($indeterminate)->toMatchArray([
+        'id' => 'claim-indeterminate',
+        'fingerprint' => hash('sha256', 'claim-indeterminate'),
+        'capability' => 'orders.refund',
+        'policy' => 'refund-once',
+        'bindingFingerprint' => hash('sha256', 'claim-indeterminate-binding'),
+        'status' => 'indeterminate',
+        'attemptCount' => 1,
+    ])
+        ->and($indeterminate->indeterminateAt)->toBeInstanceOf(ClaimTime::class)
+        ->and($indeterminate->claimedAt)->toBeInstanceOf(ClaimTime::class);
+});
+
+it('projects to arrays a UI can render', function (): void {
+    indeterminateClaim('claim-1');
+
+    $array = app(ExecutionClaimService::class)->unresolved()[0]->toArray();
+
+    expect($array)->toHaveKeys(['id', 'fingerprint', 'capability', 'policy', 'binding_fingerprint', 'status', 'attempt_count', 'claimed_at', 'indeterminate_at', 'updated_at'])
+        ->and(json_encode($array, JSON_THROW_ON_ERROR))->toBeString();
+});
+
+/**
+ * The success path asserts Verdict's *returned* transition, never the caller's intent: the outcome
+ * decides what happened, and the claim row is what the audit reads later.
+ */
+it('resolves an indeterminate claim as completed through Verdicts own transition, under the authoritys actor key', function (): void {
+    allowEveryone();
+    indeterminateClaim('claim-1');
+    $store = recordingStore();
+
+    $transition = app(ExecutionClaimService::class)->resolve('claim-1', ExecutionClaimResolution::Completed, operator('operator-7'), 'Confirmed in the payment gateway: refund 8f2a settled.');
+
+    // The resolution reached Verdict's store with the console's arguments and the manager's clock
+    // instant — never a description the console composed after touching the table itself.
+    expect($store->resolutions)->toHaveCount(1)
+        ->and($store->resolutions[0])->toMatchArray([
+            'claimId' => 'claim-1',
+            'resolution' => ExecutionClaimResolution::Completed,
+            'resolvedBy' => 'operator-7',
+            'reason' => 'Confirmed in the payment gateway: refund 8f2a settled.',
+        ])
+        ->and($store->resolutions[0]['at']->format('Y-m-d H:i:s'))->toBe(RESOLVED_AT, 'Only ExecutionClaimManager::resolve() stamps Verdict\'s clock; the store was not called directly.')
+        ->and($transition->outcome)->toBe(ExecutionClaimOutcome::Completed)
+        ->and(storedClaim('claim-1'))->toMatchArray([
+            'status' => 'completed',
+            'resolved_by' => 'operator-7',
+            'resolution_reason' => 'Confirmed in the payment gateway: refund 8f2a settled.',
+        ])
+        ->and(app(ExecutionClaimService::class)->unresolved())->toBe([]);
+});
+
+/**
+ * The host's authority is the one consulted — for both answers it gives. A tenant-scoped authority
+ * that denies is obeyed even while a permissive Gate would have allowed, and the actor recorded on
+ * the row is the authority's label, never the authenticated id taken directly.
+ */
+it('obeys a replaced authority for both its denial and its actor key', function (): void {
+    allowEveryone();
+    app()->instance(ExecutionClaimAuthority::class, new class implements ExecutionClaimAuthority
+    {
+        public function allows(ExecutionClaimItem $claim, ?Authenticatable $operator): bool
+        {
+            // A tenant boundary the Gate knows nothing about.
+            return $operator !== null && str_starts_with($claim->capability, 'orders.');
+        }
+
+        public function actorKeyFor(?Authenticatable $operator): string
+        {
+            return 'ops-team:'.$operator?->getAuthIdentifier();
+        }
+    });
+    indeterminateClaim('claim-orders', 'orders.refund');
+    indeterminateClaim('claim-billing', 'billing.charge');
+    $service = app(ExecutionClaimService::class);
+
+    expect(fn (): mixed => $service->resolve('claim-billing', ExecutionClaimResolution::Completed, operator('operator-7'), 'Checked.'))
+        ->toThrow(AuthorizationException::class)
+        ->and(storedClaim('claim-billing'))->toMatchArray(['status' => 'indeterminate', 'resolved_by' => null]);
+
+    $service->resolve('claim-orders', ExecutionClaimResolution::Completed, operator('operator-7'), 'Checked.');
+
+    expect(storedClaim('claim-orders')['resolved_by'])->toBe('ops-team:operator-7');
+});
+
+it('releases an indeterminate claim for one explicit retry', function (): void {
+    allowEveryone();
+    indeterminateClaim('claim-1');
+
+    $transition = app(ExecutionClaimService::class)->resolve('claim-1', ExecutionClaimResolution::Retryable, operator(), 'Gateway shows no charge; safe to retry.');
+
+    expect($transition->outcome)->toBe(ExecutionClaimOutcome::Released)
+        ->and(storedClaim('claim-1')['status'])->toBe('released');
+});
+
+/**
+ * The shipped authority denies until the host defines the ability, and an anonymous operator is
+ * refused before any Gate is consulted — the same fail-closed shape as approvals. Neither attempt
+ * may reach Verdict: the row stays exactly as the executor left it.
+ */
+it('refuses to resolve while no Gate ability is defined', function (): void {
+    indeterminateClaim('claim-1');
+
+    expect(fn (): mixed => app(ExecutionClaimService::class)->resolve('claim-1', ExecutionClaimResolution::Completed, operator(), 'Checked.'))
+        ->toThrow(AuthorizationException::class)
+        ->and(storedClaim('claim-1'))->toMatchArray(['status' => 'indeterminate', 'resolved_by' => null, 'resolution_reason' => null]);
+});
+
+/**
+ * An anonymous operator is refused before the Gate is consulted. The Gate here admits guests — a
+ * nullable user parameter is how Laravel lets it — so only a guard in front of it can produce this
+ * refusal, and it holds even when the claim does not exist: nobody unauthenticated learns whether
+ * an id is real.
+ */
+it('refuses an anonymous operator before the Gate, even for an unknown claim', function (): void {
+    Gate::define('resolve-verdict-execution-claim', fn (?Authenticatable $user, ExecutionClaimItem $claim): bool => true);
+    indeterminateClaim('claim-1');
+    $service = app(ExecutionClaimService::class);
+
+    expect(fn (): mixed => $service->resolve('claim-1', ExecutionClaimResolution::Completed, null, 'Checked.'))
+        ->toThrow(AuthorizationException::class)
+        ->and(fn (): mixed => $service->resolve('no-such-claim', ExecutionClaimResolution::Completed, null, 'Checked.'))
+        ->toThrow(AuthorizationException::class)
+        ->and(storedClaim('claim-1'))->toMatchArray(['status' => 'indeterminate', 'resolved_by' => null]);
+});
+
+/** The Gate receives the item, so a host policy can scope by capability, tenant, or ownership. */
+it('lets the host Gate scope which claims an operator may resolve', function (): void {
+    Gate::define('resolve-verdict-execution-claim', fn (Authenticatable $user, ExecutionClaimItem $claim): bool => str_starts_with($claim->capability, 'orders.'));
+    indeterminateClaim('claim-orders', 'orders.refund');
+    indeterminateClaim('claim-billing', 'billing.charge');
+    $service = app(ExecutionClaimService::class);
+
+    expect(fn (): mixed => $service->resolve('claim-billing', ExecutionClaimResolution::Completed, operator(), 'Checked.'))
+        ->toThrow(AuthorizationException::class)
+        ->and($service->resolve('claim-orders', ExecutionClaimResolution::Completed, operator(), 'Checked.')->outcome)->toBe(ExecutionClaimOutcome::Completed)
+        ->and(storedClaim('claim-billing')['status'])->toBe('indeterminate');
+});
+
+/** A reconciliation without a reason is not a reconciliation; refused here, before Verdict sees it. */
+it('refuses a blank reconciliation reason', function (string $reason): void {
+    allowEveryone();
+    indeterminateClaim('claim-1');
+
+    expect(fn (): mixed => app(ExecutionClaimService::class)->resolve('claim-1', ExecutionClaimResolution::Completed, operator(), $reason))
+        ->toThrow(InvalidArgumentException::class, 'reason')
+        ->and(storedClaim('claim-1')['status'])->toBe('indeterminate');
+})->with(['empty' => '', 'whitespace' => "  \n\t"]);
+
+/**
+ * A claim still marked active may be executing at this moment. Resolving it is sometimes right — a
+ * worker died without marking anything — but never by default, so the console mirrors Verdict's own
+ * command: an explicit force, or a refusal that names the state.
+ */
+it('refuses a still-active claim unless the operator forces it', function (): void {
+    allowEveryone();
+    activeClaim('claim-1');
+    $service = app(ExecutionClaimService::class);
+
+    expect(fn (): mixed => $service->resolve('claim-1', ExecutionClaimResolution::Retryable, operator(), 'Worker died mid-flight.'))
+        ->toThrow(ExecutionClaimStillActive::class)
+        ->and(storedClaim('claim-1')['status'])->toBe('claimed')
+        ->and($service->resolve('claim-1', ExecutionClaimResolution::Retryable, operator(), 'Worker died mid-flight.', force: true)->outcome)->toBe(ExecutionClaimOutcome::Released);
+});
+
+/** Claim ids are 64-character random values; naming an unknown one to an authenticated operator discloses nothing enumerable. */
+it('names an unknown claim to an authenticated operator rather than resolving nothing', function (): void {
+    allowEveryone();
+
+    expect(fn (): mixed => app(ExecutionClaimService::class)->resolve('no-such-claim', ExecutionClaimResolution::Completed, operator(), 'Checked.'))
+        ->toThrow(ExecutionClaimNotFound::class, 'no-such-claim');
+});
+
+/**
+ * Verdict answers a resolve on an already-resolved claim with an outcome, not an exception. The
+ * console must not report that as success: the transition's outcome is the fact, and a resolve that
+ * did not complete or release is a failure carrying the outcome Verdict gave.
+ */
+it('reports a transition that neither completed nor released as a failure carrying Verdicts outcome', function (): void {
+    allowEveryone();
+    indeterminateClaim('claim-1');
+    $service = app(ExecutionClaimService::class);
+    $service->resolve('claim-1', ExecutionClaimResolution::Completed, operator(), 'First reconciliation.');
+
+    try {
+        $service->resolve('claim-1', ExecutionClaimResolution::Retryable, operator(), 'Second reconciliation.');
+        $this->fail('A second resolution of a completed claim must not report success.');
+    } catch (ExecutionClaimResolutionFailed $e) {
+        expect($e->outcome)->toBe(ExecutionClaimOutcome::InvalidState)
+            ->and($e->getMessage())->toContain('claim-1');
+    }
+
+    expect(storedClaim('claim-1'))->toMatchArray(['status' => 'completed', 'resolution_reason' => 'First reconciliation.']);
+});
+
+it('binds a fail-closed Gate authority the host may replace, on its own configured ability', function (): void {
+    expect(app(ExecutionClaimAuthority::class))->toBeInstanceOf(GateExecutionClaimAuthority::class)
+        ->and(config('verdict-console.execution_claims.gate'))->toBe('resolve-verdict-execution-claim');
+
+    config()->set('verdict-console.execution_claims.gate', 'reconcile-claims');
+    Gate::define('reconcile-claims', fn (Authenticatable $user, ExecutionClaimItem $claim): bool => true);
+    indeterminateClaim('claim-1');
+
+    expect(app(ExecutionClaimService::class)->resolve('claim-1', ExecutionClaimResolution::Completed, operator(), 'Checked.')->outcome)
+        ->toBe(ExecutionClaimOutcome::Completed);
+});


### PR DESCRIPTION
## Summary

The headless service behind design §8's first ops surface — the one queue where a human is genuinely required: an execution claim whose executor threw after admission.

- **`ExecutionClaimService::unresolved()`** — mirrors `verdict:execution-claims`; each `ExecutionClaimItem` carries `fingerprint = sha256(id)`, the value Verdict records as `execution_claim_fingerprint` on decision evidence, so an operator can join a claim to the decisions it produced (the correlation design §6.2 assigned to VC-16).
- **`ExecutionClaimService::resolve(id, resolution, operator, reason, force)`** — mirrors `verdict:resolve-execution-claim`, through **`ExecutionClaimManager::resolve`** (never the store). Refusals, in order: anonymous → `AuthorizationException` *before any lookup* (the service cannot be used as an id oracle); unknown id → `ExecutionClaimNotFound`; host authority denies → `AuthorizationException` (same non-disclosing message); blank reason → `InvalidArgumentException`; still-`claimed` without `force` → `ExecutionClaimStillActive`. A transition that neither completed nor released → `ExecutionClaimResolutionFailed` carrying Verdict's outcome — **the outcome is the fact, never the caller's intent.**
- **`ExecutionClaimAuthority`** — host-replaceable, mirroring `ApproverAuthority`. Shipped `GateExecutionClaimAuthority` is fail-closed (null operator refused before the Gate, so a guest-permissive Gate can't reach it; undefined ability denies) on `verdict-console.execution_claims.gate` (default `resolve-verdict-execution-claim`). The Gate receives the item so a host policy can scope by capability/tenant. The actor recorded on Verdict's row is the authority's key, never the auth id taken directly.
- The console adds **no claim state of its own**: Verdict's row carries `resolved_by` and the reason.

## Linked issue

Closes #16

## Trust and failure behavior

- Untrusted input: the operator-supplied claim id, resolution, and reason. Only the reason is persisted, by Verdict, on its own row, and only after authority and a non-blank check.
- Fail-closed at every step above; nothing reaches Verdict until authority, reason, and the force rule pass. The tests assert the row is untouched after each refusal.
- The manager boundary is proven, not assumed: a test binds an `ExecutionClaimManager` built over a private clock the container never sees and a store spy; only a call through that manager's `resolve()` can hand the store the asserted instant.
- No retries, no transactions of the console's own: `ExecutionClaimManager::resolve` runs inside Verdict's `SecurityStateTransaction`.

## Evidence and data handling

- Items expose claim id, policy/capability names, status, counts, timestamps, and fingerprints — no arguments, targets, or bindings beyond the binding fingerprint Verdict already publishes.
- Refused attempts are not persisted anywhere (a refused-attempt incident like #67's is a possible follow-up, not built here).

## Verification

- [x] Success, denial, and relevant failure paths are tested.
- [x] Security containment and legitimate utility are both covered where applicable.
- [x] Documentation and `CHANGELOG.md` are updated.
- [x] `composer test` passes locally — phpstan clean, pint passed, type coverage 100%, **244 passed (1118 assertions)**.
- [x] No credentials, real customer data, or unredacted evidence are included.

Claims in the tests are created and transitioned through Verdict's own store (claim → indeterminate / complete / release), never inserted as terminal-shaped rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
