### PR TITLE
docs: record v0.3.0 as the current release in MILESTONES.md

### DIFF
--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -13,7 +13,7 @@ That convention **ended there** — the number space is shared with pull request
 after #48 (#51, #63, #67–#69) carry descriptive titles and no `VC-` prefix. Refer to them by issue
 number; do not mint new `VC-` numbers.
 
-Current version: `0.1.0` (unreleased). Release procedure: fissible standards in
+Current version: `0.3.0` (released 2026-08-30; v0.1.0–v0.3.0 milestones closed). Release procedure: fissible standards in
 [`fissible/.github`](https://github.com/fissible/.github).
 
 ## Core package `fissible/verdict-console`


### PR DESCRIPTION
## Summary

MILESTONES.md still said `Current version: 0.1.0 (unreleased)`. v0.3.0 shipped today (tag `v0.3.0`, https://github.com/fissible/verdict-console/releases/tag/v0.3.0); the v0.1.0, v0.2.0, and v0.3.0 GitHub milestones were closed to match (each had 0 open issues).

## Linked issue

None — release housekeeping.

## Trust and failure behavior

Docs only.

## Evidence and data handling

None.

## Verification

- [x] Docs only; no code, no CHANGELOG entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)