### PR TITLE
feat: host chat-entry contract, and the console's start, continue, and thread reads (VC-18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Host chat-entry contract (VC-18).** `ChatEntry` lets a host name the participant and a
+  resumable-agent key — a key rather than an agent instance, so VC-2 can rebuild a chat after a
+  pause. The shipped entry refuses until `verdict-console.chat.entry_key` names a registered key.
+  Foreign and unknown conversations receive the same ownership refusal; continuation deliberately
+  uses the participant's current entry key, and thread messages are read through the host's
+  `ConversationStore` rather than a console-owned message table.
+
 ## [0.3.0] - 2026-08-30
 
 - **Execution-claim read model and authorized reconciliation (VC-16).** `ExecutionClaimService`

--- a/config/verdict-console.php
+++ b/config/verdict-console.php
@@ -46,6 +46,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Chat entry
+    |--------------------------------------------------------------------------
+    | The host names a registered resumable-agent key; the package cannot choose
+    | which agent may greet a host's users. Null deliberately refuses chat entry.
+    */
+    'chat' => [
+        'entry_key' => env('VERDICT_CONSOLE_CHAT_ENTRY_KEY'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Ephemeral ingestion incidents
     |--------------------------------------------------------------------------
     |

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -350,6 +350,9 @@ free.
 
 - **Blade (embed):** `<x-verdict-console::approvals />`, server-rendered, form-post, no build step.
   Approval widget + paginated audit page + basic (non-streaming) chat thread. Publishable views.
+  Chat surfaces start and continue conversations through the host's `ChatEntry` contract (participant
+  plus resumable-agent key, `verdict-console.chat.entry_key`), check ownership against Laravel AI's
+  recorded participant, and read the thread through the host's `ConversationStore`.
 - **Livewire (end-user, flagship):** chat with **inline approval cards** (stream → card mid-thread →
   resolve in-flow → resume), live inbox, live decision feed. *Feed depends on §6.6/§6.7.*
 - **Filament (ops console, a plugin):** approval **queue** Resource; evidence **browser** Resource

--- a/src/Chat/ChatMessage.php
+++ b/src/Chat/ChatMessage.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Chat;
+
+/** One stored Laravel AI message projected for a console chat thread. */
+final readonly class ChatMessage
+{
+    public function __construct(public string $role, public ?string $content) {}
+}

--- a/src/Chat/ChatService.php
+++ b/src/Chat/ChatService.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Chat;
+
+use Fissible\VerdictConsole\Contracts\ChatEntry;
+use Fissible\VerdictConsole\Contracts\ResumableAgents;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Auth\Authenticatable;
+use InvalidArgumentException;
+use Laravel\Ai\Contracts\ConversationStore;
+use Laravel\Ai\Models\Conversation;
+use Laravel\Ai\Responses\AgentResponse;
+use LogicException;
+
+/**
+ * Starts, continues, and reads participant-owned chats through host-owned Laravel AI seams.
+ *
+ * Ownership means the Laravel AI conversation belongs to the current participant. A refusal is a
+ * single message so that a participant cannot learn whether a foreign conversation exists. The
+ * console owns no conversation or message table: the host-bound Laravel AI store is the source for
+ * both ownership and rendering. Continuation deliberately uses the participant's current entry
+ * key. In v1 the console stores no per-conversation agent key, so a host re-pointing its entry also
+ * re-points existing threads.
+ */
+final readonly class ChatService
+{
+    private const string AUTHORIZATION_REFUSAL_MESSAGE = 'This participant may not use this conversation.';
+
+    public function __construct(
+        private ChatEntry $entry,
+        private ResumableAgents $agents,
+        private ConversationStore $conversations,
+    ) {}
+
+    public function start(Authenticatable $user, string $prompt): ChatTurn
+    {
+        $this->assertPrompt($prompt);
+
+        $participant = $this->entry->participantFor($user);
+        $agent = $this->agents->resolve($this->entry->entryKeyFor($participant));
+
+        return $this->turnFrom($agent->forParticipant($participant)->prompt($prompt));
+    }
+
+    public function continue(Authenticatable $user, string $conversationId, string $prompt): ChatTurn
+    {
+        $this->assertPrompt($prompt);
+
+        $participant = $this->entry->participantFor($user);
+        $this->assertOwns($conversationId, $participant);
+
+        $agent = $this->agents->resolve($this->entry->entryKeyFor($participant));
+
+        return $this->turnFrom($agent->continue($conversationId, $participant)->prompt($prompt));
+    }
+
+    public function thread(Authenticatable $user, string $conversationId, int $limit = 100): ChatThread
+    {
+        $participant = $this->entry->participantFor($user);
+        $this->assertOwns($conversationId, $participant);
+
+        $messages = array_values($this->conversations->getLatestConversationMessages($conversationId, $limit)
+            ->map(fn (object $message): ChatMessage => new ChatMessage($message->role->value, $message->content))
+            ->all());
+
+        return new ChatThread($conversationId, $messages);
+    }
+
+    private function assertPrompt(string $prompt): void
+    {
+        if (trim($prompt) === '') {
+            throw new InvalidArgumentException('A chat prompt must not be blank.');
+        }
+    }
+
+    private function assertOwns(string $conversationId, object $participant): void
+    {
+        $owns = Conversation::query()
+            ->whereKey($conversationId)
+            ->where('participant_type', Conversation::participantType($participant))
+            ->where('participant_id', Conversation::participantKey($participant))
+            ->exists();
+
+        if (! $owns) {
+            throw new AuthorizationException(self::AUTHORIZATION_REFUSAL_MESSAGE);
+        }
+    }
+
+    private function turnFrom(AgentResponse $response): ChatTurn
+    {
+        if ($response->conversationId === null) {
+            throw new LogicException('A remembered conversation response must have a conversation id.');
+        }
+
+        return new ChatTurn(
+            $response->conversationId,
+            $response->invocationId,
+            $response->text,
+            $response->hasPendingApprovals(),
+            array_values($response->pendingApprovals->map(fn (object $approval): string => $approval->id)->all()),
+        );
+    }
+}

--- a/src/Chat/ChatThread.php
+++ b/src/Chat/ChatThread.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Chat;
+
+/** @param list<ChatMessage> $messages */
+final readonly class ChatThread
+{
+    /** @param list<ChatMessage> $messages */
+    public function __construct(public string $conversationId, public array $messages) {}
+}

--- a/src/Chat/ChatTurn.php
+++ b/src/Chat/ChatTurn.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Chat;
+
+/** The display-safe result of one console prompt. */
+final readonly class ChatTurn
+{
+    /** @param list<string> $pendingToolCallIds */
+    public function __construct(
+        public string $conversationId,
+        public string $invocationId,
+        public string $text,
+        public bool $paused,
+        public array $pendingToolCallIds,
+    ) {}
+}

--- a/src/Chat/ConfiguredChatEntry.php
+++ b/src/Chat/ConfiguredChatEntry.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Chat;
+
+use Fissible\VerdictConsole\Contracts\ChatEntry;
+use Fissible\VerdictConsole\Exceptions\ChatEntryNotConfigured;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Config\Repository as Config;
+
+/**
+ * The shipped chat entry: use the authenticated user and require the host to nominate its agent.
+ *
+ * A package cannot select a host's resumable agent safely, so an absent setting refuses before a
+ * prompt can create a conversation that no operator can continue after a pause.
+ */
+final readonly class ConfiguredChatEntry implements ChatEntry
+{
+    public function __construct(private Config $config) {}
+
+    public function participantFor(Authenticatable $user): object
+    {
+        return $user;
+    }
+
+    public function entryKeyFor(object $participant): string
+    {
+        $key = $this->config->get('verdict-console.chat.entry_key');
+
+        if (! is_string($key) || trim($key) === '') {
+            throw ChatEntryNotConfigured::make();
+        }
+
+        return $key;
+    }
+}

--- a/src/Contracts/ChatEntry.php
+++ b/src/Contracts/ChatEntry.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Contracts;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+
+/**
+ * How a host attaches a console chat to a participant and names its entry agent.
+ *
+ * The entry is a resumable-agent **key**, never an agent instance: it is the same key VC-2 rebuilds
+ * after a pause, so a chat the console starts is resumable by construction. An instance would let a
+ * host start a chat nobody can resume once that request has ended.
+ */
+interface ChatEntry
+{
+    /** Return the participant a new or continued console conversation belongs to. */
+    public function participantFor(Authenticatable $user): object;
+
+    /** Return a {@see ResumableAgents} key for this participant, not a live agent instance. */
+    public function entryKeyFor(object $participant): string;
+}

--- a/src/Exceptions/ChatEntryNotConfigured.php
+++ b/src/Exceptions/ChatEntryNotConfigured.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Exceptions;
+
+use LogicException;
+
+/** The host has not named the resumable agent that may receive console chats. */
+final class ChatEntryNotConfigured extends LogicException
+{
+    public static function make(): self
+    {
+        return new self(
+            'No chat entry is configured. Set [verdict-console.chat.entry_key] to a key registered with '
+            .'[Fissible\VerdictConsole\Contracts\ResumableAgents].'
+        );
+    }
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -13,12 +13,15 @@ use Fissible\VerdictConsole\Approvals\ApprovalChallengeReader;
 use Fissible\VerdictConsole\Approvals\GateApproverAuthority;
 use Fissible\VerdictConsole\Approvals\UnscopedApprovalScope;
 use Fissible\VerdictConsole\Approvals\VerdictApprovalChallengeReader;
+use Fissible\VerdictConsole\Chat\ChatService;
+use Fissible\VerdictConsole\Chat\ConfiguredChatEntry;
 use Fissible\VerdictConsole\Configuration\VerdictConfigurationInspection;
 use Fissible\VerdictConsole\Console\Commands\DoctorCommand;
 use Fissible\VerdictConsole\Contracts\ApprovalNotificationRecipients;
 use Fissible\VerdictConsole\Contracts\ApprovalPresenter;
 use Fissible\VerdictConsole\Contracts\ApprovalScope;
 use Fissible\VerdictConsole\Contracts\ApproverAuthority;
+use Fissible\VerdictConsole\Contracts\ChatEntry;
 use Fissible\VerdictConsole\Contracts\ConfigurationInspection;
 use Fissible\VerdictConsole\Contracts\ConversationParticipants;
 use Fissible\VerdictConsole\Contracts\EvidenceQuery;
@@ -79,6 +82,10 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         $this->app->singleton(ResumableAgents::class, AgentResolverRegistry::class);
 
         $this->app->singleton(ConversationParticipants::class, UnconfiguredConversationParticipants::class);
+
+        $this->app->singleton(ChatEntry::class, ConfiguredChatEntry::class);
+
+        $this->app->bind(ChatService::class);
 
         $this->app->singleton(ApprovalNotificationRecipients::class, UnconfiguredApprovalNotificationRecipients::class);
 

--- a/tests/EndToEnd/ChatServiceTest.php
+++ b/tests/EndToEnd/ChatServiceTest.php
@@ -1,0 +1,511 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Actions\ActionContext;
+use Fissible\Verdict\Actions\ActionEnvelope;
+use Fissible\Verdict\Actions\AuthorizedAction;
+use Fissible\Verdict\Capabilities\Capability;
+use Fissible\Verdict\Capabilities\CapabilityRegistry;
+use Fissible\Verdict\Contracts\CapabilityAuthorizer;
+use Fissible\Verdict\Decisions\Decision;
+use Fissible\Verdict\LaravelAi\VerdictApprovalMiddleware;
+use Fissible\Verdict\Targets\ExecutionTargetPolicy;
+use Fissible\Verdict\VerdictManager;
+use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
+use Fissible\VerdictConsole\Approvals\PendingApproval as StoredPendingApproval;
+use Fissible\VerdictConsole\Approvals\Resumability;
+use Fissible\VerdictConsole\Chat\ChatService;
+use Fissible\VerdictConsole\Chat\ChatThread;
+use Fissible\VerdictConsole\Chat\ChatTurn;
+use Fissible\VerdictConsole\Contracts\ChatEntry;
+use Fissible\VerdictConsole\Contracts\ConversationParticipants;
+use Fissible\VerdictConsole\Contracts\ResumableAgents;
+use Fissible\VerdictConsole\Exceptions\ChatEntryNotConfigured;
+use Fissible\VerdictConsole\Exceptions\UnresolvableAgentKey;
+use Fissible\VerdictConsole\Tests\EndToEndTestCase;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\GenericUser;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Concerns\RemembersConversations as RemembersConversationsTrait;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\ConversationStore;
+use Laravel\Ai\Contracts\HasMiddleware;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Contracts\RemembersConversations as RemembersConversationsContract;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Prompts\AgentPrompt;
+use Laravel\Ai\Responses\AgentResponse;
+use Laravel\Ai\Tools\Request;
+
+/**
+ * The console starting and continuing a chat through the host's entry contract, over the real
+ * Laravel AI + Verdict stack. Fixtures are this file's own: a test file must not depend on classes
+ * another test file happens to have declared first.
+ */
+const CHAT_ENTRY_KEY = 'chat@v1';
+
+final class ChatLedger
+{
+    public int $executions = 0;
+}
+
+final readonly class ChatOrder
+{
+    public function __construct(public int $id) {}
+}
+
+final class ChatCancelOrderTool implements Tool
+{
+    public function description(): Stringable|string
+    {
+        return 'Cancel an order by id.';
+    }
+
+    public function handle(Request $request): Stringable|string
+    {
+        return 'The Verdict-bound tool handles this.';
+    }
+
+    /** @return array<string, Type> */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}
+
+function chatBoundTool(): Tool
+{
+    $verdict = app(VerdictManager::class);
+
+    if (! app(CapabilityRegistry::class)->has('orders.cancel')) {
+        $verdict->capability(
+            Capability::usingPolicy(
+                name: 'orders.cancel',
+                ability: 'update',
+                resolveTarget: fn (ActionEnvelope $e): ChatOrder => new ChatOrder((int) $e->proposal->arguments['order_id']),
+            )
+                ->executionTarget(ExecutionTargetPolicy::acceptStaleSnapshot(
+                    name: 'chat-target',
+                    identityUsing: fn (ActionEnvelope $e, ChatOrder $t): array => ['id' => $t->id],
+                ))
+                ->requiresConfirmation(fn (ActionEnvelope $e, ChatOrder $t): array => ['order_id' => $t->id])
+                ->executeUsing(function (AuthorizedAction $a): string {
+                    app(ChatLedger::class)->executions++;
+
+                    return 'Order cancelled.';
+                }),
+        );
+    }
+
+    return $verdict->bound(new ChatCancelOrderTool, 'orders.cancel', new ActionContext('customer'));
+}
+
+class ChatAgent implements Agent, HasMiddleware, HasTools, RemembersConversationsContract
+{
+    use Promptable;
+    use RemembersConversationsTrait;
+
+    public function instructions(): Stringable|string
+    {
+        return 'Help customers with their orders.';
+    }
+
+    /** @return array<int, Tool> */
+    public function tools(): array
+    {
+        return [chatBoundTool()];
+    }
+
+    /** @return array<int, object> */
+    public function middleware(): array
+    {
+        return [app(VerdictApprovalMiddleware::class)];
+    }
+
+    public function provider(): string
+    {
+        return EndToEndTestCase::PROVIDER;
+    }
+
+    public function maxSteps(): int
+    {
+        return 3;
+    }
+}
+
+/** A second entry agent, distinguishable from the first by the `agent` column Laravel AI records per message. */
+final class ChatAgentV2 extends ChatAgent {}
+
+/**
+ * Wraps the host's conversation store and records what the console asked it for, so a test can
+ * prove the thread is read through the host's binding rather than from a console-owned copy.
+ */
+final class RecordingConversationStore implements ConversationStore
+{
+    /** @var list<array{conversationId: string, limit: int}> */
+    public array $reads = [];
+
+    public function __construct(private readonly ConversationStore $inner) {}
+
+    public function latestConversationId(string $participantType, string|int $participantId): ?string
+    {
+        return $this->inner->latestConversationId($participantType, $participantId);
+    }
+
+    public function storeConversation(?string $participantType, string|int|null $participantId, string $title): string
+    {
+        return $this->inner->storeConversation($participantType, $participantId, $title);
+    }
+
+    public function storeUserMessage(string $conversationId, ?string $participantType, string|int|null $participantId, AgentPrompt $prompt): string
+    {
+        return $this->inner->storeUserMessage($conversationId, $participantType, $participantId, $prompt);
+    }
+
+    public function storeAssistantMessage(string $conversationId, ?string $participantType, string|int|null $participantId, AgentPrompt $prompt, AgentResponse $response): ?string
+    {
+        return $this->inner->storeAssistantMessage($conversationId, $participantType, $participantId, $prompt, $response);
+    }
+
+    public function getLatestConversationMessages(string $conversationId, int $limit): Collection
+    {
+        $this->reads[] = ['conversationId' => $conversationId, 'limit' => $limit];
+
+        return $this->inner->getLatestConversationMessages($conversationId, $limit);
+    }
+
+    /** @param  array<int, mixed>  $toolResults */
+    public function storeApprovalResults(string $conversationId, ?string $participantType, string|int|null $participantId, array $toolResults): void
+    {
+        $this->inner->storeApprovalResults($conversationId, $participantType, $participantId, $toolResults);
+    }
+}
+
+/** Faithful round trip for the integer-keyed GenericUser participants below. */
+final class ChatParticipants implements ConversationParticipants
+{
+    public function referenceFor(object $participant): string
+    {
+        return (string) $participant->id;
+    }
+
+    public function resolve(string $reference): object
+    {
+        return new GenericUser(['id' => (int) $reference]);
+    }
+}
+
+function chatUser(int $id = 7): GenericUser
+{
+    // Laravel AI stores participant_id as an unsigned integer, so participants carry integer ids.
+    return new GenericUser(['id' => $id]);
+}
+
+/** @return array<string, mixed>|null */
+function conversationRow(string $conversationId): ?array
+{
+    $row = DB::table('agent_conversations')->where('id', $conversationId)->first();
+
+    return $row === null ? null : (array) $row;
+}
+
+/** @return list<array{participant_type: ?string, participant_id: ?int, agent: string}> */
+function storedMessageOwners(string $conversationId): array
+{
+    return DB::table('agent_conversation_messages')
+        ->where('conversation_id', $conversationId)
+        ->orderBy('id')
+        ->get(['participant_type', 'participant_id', 'agent'])
+        ->map(fn (object $row): array => ['participant_type' => $row->participant_type, 'participant_id' => $row->participant_id === null ? null : (int) $row->participant_id, 'agent' => (string) $row->agent])
+        ->all();
+}
+
+/** @return list<array{role: string, content: string}> */
+function storedMessages(string $conversationId): array
+{
+    return DB::table('agent_conversation_messages')
+        ->where('conversation_id', $conversationId)
+        ->orderBy('id')
+        ->get(['role', 'content'])
+        ->map(fn (object $row): array => ['role' => (string) $row->role, 'content' => (string) $row->content])
+        ->all();
+}
+
+beforeEach(function (): void {
+    $this->migrateRoundTripTables();
+
+    $console = dirname(__DIR__, 2).'/database/migrations';
+    (require $console.'/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require $console.'/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require $console.'/create_verdict_console_approval_notifications_table.php.stub')->up();
+    (require $console.'/create_verdict_console_approval_reconciliations_table.php.stub')->up();
+
+    $this->app->instance(ChatLedger::class, new ChatLedger);
+    $this->app->instance(ConversationParticipants::class, new ChatParticipants);
+    $this->app->instance(CapabilityAuthorizer::class, new class implements CapabilityAuthorizer
+    {
+        public function decide(Capability $capability, ActionEnvelope $envelope, mixed $target): Decision
+        {
+            return Decision::permit('chat test');
+        }
+    });
+
+    /** @var AgentResolverRegistry $resolvers */
+    $resolvers = app(ResumableAgents::class);
+    $resolvers->register(CHAT_ENTRY_KEY, fn (): ChatAgent => new ChatAgent, fn (Agent $agent): bool => $agent instanceof ChatAgent && ! $agent instanceof ChatAgentV2);
+    $resolvers->register('chat@v2', fn (): ChatAgentV2 => new ChatAgentV2, fn (Agent $agent): bool => $agent instanceof ChatAgentV2);
+
+    config()->set('verdict-console.chat.entry_key', CHAT_ENTRY_KEY);
+});
+
+it('starts a new conversation through the hosts entry agent, owned by the participant', function (): void {
+    Http::fake(['*/chat/completions' => Http::response($this->textResponse('Hi there. How can I help?'))]);
+
+    $turn = app(ChatService::class)->start(chatUser(7), 'Hello');
+
+    expect($turn)->toBeInstanceOf(ChatTurn::class)
+        ->and($turn->conversationId)->not->toBeNull()
+        ->and($turn->text)->toBe('Hi there. How can I help?')
+        ->and($turn->paused)->toBeFalse()
+        ->and($turn->pendingToolCallIds)->toBe([])
+        ->and(conversationRow($turn->conversationId))->toMatchArray([
+            'participant_type' => GenericUser::class,
+            'participant_id' => 7,
+        ])
+        ->and(storedMessages($turn->conversationId))->toBe([
+            ['role' => 'user', 'content' => 'Hello'],
+            ['role' => 'assistant', 'content' => 'Hi there. How can I help?'],
+        ])
+        ->and(storedMessageOwners($turn->conversationId))->each->toMatchArray(['participant_type' => GenericUser::class, 'participant_id' => 7, 'agent' => ChatAgent::class]);
+
+    Http::assertSentCount(1);
+});
+
+it('continues an owned conversation with the next turn', function (): void {
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->textResponse('Hi there.'))
+            ->push($this->textResponse('Order 1001 ships tomorrow.')),
+    ]);
+    $service = app(ChatService::class);
+
+    $first = $service->start(chatUser(7), 'Hello');
+    $second = $service->continue(chatUser(7), $first->conversationId, 'Where is order 1001?');
+
+    expect($second->conversationId)->toBe($first->conversationId)
+        ->and($second->text)->toBe('Order 1001 ships tomorrow.')
+        ->and($second->invocationId)->not->toBe($first->invocationId)
+        ->and(array_column(storedMessages($first->conversationId), 'content'))
+        ->toBe(['Hello', 'Hi there.', 'Where is order 1001?', 'Order 1001 ships tomorrow.'])
+        ->and(storedMessageOwners($first->conversationId))->toHaveCount(4)
+        ->and(storedMessageOwners($first->conversationId))->each->toMatchArray(['participant_type' => GenericUser::class, 'participant_id' => 7]);
+
+    Http::assertSentCount(2);
+});
+
+/**
+ * Message rendering reads through Laravel AI's own conversation store, never a console-owned copy:
+ * the host's store binding owns the messages, and the console projects the ones it may show.
+ */
+it('reads the thread of an owned conversation in order', function (): void {
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->textResponse('Hi there.'))
+            ->push($this->textResponse('Order 1001 ships tomorrow.')),
+    ]);
+    $service = app(ChatService::class);
+    $started = $service->start(chatUser(7), 'Hello');
+    $service->continue(chatUser(7), $started->conversationId, 'Where is order 1001?');
+
+    $store = new RecordingConversationStore(app(ConversationStore::class));
+    app()->instance(ConversationStore::class, $store);
+
+    $thread = $service->thread(chatUser(7), $started->conversationId);
+    $latest = $service->thread(chatUser(7), $started->conversationId, limit: 2);
+
+    expect($thread)->toBeInstanceOf(ChatThread::class)
+        ->and($thread->conversationId)->toBe($started->conversationId)
+        ->and(array_map(fn ($m): array => [$m->role, $m->content], $thread->messages))->toBe([
+            ['user', 'Hello'],
+            ['assistant', 'Hi there.'],
+            ['user', 'Where is order 1001?'],
+            ['assistant', 'Order 1001 ships tomorrow.'],
+        ])
+        ->and(array_map(fn ($m): string => (string) $m->content, $latest->messages))->toBe(['Where is order 1001?', 'Order 1001 ships tomorrow.'])
+        // Both reads went through the host's store binding — the console keeps no copy to read from.
+        ->and($store->reads)->toBe([
+            ['conversationId' => $started->conversationId, 'limit' => 100],
+            ['conversationId' => $started->conversationId, 'limit' => 2],
+        ]);
+});
+
+/**
+ * Ownership is checked against the conversation's recorded participant, before any model call. A
+ * conversation that belongs to someone else and one that does not exist are refused identically —
+ * a caller must not learn which.
+ */
+it('refuses to continue or read a conversation the participant does not own, sending nothing', function (): void {
+    Http::fake(['*/chat/completions' => Http::response($this->textResponse('Hi there.'))]);
+    $service = app(ChatService::class);
+    $theirs = $service->start(chatUser(7), 'Hello')->conversationId;
+
+    $attempts = [
+        'continue foreign' => fn (): mixed => $service->continue(chatUser(8), $theirs, 'Show me everything.'),
+        'continue unknown' => fn (): mixed => $service->continue(chatUser(8), 'no-such-conversation', 'Show me everything.'),
+        'read foreign' => fn (): mixed => $service->thread(chatUser(8), $theirs),
+        'read unknown' => fn (): mixed => $service->thread(chatUser(8), 'no-such-conversation'),
+    ];
+    $messages = [];
+
+    foreach ($attempts as $label => $attempt) {
+        try {
+            $attempt();
+            $this->fail($label.' must be refused.');
+        } catch (AuthorizationException $e) {
+            $messages[$label] = $e->getMessage();
+        }
+    }
+
+    expect(array_unique($messages))->toHaveCount(1, 'Foreign and unknown must be indistinguishable.');
+
+    Http::assertSentCount(1);
+
+    expect(count(storedMessages($theirs)))->toBe(2);
+});
+
+/**
+ * The reason the entry is a resumable-agent *key*: a chat the console started can pause on a
+ * confirmation, and that pause must be one VC-5 records as drivable — same key, same participant
+ * round trip — or the console would be minting approvals nobody can resume.
+ */
+it('starts a chat whose pause is drivable by this console', function (): void {
+    Http::fake(['*/chat/completions' => Http::response($this->toolCallResponse('call_chat_1', 'ChatCancelOrderTool', ['order_id' => 1001]))]);
+
+    $turn = app(ChatService::class)->start(chatUser(7), 'Please cancel order 1001.');
+
+    expect($turn->paused)->toBeTrue()
+        ->and($turn->pendingToolCallIds)->toBe(['call_chat_1'])
+        ->and(app(ChatLedger::class)->executions)->toBe(0);
+
+    $row = StoredPendingApproval::query()->sole();
+
+    expect($row->conversation_id)->toBe($turn->conversationId)
+        ->and($row->tool_call_id)->toBe('call_chat_1')
+        ->and($row->resolver_key)->toBe(CHAT_ENTRY_KEY)
+        ->and($row->participant_reference)->toBe('7')
+        ->and($row->resumability)->toBe(Resumability::Drivable);
+});
+
+it('refuses to start a chat until the host has configured an entry, sending nothing', function (): void {
+    Http::fake();
+    config()->set('verdict-console.chat.entry_key', null);
+
+    expect(fn (): mixed => app(ChatService::class)->start(chatUser(7), 'Hello'))
+        ->toThrow(ChatEntryNotConfigured::class);
+
+    Http::assertNothingSent();
+
+    expect(DB::table('agent_conversations')->count())->toBe(0);
+});
+
+it('refuses an entry key nothing resolves, sending nothing', function (): void {
+    Http::fake();
+    config()->set('verdict-console.chat.entry_key', 'ghost@v9');
+
+    expect(fn (): mixed => app(ChatService::class)->start(chatUser(7), 'Hello'))
+        ->toThrow(UnresolvableAgentKey::class);
+
+    Http::assertNothingSent();
+});
+
+it('refuses a blank prompt, sending nothing', function (string $blank): void {
+    Http::fake();
+
+    expect(fn (): mixed => app(ChatService::class)->start(chatUser(7), $blank))
+        ->toThrow(InvalidArgumentException::class, 'prompt');
+
+    Http::assertNothingSent();
+})->with(['empty' => '', 'whitespace' => " \n\t"]);
+
+/** The host's replacement is what is consulted — for the participant AND the key. */
+it('starts through a replaced entry, attaching its participant and resolving its key', function (): void {
+    Http::fake(['*/chat/completions' => Http::response($this->textResponse('Hi there.'))]);
+    app()->instance(ChatEntry::class, new class implements ChatEntry
+    {
+        public function participantFor(Authenticatable $user): object
+        {
+            // A host that chats on behalf of an account rather than the signed-in user.
+            return chatUser(42);
+        }
+
+        public function entryKeyFor(object $participant): string
+        {
+            return 'chat@v2';
+        }
+    });
+
+    $turn = app(ChatService::class)->start(chatUser(7), 'Hello');
+
+    $owners = storedMessageOwners($turn->conversationId);
+
+    expect(conversationRow($turn->conversationId))->toMatchArray(['participant_type' => GenericUser::class, 'participant_id' => 42])
+        ->and($owners)->toHaveCount(2)
+        ->and($owners)->each->toMatchArray(['participant_type' => GenericUser::class, 'participant_id' => 42, 'agent' => ChatAgentV2::class]);
+});
+
+/**
+ * A deliberate v1 decision, pinned so it cannot change silently: a continuation runs the
+ * participant's *current* entry agent, not the agent that started the thread. The console records
+ * no per-conversation agent key; a host that re-points its entry key re-points existing threads too.
+ */
+it('continues with the participants current entry key, not the agent that started the thread', function (): void {
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->textResponse('Hi there.'))
+            ->push($this->textResponse('Still here.')),
+    ]);
+    // A host entry whose answer changes between turns: the contract, not the config, is what
+    // continue() must consult.
+    $entry = new class implements ChatEntry
+    {
+        public string $key = CHAT_ENTRY_KEY;
+
+        public function participantFor(Authenticatable $user): object
+        {
+            return $user;
+        }
+
+        public function entryKeyFor(object $participant): string
+        {
+            return $this->key;
+        }
+    };
+    app()->instance(ChatEntry::class, $entry);
+    $service = app(ChatService::class);
+    $started = $service->start(chatUser(7), 'Hello');
+
+    $entry->key = 'chat@v2';
+    $service->continue(chatUser(7), $started->conversationId, 'Are you there?');
+
+    expect(array_column(storedMessageOwners($started->conversationId), 'agent'))
+        ->toBe([ChatAgent::class, ChatAgent::class, ChatAgentV2::class, ChatAgentV2::class]);
+});
+
+it('refuses a blank continuation prompt, sending nothing', function (): void {
+    Http::fake(['*/chat/completions' => Http::response($this->textResponse('Hi there.'))]);
+    $service = app(ChatService::class);
+    $started = $service->start(chatUser(7), 'Hello');
+
+    expect(fn (): mixed => $service->continue(chatUser(7), $started->conversationId, '   '))
+        ->toThrow(InvalidArgumentException::class, 'prompt')
+        ->and(storedMessages($started->conversationId))->toHaveCount(2, 'A refused turn must leave no row behind.');
+
+    Http::assertSentCount(1);
+});

--- a/tests/EndToEnd/ChatServiceTest.php
+++ b/tests/EndToEnd/ChatServiceTest.php
@@ -324,11 +324,14 @@ it('reads the thread of an owned conversation in order', function (): void {
     $started = $service->start(chatUser(7), 'Hello');
     $service->continue(chatUser(7), $started->conversationId, 'Where is order 1001?');
 
+    // Bound before the reading service is resolved: the store is an injected collaborator, not
+    // something the service may look up from the container on each call.
     $store = new RecordingConversationStore(app(ConversationStore::class));
     app()->instance(ConversationStore::class, $store);
+    $reader = app(ChatService::class);
 
-    $thread = $service->thread(chatUser(7), $started->conversationId);
-    $latest = $service->thread(chatUser(7), $started->conversationId, limit: 2);
+    $thread = $reader->thread(chatUser(7), $started->conversationId);
+    $latest = $reader->thread(chatUser(7), $started->conversationId, limit: 2);
 
     expect($thread)->toBeInstanceOf(ChatThread::class)
         ->and($thread->conversationId)->toBe($started->conversationId)

--- a/tests/Feature/ChatEntryTest.php
+++ b/tests/Feature/ChatEntryTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\VerdictConsole\Chat\ConfiguredChatEntry;
+use Fissible\VerdictConsole\Contracts\ChatEntry;
+use Fissible\VerdictConsole\Exceptions\ChatEntryNotConfigured;
+use Illuminate\Auth\GenericUser;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+/**
+ * The shipped entry: the authenticated user is the participant, and the entry agent is the
+ * resumable-agent key the host names in config. Nominating a *key* rather than an agent is the
+ * point — it is the same key VC-2 rebuilds after a pause, so a chat the console starts is resumable
+ * by construction rather than by hope.
+ */
+it('names the configured resumable-agent key as the entry for any participant', function (): void {
+    config()->set('verdict-console.chat.entry_key', 'support@v2');
+
+    $entry = app(ChatEntry::class);
+
+    expect($entry)->toBeInstanceOf(ConfiguredChatEntry::class)
+        ->and($entry->entryKeyFor(new GenericUser(['id' => 7])))->toBe('support@v2');
+});
+
+it('attaches a new conversation to the authenticated user by default', function (): void {
+    $user = new GenericUser(['id' => 7]);
+
+    expect(app(ChatEntry::class)->participantFor($user))->toBe($user);
+});
+
+/** No key is shipped: the package cannot know which of the host's agents should greet a user. */
+it('refuses to name an entry until the host configures one, and says where', function (): void {
+    expect(config('verdict-console.chat.entry_key'))->toBeNull('The shipped config must leave the key unset.');
+
+    expect(fn (): string => app(ChatEntry::class)->entryKeyFor(new GenericUser(['id' => 7])))
+        ->toThrow(ChatEntryNotConfigured::class, 'verdict-console.chat.entry_key');
+});
+
+it('treats a blank configured key as unconfigured', function (string $blank): void {
+    config()->set('verdict-console.chat.entry_key', $blank);
+
+    expect(fn (): string => app(ChatEntry::class)->entryKeyFor(new GenericUser(['id' => 7])))
+        ->toThrow(ChatEntryNotConfigured::class);
+})->with(['empty' => '', 'whitespace' => '   ']);
+
+it('binds the shipped entry to a contract a host may replace', function (): void {
+    $replacement = new class implements ChatEntry
+    {
+        public function participantFor(Authenticatable $user): object
+        {
+            return new GenericUser(['id' => 99]);
+        }
+
+        public function entryKeyFor(object $participant): string
+        {
+            return 'tenant-router@v1';
+        }
+    };
+
+    app()->instance(ChatEntry::class, $replacement);
+
+    expect(app(ChatEntry::class))->toBe($replacement);
+});

--- a/tests/Feature/DocumentationCorrectionsTest.php
+++ b/tests/Feature/DocumentationCorrectionsTest.php
@@ -94,6 +94,13 @@ it('names the execution-claim service in the design of record', function (): voi
         ->toContain('`verdict-console.execution_claims.gate`');
 });
 
+/** The chat surfaces (VC-21, VC-24) start conversations through a host contract; the design must name it and its key. */
+it('names the chat-entry contract in the design of record', function (): void {
+    expect(documentation('docs/design/0001-verdict-console-design.md'))
+        ->toContain('`ChatEntry`')
+        ->toContain('`verdict-console.chat.entry_key`');
+});
+
 /** Folded in from the VC-13 review: the UTC reading is a contract from verdict#335 onward, not a hope. */
 it('cites the Verdict change that makes the evidence timestamp reading a UTC contract', function (): void {
     expect(documentation('src/Evidence/DatabaseEvidenceQuery.php'))->toContain('fissible/verdict#335');


### PR DESCRIPTION
## Summary

The host contract the v0.4.0 chat surfaces (Blade VC-21, Livewire VC-24) start conversations through, plus the headless service they will call. The design doc had nothing on this; the tests are the spec, and the shape is:

- **`ChatEntry`** (host, replaceable): `participantFor(Authenticatable): object` and `entryKeyFor(object): string`. The entry is a **resumable-agent key** — the same key VC-2 rebuilds after a pause — never an agent instance, so a chat the console starts is drivable by construction (proven end-to-end: a console-started chat that pauses yields a VC-5 row with `resolver_key`, `participant_reference`, and `Drivable`). Shipped `ConfiguredChatEntry` uses the authenticated user and refuses (`ChatEntryNotConfigured`, naming the key) until `verdict-console.chat.entry_key` names a registered key — the package cannot choose which of a host's agents greets its users.
- **`ChatService`**: `start(user, prompt)`, `continue(user, conversationId, prompt)`, `thread(user, conversationId, limit)`. **Ownership** is checked against Laravel AI's recorded `participant_type`/`participant_id` *before any model call*; a foreign conversation and an unknown one are refused with the same `AuthorizationException` message, so a caller cannot learn which. Blank prompts are refused before anything is stored or sent. The console owns **no conversation or message table** — Laravel AI's store, bound by the host, is the source for both ownership and rendering (the thread test proves reads go through the host's `ConversationStore` binding).
- **Continuation uses the participant's *current* entry key**, not the agent that started the thread — a deliberate v1 decision (the console records no per-conversation key), pinned by a test with a stateful replaced entry.

## Linked issue

Closes #18

## Trust and failure behavior

- Untrusted input: the prompt text and the conversation id. The id is only ever matched against the participant's own conversations; the prompt reaches the model only after entry resolution and ownership pass.
- Fail-closed: unconfigured entry, unresolvable key, blank prompt, foreign/unknown conversation — each refuses with nothing sent (`Http::assertNothingSent` / sent-count assertions) and no rows written.
- No retries, no transactions; a single `prompt()` per turn, exactly as a host would call Laravel AI.

## Evidence and data handling

- `ChatTurn` exposes the reply text, conversation/invocation ids, and pending tool-call ids; `ChatThread` exposes the participant's own stored messages (role + content) read through the host's store. No Verdict evidence, arguments, or other participants' data.

## Verification

- [x] Success, denial, and relevant failure paths are tested.
- [x] Security containment and legitimate utility are both covered where applicable.
- [x] Documentation and `CHANGELOG.md` are updated.
- [x] `composer test` passes locally — phpstan clean, pint passed, type coverage 100%, **272 passed (1374 assertions)**.
- [x] No credentials, real customer data, or unredacted evidence are included.

Follow-up worth filing after VC-21 lands: a doctor finding for an entry key that is configured but not registered (`entry_key_unresolvable`), mirroring `resolver_key_unresolvable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
