### PR TITLE
feat: Blade approval inbox widget with opt-in routes and the form-post round trip (VC-19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Blade approval inbox widget (VC-19).** `<x-verdict-console::approvals />` renders the ADR 0001
+  verb and provenance contract in its pending, expired-or-already-decided, and
+  not-console-actionable states, and form-posts each offered verb through VC-6. Routes remain
+  opt-in through `VerdictConsoleRoutes` and `verdict-console.routes.register`; unmounted widgets
+  explain that actions are unavailable. Views are publishable, and the package now requires
+  `illuminate/view` and `illuminate/routing`.
+
 - **Host chat-entry contract (VC-18).** `ChatEntry` lets a host name the participant and a
   resumable-agent key — a key rather than an agent instance, so VC-2 can rebuild a chat after a
   pause. The shipped entry refuses until `verdict-console.chat.entry_key` names a registered key.

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,9 @@
     "illuminate/console": "^12.0||^13.0",
     "illuminate/contracts": "^12.0||^13.0",
     "illuminate/database": "^12.0||^13.0",
+    "illuminate/routing": "^12.0||^13.0",
     "illuminate/support": "^12.0||^13.0",
+    "illuminate/view": "^12.0||^13.0",
     "fissible/verdict": "^0.13",
     "laravel/ai": "^0.11.0"
   },

--- a/config/verdict-console.php
+++ b/config/verdict-console.php
@@ -34,6 +34,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Approval routes
+    |--------------------------------------------------------------------------
+    | Mounting is the host's decision. The shipped default exposes no action
+    | endpoint; a host may opt in here or call VerdictConsoleRoutes directly.
+    */
+    'routes' => [
+        'register' => false,
+        'prefix' => 'verdict-console',
+        'middleware' => ['web'],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Execution-claim authority
     |--------------------------------------------------------------------------
     | Who may reconcile a claim is the HOST's decision, delegated to a Laravel

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -349,6 +349,10 @@ Each read-heavy surface carries its **projection dependency** explicitly (ยง6.6โ
 free.
 
 - **Blade (embed):** `<x-verdict-console::approvals />`, server-rendered, form-post, no build step.
+  The approval-inbox widget renders ADR 0001's state, verb, and provenance contract from its live
+  read model; `VerdictConsoleRoutes` mounts its forms only when the host opts in through
+  `verdict-console.routes.register`. Routes are opt-in, and any future install or setup command
+  must ask before registering routes. Until then the widget renders its rows without forms.
   Approval widget + paginated audit page + basic (non-streaming) chat thread. Publishable views.
   Chat surfaces start and continue conversations through the host's `ChatEntry` contract (participant
   plus resumable-agent key, `verdict-console.chat.entry_key`), check ownership against Laravel AI's

--- a/resources/views/components/approvals.blade.php
+++ b/resources/views/components/approvals.blade.php
@@ -1,0 +1,65 @@
+<section data-verdict-console="approvals" data-routes="{{ $mounted ? 'mounted' : 'unmounted' }}">
+    @forelse ($items as $item)
+        @php
+            $state = $item->resumability !== 'drivable' ? 'not_console_actionable' : $item->state;
+            $presentation = $item->presentation ?? [];
+            $capability = $presentation['capability'] ?? $item->capability;
+        @endphp
+        <article data-approval="{{ $item->id }}" data-state="{{ $state }}"@if ($item->unresumableReason !== null) data-unresumable-reason="{{ $item->unresumableReason }}"@endif>
+            <h2>{{ $presentation['tool'] ?? $item->toolCallId }}</h2>
+            @if ($capability !== null)
+                <p>{{ $capability }}</p>
+            @endif
+            @if (isset($presentation['arguments_fingerprint']))
+                <p>{{ $presentation['arguments_fingerprint'] }}</p>
+            @endif
+            @if (($presentation['details'] ?? []) !== [])
+                <dl>
+                    @foreach ($presentation['details'] as $name => $value)
+                        <dt>{{ $name }}</dt><dd>{{ $value }}</dd>
+                    @endforeach
+                </dl>
+            @endif
+            @if ($item->reason !== null)
+                <dl><dt>Why this capability is gated</dt><dd>{{ $item->reason }}</dd></dl>
+            @endif
+            @if ($state === 'pending' && $item->expiresAt !== null)
+                <time datetime="{{ $item->expiresAt->format(DATE_ATOM) }}">{{ $item->expiresAt->format(DATE_ATOM) }}</time>
+            @elseif ($state === 'expired_or_already_decided')
+                <p>expired or already decided</p>
+            @elseif ($state === 'not_console_actionable')
+                <p>not actionable from this console: <code>{{ $item->unresumableReason }}</code></p>
+            @endif
+            <div data-provenance="{{ $item->provenance['state'] }}">
+                @if ($item->provenance['state'] === 'declared')
+                    <ul>
+                        @foreach ($item->provenance['sources'] as $source)
+                            <li data-source-warning="{{ $source['warning'] ? 'true' : 'false' }}">{{ $source['kind'] }} · {{ $source['name'] }} · {{ $source['trust'] }} · {{ $source['data_class'] }} · {{ $source['channel'] }}</li>
+                        @endforeach
+                    </ul>
+                    @if ($item->provenance['undescribed_source_count'] > 0)
+                        <p>{{ $item->provenance['undescribed_source_count'] }} upstream source{{ $item->provenance['undescribed_source_count'] === 1 ? '' : 's' }} undescribed</p>
+                    @endif
+                    @if ($item->provenance['withheld_source_count'] > 0)
+                        <p>{{ $item->provenance['withheld_source_count'] }} upstream source{{ $item->provenance['withheld_source_count'] === 1 ? '' : 's' }} withheld by release policy</p>
+                    @endif
+                @else
+                    <p>{{ $item->provenance['message'] }}</p>
+                @endif
+            </div>
+            @if ($state === 'not_console_actionable')
+            @elseif (! $mounted && $item->verbs !== [])
+                <p data-actions-unavailable>Actions are unavailable: the console routes are not registered.</p>
+            @elseif ($mounted)
+                @foreach ($item->verbs as $verb)
+                    <form method="post" action="{{ route($routes[$verb->value], $item->id) }}" data-verb="{{ $verb->value }}">
+                        @csrf
+                        <button type="submit">{{ ucfirst($verb->value) }}</button>
+                    </form>
+                @endforeach
+            @endif
+        </article>
+    @empty
+        <p data-empty>No approvals are waiting.</p>
+    @endforelse
+</section>

--- a/src/Approvals/ApprovalInbox.php
+++ b/src/Approvals/ApprovalInbox.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+/** Reads the host-visible approval index into render-time approval items. */
+final readonly class ApprovalInbox
+{
+    public function __construct(
+        private PendingApprovalStore $pendingApprovals,
+        private ApprovalItemFactory $items,
+    ) {}
+
+    /** @return list<ApprovalItem> */
+    public function items(): array
+    {
+        return array_map($this->items->make(...), $this->pendingApprovals->visible());
+    }
+}

--- a/src/Approvals/ApprovalItem.php
+++ b/src/Approvals/ApprovalItem.php
@@ -38,6 +38,8 @@ final readonly class ApprovalItem
         public ?DateTimeImmutable $expiresAt,
         public ?DateTimeImmutable $waitingSince,
         public string $state,
+        public string $resumability,
+        public ?string $unresumableReason,
         public array $verbs,
         public array $provenance,
     ) {}
@@ -57,6 +59,8 @@ final readonly class ApprovalItem
             // Verdict #300 adds issuedAt. The console row's created_at is ingestion time, not it.
             waitingSince: null,
             state: $challenge === null ? 'expired_or_already_decided' : 'pending',
+            resumability: $approval->resumability->value,
+            unresumableReason: $approval->unresumable_reason?->value,
             verbs: $verbs,
             provenance: self::provenance($challenge?->provenance),
         );
@@ -76,6 +80,8 @@ final readonly class ApprovalItem
             'expires_at' => $this->expiresAt?->format(DATE_ATOM),
             'waiting_since' => $this->waitingSince?->format(DATE_ATOM),
             'state' => $this->state,
+            'resumability' => $this->resumability,
+            'unresumable_reason' => $this->unresumableReason,
             'verbs' => array_map(static fn (ApprovalVerb $verb): string => $verb->value, $this->verbs),
             'provenance' => $this->provenance,
         ];

--- a/src/Approvals/PendingApprovalStore.php
+++ b/src/Approvals/PendingApprovalStore.php
@@ -157,6 +157,32 @@ final class PendingApprovalStore
     }
 
     /**
+     * Find an approval only when the host's operator scope currently exposes it.
+     *
+     * Unlike the correlation reads, this read is scoped because it serves an operator action.
+     */
+    public function findVisible(string $id): ?PendingApproval
+    {
+        return $this->scope->apply(PendingApproval::query())->find($id);
+    }
+
+    /**
+     * List the approvals the host currently exposes to an operator, newest first.
+     *
+     * Unlike correlation reads, this list is an operator surface and therefore always scoped.
+     *
+     * @return list<PendingApproval>
+     */
+    public function visible(): array
+    {
+        return array_values($this->scope->apply(PendingApproval::query())
+            ->orderByDesc('created_at')
+            ->orderBy('id')
+            ->get()
+            ->all());
+    }
+
+    /**
      * Record that a resume attempt is beginning, and say which attempt it is.
      *
      * **Locked rather than incremented-then-read.** `increment()` followed by a separate `value()`

--- a/src/Http/Controllers/ApprovalActionController.php
+++ b/src/Http/Controllers/ApprovalActionController.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Http\Controllers;
+
+use Fissible\VerdictConsole\Approvals\ApprovalResolutionService;
+use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
+use Fissible\VerdictConsole\Exceptions\ApprovalNotDrivable;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/** Relays one scoped inbox form post to the headless approval-resolution service. */
+final readonly class ApprovalActionController
+{
+    public function __construct(
+        private PendingApprovalStore $pendingApprovals,
+        private ApprovalResolutionService $resolutions,
+    ) {}
+
+    public function approve(Request $request, string $approval): RedirectResponse
+    {
+        return $this->resolve($request, $approval, 'approve');
+    }
+
+    public function reject(Request $request, string $approval): RedirectResponse
+    {
+        return $this->resolve($request, $approval, 'reject');
+    }
+
+    public function close(Request $request, string $approval): RedirectResponse
+    {
+        $pending = $this->pendingApprovals->findVisible($approval);
+
+        abort_if($pending === null, 404);
+
+        try {
+            $status = $this->resolutions->close($pending, $request->user())->value;
+        } catch (ApprovalNotDrivable) {
+            $status = 'not_actionable';
+        }
+
+        return redirect()->back()->with('verdict-console.status', $status);
+    }
+
+    /** @param 'approve'|'reject' $verb */
+    private function resolve(Request $request, string $approval, string $verb): RedirectResponse
+    {
+        $pending = $this->pendingApprovals->findVisible($approval);
+
+        abort_if($pending === null, 404);
+
+        try {
+            $transition = match ($verb) {
+                'approve' => $this->resolutions->approve($pending, $request->user()),
+                'reject' => $this->resolutions->reject($pending, $request->user()),
+            };
+            $status = $transition === null ? 'not_actionable' : match ($verb) {
+                'approve' => 'approved',
+                'reject' => 'rejected',
+            };
+        } catch (ApprovalNotDrivable) {
+            $status = 'not_actionable';
+        }
+
+        return redirect()->back()->with('verdict-console.status', $status);
+    }
+}

--- a/src/Http/VerdictConsoleRoutes.php
+++ b/src/Http/VerdictConsoleRoutes.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Http;
+
+use Fissible\VerdictConsole\Http\Controllers\ApprovalActionController;
+use Illuminate\Support\Facades\Route;
+
+/**
+ * Opt-in route helper for the Blade approval inbox's single-row action forms.
+ *
+ * Mounting is opt-in and the host's decision: this package registers no routes unless the host calls this helper
+ * or sets the verdict-console.routes.register configuration. Any future install or setup command must ask the user
+ * before registering these routes.
+ */
+final readonly class VerdictConsoleRoutes
+{
+    /**
+     * Register the console's action endpoints using host-supplied or configured mount settings.
+     *
+     * @param  list<string>|null  $middleware
+     */
+    public static function register(?string $prefix = null, ?array $middleware = null): void
+    {
+        Route::middleware($middleware ?? config('verdict-console.routes.middleware'))
+            ->prefix($prefix ?? config('verdict-console.routes.prefix'))
+            ->group(function (): void {
+                Route::name('verdict-console.approvals.approve')
+                    ->post('approvals/{approval}/approve', [ApprovalActionController::class, 'approve']);
+                Route::name('verdict-console.approvals.reject')
+                    ->post('approvals/{approval}/reject', [ApprovalActionController::class, 'reject']);
+                Route::name('verdict-console.approvals.close')
+                    ->post('approvals/{approval}/close', [ApprovalActionController::class, 'close']);
+            });
+    }
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -31,6 +31,7 @@ use Fissible\VerdictConsole\Events\ApprovalDecisionRefused;
 use Fissible\VerdictConsole\Events\ApprovalIngestionIncident;
 use Fissible\VerdictConsole\Evidence\DatabaseEvidenceQuery;
 use Fissible\VerdictConsole\ExecutionClaims\GateExecutionClaimAuthority;
+use Fissible\VerdictConsole\Http\VerdictConsoleRoutes;
 use Fissible\VerdictConsole\Incidents\IncidentStore;
 use Fissible\VerdictConsole\Listeners\IngestToolApprovalRequests;
 use Fissible\VerdictConsole\Listeners\LogApprovalIngestionIncident;
@@ -41,6 +42,7 @@ use Fissible\VerdictConsole\Notifications\UnconfiguredApprovalNotificationRecipi
 use Fissible\VerdictConsole\Participants\UnconfiguredConversationParticipants;
 use Fissible\VerdictConsole\Presentation\DefaultApprovalPresenter;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Ai\Events\AgentPrompted;
 use Laravel\Ai\Events\AgentStreamed;
@@ -98,6 +100,13 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
 
     public function boot(Dispatcher $events): void
     {
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'verdict-console');
+        Blade::componentNamespace('Fissible\\VerdictConsole\\View\\Components', 'verdict-console');
+
+        if (config('verdict-console.routes.register')) {
+            VerdictConsoleRoutes::register();
+        }
+
         // Listener registration belongs in boot, after every provider has registered its bindings.
         // It must precede the console-only guard: approvals are ingested on ordinary web requests.
         $events->listen(ToolApprovalRequested::class, IngestToolApprovalRequests::class);
@@ -129,6 +138,10 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../config/verdict-console.php' => config_path('verdict-console.php'),
         ], ['verdict-console', 'verdict-console-config']);
+
+        $this->publishes([
+            __DIR__.'/../resources/views' => resource_path('views/vendor/verdict-console'),
+        ], ['verdict-console', 'verdict-console-views']);
 
         // Published rather than loaded from the package: the host owns when its schema changes, and
         // a console table appearing on `migrate` without the host having asked for it is the kind of

--- a/src/View/Components/Approvals.php
+++ b/src/View/Components/Approvals.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\View\Components;
+
+use Fissible\VerdictConsole\Approvals\ApprovalInbox;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Route;
+use Illuminate\View\Component;
+
+/** Server-rendered inbox for the approvals currently visible to the host operator. */
+final class Approvals extends Component
+{
+    public function __construct(private ApprovalInbox $inbox) {}
+
+    public function render(): View
+    {
+        return view('verdict-console::components.approvals', [
+            'items' => $this->inbox->items(),
+            'mounted' => Route::has('verdict-console.approvals.approve'),
+            'routes' => [
+                'approve' => 'verdict-console.approvals.approve',
+                'reject' => 'verdict-console.approvals.reject',
+                'close' => 'verdict-console.approvals.close',
+            ],
+        ]);
+    }
+}

--- a/tests/.pest/snapshots/Feature/ApprovalInboxComponentTest/it_matches_the_snapshot_of_the_three_state_matrix.snap
+++ b/tests/.pest/snapshots/Feature/ApprovalInboxComponentTest/it_matches_the_snapshot_of_the_three_state_matrix.snap
@@ -1,0 +1,52 @@
+<section data-verdict-console="approvals" data-routes="mounted">
+<article data-approval="{approval-3}" data-state="expired_or_already_decided">
+<h2>CloseAccountTool</h2>
+<p>orders.cancel</p>
+<p>sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</p>
+<dl>
+<dt>order</dt><dd>#1001</dd>
+</dl>
+<p>expired or already decided</p>
+<div data-provenance="issued_before_provenance_capture">
+<p>issued before provenance capture</p>
+</div>
+<form method="post" action="http://localhost/verdict-console/approvals/{approval-3}/close" data-verb="close">
+<input type="hidden" name="_token" value="{token}" autocomplete="off">                        <button type="submit">Close</button>
+</form>
+</article>
+<article data-approval="{approval-2}" data-state="not_console_actionable" data-unresumable-reason="agent_unresolvable">
+<h2>RefundTool</h2>
+<p>orders.cancel</p>
+<p>sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</p>
+<dl>
+<dt>order</dt><dd>#1001</dd>
+</dl>
+<dl><dt>Why this capability is gated</dt><dd>Cancelling an order needs confirmation.</dd></dl>
+<p>not actionable from this console: <code>agent_unresolvable</code></p>
+<div data-provenance="unknown">
+<p>provenance unknown — no derivation was declared</p>
+</div>
+</article>
+<article data-approval="{approval-1}" data-state="pending">
+<h2>CancelOrderTool</h2>
+<p>orders.cancel</p>
+<p>sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</p>
+<dl>
+<dt>order</dt><dd>#1001</dd>
+</dl>
+<dl><dt>Why this capability is gated</dt><dd>Cancelling an order needs confirmation.</dd></dl>
+<time datetime="2030-01-02T03:04:05+00:00">2030-01-02T03:04:05+00:00</time>
+<div data-provenance="declared">
+<ul>
+<li data-source-warning="true">external · search · untrusted · public · retrieved_document</li>
+</ul>
+<p>1 upstream source undescribed</p>
+</div>
+<form method="post" action="http://localhost/verdict-console/approvals/{approval-1}/approve" data-verb="approve">
+<input type="hidden" name="_token" value="{token}" autocomplete="off">                        <button type="submit">Approve</button>
+</form>
+<form method="post" action="http://localhost/verdict-console/approvals/{approval-1}/reject" data-verb="reject">
+<input type="hidden" name="_token" value="{token}" autocomplete="off">                        <button type="submit">Reject</button>
+</form>
+</article>
+</section>

--- a/tests/EndToEnd/ApprovalInboxHttpTest.php
+++ b/tests/EndToEnd/ApprovalInboxHttpTest.php
@@ -1,0 +1,362 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Actions\ActionContext;
+use Fissible\Verdict\Actions\ActionEnvelope;
+use Fissible\Verdict\Actions\AuthorizedAction;
+use Fissible\Verdict\Capabilities\Capability;
+use Fissible\Verdict\Capabilities\CapabilityRegistry;
+use Fissible\Verdict\Contracts\CapabilityAuthorizer;
+use Fissible\Verdict\Decisions\Decision;
+use Fissible\Verdict\LaravelAi\VerdictApprovalMiddleware;
+use Fissible\Verdict\Targets\ExecutionTargetPolicy;
+use Fissible\Verdict\VerdictManager;
+use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
+use Fissible\VerdictConsole\Approvals\PendingApproval as StoredPendingApproval;
+use Fissible\VerdictConsole\Contracts\ApprovalScope;
+use Fissible\VerdictConsole\Contracts\ResumableAgents;
+use Fissible\VerdictConsole\Http\VerdictConsoleRoutes;
+use Fissible\VerdictConsole\Tests\EndToEndTestCase;
+use Illuminate\Auth\GenericUser;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
+use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
+use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Concerns\RemembersConversations as RemembersConversationsTrait;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasMiddleware;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Contracts\RemembersConversations as RemembersConversationsContract;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Tools\Request;
+
+/**
+ * The widget's form-posts, end to end: a real pause, a real receipt, a browser-shaped POST, and the
+ * VC-6 outcome measured where it matters — whether the executor ran. Fixtures are this file's own.
+ */
+const INBOX_ORDER_ID = 7001;
+
+final class InboxLedger
+{
+    public int $executions = 0;
+}
+
+final readonly class InboxOrder
+{
+    public function __construct(public int $id) {}
+}
+
+final class InboxCancelOrderTool implements Tool
+{
+    public function description(): Stringable|string
+    {
+        return 'Cancel an order by id.';
+    }
+
+    public function handle(Request $request): Stringable|string
+    {
+        return 'The Verdict-bound tool handles this.';
+    }
+
+    /** @return array<string, Type> */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}
+
+function inboxBoundTool(): Tool
+{
+    $verdict = app(VerdictManager::class);
+
+    if (! app(CapabilityRegistry::class)->has('orders.cancel')) {
+        $verdict->capability(
+            Capability::usingPolicy(
+                name: 'orders.cancel',
+                ability: 'update',
+                resolveTarget: fn (ActionEnvelope $e): InboxOrder => new InboxOrder((int) $e->proposal->arguments['order_id']),
+            )
+                ->executionTarget(ExecutionTargetPolicy::acceptStaleSnapshot(
+                    name: 'inbox-target',
+                    identityUsing: fn (ActionEnvelope $e, InboxOrder $t): array => ['id' => $t->id],
+                ))
+                ->requiresConfirmation(fn (ActionEnvelope $e, InboxOrder $t): array => ['order_id' => $t->id], reason: 'Cancelling an order needs confirmation.')
+                ->executeUsing(function (AuthorizedAction $a): string {
+                    app(InboxLedger::class)->executions++;
+
+                    return 'Order cancelled.';
+                }),
+        );
+    }
+
+    return $verdict->bound(new InboxCancelOrderTool, 'orders.cancel', new ActionContext('customer'));
+}
+
+final class InboxAgent implements Agent, HasMiddleware, HasTools, RemembersConversationsContract
+{
+    use Promptable;
+    use RemembersConversationsTrait;
+
+    public function instructions(): Stringable|string
+    {
+        return 'Cancel orders when asked.';
+    }
+
+    /** @return array<int, Tool> */
+    public function tools(): array
+    {
+        return [inboxBoundTool()];
+    }
+
+    /** @return array<int, object> */
+    public function middleware(): array
+    {
+        return [app(VerdictApprovalMiddleware::class)];
+    }
+
+    public function provider(): string
+    {
+        return EndToEndTestCase::PROVIDER;
+    }
+
+    public function maxSteps(): int
+    {
+        return 3;
+    }
+}
+
+/** Pause a participant-less run and return the stored console row. */
+function pausedInboxRow(): StoredPendingApproval
+{
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push(test()->toolCallResponse('call_inbox', 'InboxCancelOrderTool', ['order_id' => INBOX_ORDER_ID]))
+            ->push(test()->textResponse('Done.')),
+    ]);
+
+    $paused = (new InboxAgent)->prompt('Please cancel order '.INBOX_ORDER_ID.'.');
+
+    expect($paused->hasPendingApprovals())->toBeTrue('Fixture: the run must pause.');
+
+    return StoredPendingApproval::query()->sole();
+}
+
+function inboxApprover(): GenericUser
+{
+    return new GenericUser(['id' => 501]);
+}
+
+beforeEach(function (): void {
+    $this->migrateRoundTripTables();
+
+    $console = dirname(__DIR__, 2).'/database/migrations';
+    (require $console.'/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require $console.'/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require $console.'/create_verdict_console_approval_notifications_table.php.stub')->up();
+    (require $console.'/create_verdict_console_approval_reconciliations_table.php.stub')->up();
+
+    $this->app->instance(InboxLedger::class, new InboxLedger);
+    $this->app->instance(CapabilityAuthorizer::class, new class implements CapabilityAuthorizer
+    {
+        public function decide(Capability $capability, ActionEnvelope $envelope, mixed $target): Decision
+        {
+            return Decision::permit('inbox test');
+        }
+    });
+
+    /** @var AgentResolverRegistry $resolvers */
+    $resolvers = app(ResumableAgents::class);
+    $resolvers->register('inbox@v1', fn (): InboxAgent => new InboxAgent, fn (Agent $agent): bool => $agent instanceof InboxAgent);
+
+    // The host mounts the routes; the browser-shaped requests below carry no CSRF token. Both
+    // framework names are bypassed so the suite holds across the Laravel versions in the matrix.
+    VerdictConsoleRoutes::register();
+    $this->withoutMiddleware([PreventRequestForgery::class, ValidateCsrfToken::class]);
+});
+
+/** Hides every row: the endpoint must answer as if the row did not exist, before any Gate. */
+final class HideEverythingScope implements ApprovalScope
+{
+    public function apply(Builder $query): Builder
+    {
+        return $query->whereRaw('1 = 0');
+    }
+}
+
+it('approves through the form-post and the paused run executes exactly once', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    $row = pausedInboxRow();
+
+    $response = $this->actingAs(inboxApprover())->from('/inbox')->post(route('verdict-console.approvals.approve', $row->id));
+
+    $response->assertRedirect('/inbox')->assertSessionHas('verdict-console.status', 'approved');
+
+    expect(app(InboxLedger::class)->executions)->toBe(1, 'An approved, keyed resume executes exactly once.')
+        ->and(DB::table($this->approvalReceiptTable())->where('tool_call_id', 'call_inbox')->first())
+        ->toMatchArray(['status' => 'consumed', 'approved_by' => '501']);
+
+    Http::assertSentCount(2);
+});
+
+it('rejects through the form-post and the run resumes to a refusal without executing', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    $row = pausedInboxRow();
+
+    $this->actingAs(inboxApprover())->from('/inbox')->post(route('verdict-console.approvals.reject', $row->id))
+        ->assertRedirect('/inbox')
+        ->assertSessionHas('verdict-console.status', 'rejected');
+
+    expect(app(InboxLedger::class)->executions)->toBe(0)
+        ->and(DB::table($this->approvalReceiptTable())->where('tool_call_id', 'call_inbox')->first())
+        ->toMatchArray(['status' => 'rejected', 'rejected_by' => '501']);
+
+    Http::assertSentCount(2);
+});
+
+/** "Back" with nowhere to go back to falls back to the application root, never to an error. */
+it('redirects to the application root when the post carries no referer', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    $row = pausedInboxRow();
+
+    $this->actingAs(inboxApprover())->post(route('verdict-console.approvals.reject', $row->id))
+        ->assertRedirect(url('/'));
+});
+
+/**
+ * The widget carries no authority of its own: the same Gate that governs the service governs the
+ * endpoint, and a refusal is a 403 with nothing spent — no receipt transition, no resume.
+ */
+it('refuses an approver the host Gate denies, spending nothing', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => false);
+    $row = pausedInboxRow();
+
+    $this->actingAs(inboxApprover())->post(route('verdict-console.approvals.approve', $row->id))->assertForbidden();
+
+    expect(app(InboxLedger::class)->executions)->toBe(0)
+        ->and(app(VerdictManager::class)->approvals()->challengeForToolCall('call_inbox'))->not->toBeNull('The receipt is still pending.');
+
+    Http::assertSentCount(1);
+});
+
+it('refuses an unauthenticated post', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    $row = pausedInboxRow();
+
+    $this->post(route('verdict-console.approvals.approve', $row->id))->assertForbidden();
+
+    expect(app(InboxLedger::class)->executions)->toBe(0);
+});
+
+it('answers not-found for a row that does not exist, before any authority check', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => throw new LogicException('The Gate must not be consulted for a row that is not there.'));
+
+    $this->actingAs(inboxApprover())->post(route('verdict-console.approvals.approve', 'not-a-row'))->assertNotFound();
+});
+
+/** VC-12: a row outside the host scope is indistinguishable from a row that does not exist. */
+it('answers not-found for an existing row outside the host scope, before any authority check', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => throw new LogicException('The Gate must not be consulted for a hidden row.'));
+    $row = pausedInboxRow();
+    app()->instance(ApprovalScope::class, new HideEverythingScope);
+
+    $this->actingAs(inboxApprover())->post(route('verdict-console.approvals.approve', $row->id))->assertNotFound();
+
+    expect(app(InboxLedger::class)->executions)->toBe(0);
+});
+
+it('refuses a close the host Gate denies, spending nothing', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => false);
+    $row = pausedInboxRow();
+
+    $this->actingAs(inboxApprover())->post(route('verdict-console.approvals.close', $row->id))->assertForbidden();
+
+    expect(app(InboxLedger::class)->executions)->toBe(0)
+        ->and(DB::table($this->approvalReceiptTable())->where('tool_call_id', 'call_inbox')->value('status'))->toBe('pending');
+
+    Http::assertSentCount(1);
+});
+
+/**
+ * The state the close form exists for: a receipt that lapsed. The widget renders the row as
+ * expired-or-already-decided with close as its only control, and posting it resumes the exact
+ * conversation with a rejection — the receipt is never decided on the human's behalf.
+ */
+it('renders a lapsed receipt with only a close form, and close resumes without deciding the receipt', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    $row = pausedInboxRow();
+    DB::table($this->approvalReceiptTable())->where('tool_call_id', 'call_inbox')->update(['expires_at' => now()->subMinute()]);
+
+    $html = (string) $this->blade('<x-verdict-console::approvals />');
+
+    expect($html)->toContain('data-approval="'.$row->id.'"')
+        ->and($html)->toContain('data-state="expired_or_already_decided"')
+        ->and($html)->toContain('expired or already decided')
+        ->and($html)->toContain('action="'.route('verdict-console.approvals.close', $row->id).'"')
+        ->and($html)->not->toContain('data-verb="approve"')
+        ->and($html)->not->toContain('data-verb="reject"');
+
+    $this->actingAs(inboxApprover())->from('/inbox')->post(route('verdict-console.approvals.close', $row->id))
+        ->assertRedirect('/inbox')
+        ->assertSessionHas('verdict-console.status', 'closed');
+
+    expect(app(InboxLedger::class)->executions)->toBe(0, 'Close only sends Laravel AI a rejection.')
+        ->and(DB::table($this->approvalReceiptTable())->where('tool_call_id', 'call_inbox')->value('status'))->toBe('pending', 'Close never mutates the receipt.');
+
+    Http::assertSentCount(2);
+});
+
+/**
+ * The absence of approve and reject controls on a lapsed row is not what protects it. A forged
+ * POST to either still-routable endpoint must decide nothing, execute nothing, and resume nothing:
+ * VC-6 answers null for a receipt Verdict no longer accepts a decision on, and the widget relays it.
+ */
+it('refuses forged approve and reject posts against a lapsed receipt, spending nothing', function (string $verb): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    $row = pausedInboxRow();
+    DB::table($this->approvalReceiptTable())->where('tool_call_id', 'call_inbox')->update(['expires_at' => now()->subMinute()]);
+
+    $this->actingAs(inboxApprover())->from('/inbox')->post(route('verdict-console.approvals.'.$verb, $row->id))
+        ->assertRedirect('/inbox')
+        ->assertSessionHas('verdict-console.status', 'not_actionable');
+
+    expect(app(InboxLedger::class)->executions)->toBe(0)
+        ->and(DB::table($this->approvalReceiptTable())->where('tool_call_id', 'call_inbox')->first())
+        ->toMatchArray(['status' => 'pending', 'approved_by' => null, 'rejected_by' => null]);
+
+    Http::assertSentCount(1, 'Nothing resumed: only the original pause reached the model.');
+})->with(['approve', 'reject']);
+
+/** Close on a row whose decision is still available does not decide: the service reports it, the widget relays it. */
+it('relays a close that found a live decision still available, deciding nothing', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    $row = pausedInboxRow();
+
+    $this->actingAs(inboxApprover())->from('/inbox')->post(route('verdict-console.approvals.close', $row->id))
+        ->assertRedirect('/inbox')
+        ->assertSessionHas('verdict-console.status', 'decision_still_available');
+
+    expect(app(InboxLedger::class)->executions)->toBe(0)
+        ->and(app(VerdictManager::class)->approvals()->challengeForToolCall('call_inbox'))->not->toBeNull();
+
+    Http::assertSentCount(1);
+});
+
+/** The widget over a real pause: the row is drivable and offers exactly approve and reject. */
+it('renders the real paused row as drivable with approve and reject forms', function (): void {
+    $row = pausedInboxRow();
+
+    $html = (string) $this->blade('<x-verdict-console::approvals />');
+
+    expect($html)->toContain('data-approval="'.$row->id.'"')
+        ->and($html)->toContain('data-state="pending"')
+        ->and($html)->toContain('action="'.route('verdict-console.approvals.approve', $row->id).'"')
+        ->and($html)->toContain('action="'.route('verdict-console.approvals.reject', $row->id).'"')
+        ->and($html)->not->toContain('data-verb="close"')
+        ->and($html)->toContain('Cancelling an order needs confirmation.');
+});

--- a/tests/EndToEnd/ApprovalInboxHttpTest.php
+++ b/tests/EndToEnd/ApprovalInboxHttpTest.php
@@ -174,6 +174,10 @@ beforeEach(function (): void {
     $resolvers = app(ResumableAgents::class);
     $resolvers->register('inbox@v1', fn (): InboxAgent => new InboxAgent, fn (Agent $agent): bool => $agent instanceof InboxAgent);
 
+    // The `web` group encrypts cookies and flashes to the session, both of which need an app key;
+    // a fixed test-only key keeps the suite hermetic and deterministic.
+    config()->set('app.key', 'base64:'.base64_encode(str_repeat('k', 32)));
+
     // The host mounts the routes; the browser-shaped requests below carry no CSRF token. Both
     // framework names are bypassed so the suite holds across the Laravel versions in the matrix.
     VerdictConsoleRoutes::register();

--- a/tests/EndToEnd/ApprovalInboxHttpTest.php
+++ b/tests/EndToEnd/ApprovalInboxHttpTest.php
@@ -220,7 +220,9 @@ it('rejects through the form-post and the run resumes to a refusal without execu
         ->and(DB::table($this->approvalReceiptTable())->where('tool_call_id', 'call_inbox')->first())
         ->toMatchArray(['status' => 'rejected', 'rejected_by' => '501']);
 
-    Http::assertSentCount(2);
+    // Measured, not assumed: a bare rejection ends the turn — Laravel AI records the denied tool
+    // result and returns without another model call (TextGenerationLoop::resumeFromApproval).
+    Http::assertSentCount(1);
 });
 
 /** "Back" with nowhere to go back to falls back to the application root, never to an error. */
@@ -312,7 +314,8 @@ it('renders a lapsed receipt with only a close form, and close resumes without d
     expect(app(InboxLedger::class)->executions)->toBe(0, 'Close only sends Laravel AI a rejection.')
         ->and(DB::table($this->approvalReceiptTable())->where('tool_call_id', 'call_inbox')->value('status'))->toBe('pending', 'Close never mutates the receipt.');
 
-    Http::assertSentCount(2);
+    // Same measured fact as reject: the bare rejection close sends ends the turn with no model call.
+    Http::assertSentCount(1);
 });
 
 /**

--- a/tests/Feature/ApprovalInboxComponentTest.php
+++ b/tests/Feature/ApprovalInboxComponentTest.php
@@ -1,0 +1,387 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Approvals\ApprovalChallenge;
+use Fissible\Verdict\Approvals\ProposalProvenance;
+use Fissible\Verdict\Approvals\UpstreamSource;
+use Fissible\Verdict\Context\ContextChannel;
+use Fissible\Verdict\Context\DataClass;
+use Fissible\Verdict\Context\Source;
+use Fissible\Verdict\Context\Trust;
+use Fissible\VerdictConsole\Approvals\ApprovalChallengeReader;
+use Fissible\VerdictConsole\Approvals\ApprovalSurfaceContract;
+use Fissible\VerdictConsole\Approvals\ApprovalVerb;
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
+use Fissible\VerdictConsole\Approvals\Resumability;
+use Fissible\VerdictConsole\Approvals\UnresumableReason;
+use Fissible\VerdictConsole\Contracts\ApprovalScope;
+use Fissible\VerdictConsole\Http\VerdictConsoleRoutes;
+use Fissible\VerdictConsole\View\Components\Approvals;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The widget is a pure function of the console index and the live challenge, so the challenge
+ * reader is faked per tool call: this suite proves markup, not Verdict.
+ */
+final class InboxChallenges implements ApprovalChallengeReader
+{
+    /** @var list<string> every tool call the widget asked Verdict about, in order */
+    public array $reads = [];
+
+    /** @param array<string, ApprovalChallenge|null> $byToolCall */
+    public function __construct(private array $byToolCall = []) {}
+
+    public function with(string $toolCallId, ?ApprovalChallenge $challenge): self
+    {
+        $this->byToolCall[$toolCallId] = $challenge;
+
+        return $this;
+    }
+
+    public function challengeForToolCall(string $toolCallId): ?ApprovalChallenge
+    {
+        $this->reads[] = $toolCallId;
+
+        return $this->byToolCall[$toolCallId] ?? null;
+    }
+}
+
+final readonly class InboxConversationScope implements ApprovalScope
+{
+    public function __construct(private string $conversationId) {}
+
+    public function apply(Builder $query): Builder
+    {
+        return $query->where('conversation_id', $this->conversationId);
+    }
+}
+
+function inboxChallenge(string $toolCallId, ?ProposalProvenance $provenance = null, string $expiresAt = '2030-01-02T03:04:05+00:00'): ApprovalChallenge
+{
+    return new ApprovalChallenge(
+        receiptId: 'receipt-'.$toolCallId,
+        toolCallId: $toolCallId,
+        capability: 'orders.cancel',
+        reason: 'Cancelling an order needs confirmation.',
+        expiresAt: new DateTimeImmutable($expiresAt),
+        provenance: $provenance,
+    );
+}
+
+/** @return array<string, mixed> */
+function inboxPresentation(string $tool = 'CancelOrderTool'): array
+{
+    return [
+        'tool' => $tool,
+        'capability' => 'orders.cancel',
+        'reason' => 'Cancelling an order needs confirmation.',
+        'arguments_fingerprint' => 'sha256:'.str_repeat('a', 64),
+        'details' => ['order' => '#1001'],
+    ];
+}
+
+function renderInbox(): string
+{
+    return (string) test()->blade('<x-verdict-console::approvals />');
+}
+
+/**
+ * Split the rendered widget into rows keyed by approval id, so assertions can say "this row" and
+ * "this row only". The `data-approval` attribute on the row's wrapping element is the widget's
+ * stable contract for tests and host CSS alike; which element wraps a row, and what it nests, is
+ * the view's choice — hence a DOM walk rather than a regex that would stop at the first nested
+ * closing tag.
+ *
+ * @return array<string, string>
+ */
+function inboxRows(string $html): array
+{
+    $document = new DOMDocument;
+    libxml_use_internal_errors(true);
+    $document->loadHTML('<?xml encoding="utf-8" ?>'.$html);
+    libxml_clear_errors();
+
+    $rows = [];
+
+    foreach ((new DOMXPath($document))->query('//*[@data-approval]') ?: [] as $node) {
+        if ($node instanceof DOMElement) {
+            $rows[$node->getAttribute('data-approval')] = (string) $document->saveHTML($node);
+        }
+    }
+
+    return $rows;
+}
+
+function rowAttribute(string $row, string $attribute): ?string
+{
+    return preg_match('/^<\w+\b[^>]*\b'.preg_quote($attribute, '/').'="([^"]*)"/', $row, $m) === 1 ? $m[1] : null;
+}
+
+/**
+ * The rendered widget with every per-run value replaced by a stable placeholder, so the complete
+ * markup of the three-state matrix can be held as a snapshot: row ids become {approval-N} and the
+ * mounted route URLs follow them.
+ *
+ * @param  list<string>  $ids  approval ids in the order they should be numbered
+ */
+function normalizedInbox(string $html, array $ids): string
+{
+    foreach ($ids as $n => $id) {
+        $html = str_replace($id, '{approval-'.($n + 1).'}', $html);
+    }
+
+    // The CSRF token value is per session; the field's presence is what the snapshot pins.
+    $html = preg_replace('/(name="_token"\s+value=")[^"]*(")/', '${1}{token}${2}', $html) ?? $html;
+
+    return trim(preg_replace('/^[ \t]+|[ \t]+$/m', '', $html) ?? $html);
+}
+
+/** @return list<ApprovalVerb> */
+function renderedVerbs(string $row): array
+{
+    preg_match_all('/<form\b[^>]*\bdata-verb="([^"]+)"/', $row, $matches);
+
+    return array_map(fn (string $verb): ApprovalVerb => ApprovalVerb::from($verb), $matches[1]);
+}
+
+beforeEach(function (): void {
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+
+    $this->challenges = new InboxChallenges;
+    app()->instance(ApprovalChallengeReader::class, $this->challenges);
+    $this->store = new PendingApprovalStore;
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists('verdict_console_pending_approvals');
+});
+
+/** The three rows the issue names, and only those, each told apart by its state attribute. */
+it('renders drivable, not-console-actionable, and expired-or-already-decided rows distinctly', function (): void {
+    VerdictConsoleRoutes::register();
+    $drivable = $this->store->ingest('call_drivable', conversationId: 'c1', receiptId: 'receipt-call_drivable', presentation: inboxPresentation(), resumability: Resumability::Drivable);
+    $unresumable = $this->store->ingest('call_unresumable', conversationId: 'c2', receiptId: 'receipt-call_unresumable', presentation: inboxPresentation('RefundTool'), resumability: Resumability::Unresumable, unresumableReason: UnresumableReason::AgentUnresolvable);
+    $lapsed = $this->store->ingest('call_lapsed', conversationId: 'c3', receiptId: 'receipt-call_lapsed', presentation: inboxPresentation('CloseAccountTool'), resumability: Resumability::Drivable);
+    $this->challenges->with('call_drivable', inboxChallenge('call_drivable'))->with('call_unresumable', inboxChallenge('call_unresumable'))->with('call_lapsed', null);
+
+    $rows = inboxRows(renderInbox());
+
+    expect(array_keys($rows))->toEqualCanonicalizing([$drivable->id, $unresumable->id, $lapsed->id]);
+
+    expect(rowAttribute($rows[$drivable->id], 'data-state'))->toBe('pending')
+        ->and(renderedVerbs($rows[$drivable->id]))->toEqualCanonicalizing([ApprovalVerb::Approve, ApprovalVerb::Reject])
+        ->and($rows[$drivable->id])->toContain('CancelOrderTool')
+        ->and($rows[$drivable->id])->toContain('orders.cancel');
+
+    // Verdict still holds a live receipt here, but this console cannot drive the run: the row must
+    // say so, and must offer nothing that looks like a decision.
+    expect(rowAttribute($rows[$unresumable->id], 'data-state'))->toBe('not_console_actionable')
+        ->and(rowAttribute($rows[$unresumable->id], 'data-unresumable-reason'))->toBe('agent_unresolvable')
+        ->and(renderedVerbs($rows[$unresumable->id]))->toBe([])
+        ->and($rows[$unresumable->id])->not->toContain('<form')
+        ->and($rows[$unresumable->id])->not->toContain('<button')
+        ->and($rows[$unresumable->id])->not->toContain('data-verb');
+
+    // A null challenge collapses expired with already-decided (ADR 0001 §3); the copy says both and
+    // the only verb is the non-authorizing close — a real POST form, to the named route, with a token.
+    expect(rowAttribute($rows[$lapsed->id], 'data-state'))->toBe('expired_or_already_decided')
+        ->and($rows[$lapsed->id])->toContain('expired or already decided')
+        ->and(renderedVerbs($rows[$lapsed->id]))->toBe([ApprovalVerb::Close])
+        ->and($rows[$lapsed->id])->toContain('action="'.route('verdict-console.approvals.close', $lapsed->id).'"')
+        ->and($rows[$lapsed->id])->toContain('method="post"')
+        ->and($rows[$lapsed->id])->toContain('_token')
+        ->and($rows[$lapsed->id])->not->toContain('data-verb="approve"');
+});
+
+/**
+ * The issue asks for snapshot coverage, and this is where it earns its keep: the complete markup
+ * of the three-state matrix, normalized, so an unintended change to any row's shape — a control
+ * appearing, a state label drifting, a provenance line vanishing — fails visibly rather than
+ * slipping past fragment assertions. Ids, route URLs, and the token are placeholders.
+ */
+it('matches the snapshot of the three-state matrix', function (): void {
+    VerdictConsoleRoutes::register();
+    $drivable = $this->store->ingest('call_drivable', conversationId: 'c1', receiptId: 'receipt-call_drivable', presentation: inboxPresentation(), resumability: Resumability::Drivable);
+    $unresumable = $this->store->ingest('call_unresumable', conversationId: 'c2', receiptId: 'receipt-call_unresumable', presentation: inboxPresentation('RefundTool'), resumability: Resumability::Unresumable, unresumableReason: UnresumableReason::AgentUnresolvable);
+    $lapsed = $this->store->ingest('call_lapsed', conversationId: 'c3', receiptId: 'receipt-call_lapsed', presentation: inboxPresentation('CloseAccountTool'), resumability: Resumability::Drivable);
+    $this->challenges
+        ->with('call_drivable', inboxChallenge('call_drivable', ProposalProvenance::declared([
+            new UpstreamSource(Source::external('search'), Trust::Untrusted, DataClass::Public, ContextChannel::RetrievedDocument),
+        ], undescribedSourceCount: 1, withheldSourceCount: 0)))
+        ->with('call_unresumable', inboxChallenge('call_unresumable', ProposalProvenance::unknown()))
+        ->with('call_lapsed', null);
+
+    expect(normalizedInbox(renderInbox(), [$drivable->id, $unresumable->id, $lapsed->id]))->toMatchSnapshot();
+});
+
+/**
+ * ADR 0001's verb invariant, pinned the way every surface must pin it: the verbs the markup offers
+ * are compared to VC-41's resolver, so presentation code cannot grow an approve button of its own.
+ */
+it('renders exactly the verb set the surface contract resolves for every row', function (): void {
+    VerdictConsoleRoutes::register();
+    $rows = [
+        'call_drivable' => $this->store->ingest('call_drivable', conversationId: 'c1', receiptId: 'receipt-call_drivable', resumability: Resumability::Drivable),
+        'call_unresumable' => $this->store->ingest('call_unresumable', conversationId: 'c2', receiptId: 'receipt-call_unresumable', resumability: Resumability::Unresumable, unresumableReason: UnresumableReason::ChallengeUnavailable),
+        'call_lapsed' => $this->store->ingest('call_lapsed', conversationId: 'c3', receiptId: 'receipt-call_lapsed', resumability: Resumability::Drivable),
+    ];
+    $challenges = ['call_drivable' => inboxChallenge('call_drivable'), 'call_unresumable' => null, 'call_lapsed' => null];
+
+    foreach ($challenges as $toolCallId => $challenge) {
+        $this->challenges->with($toolCallId, $challenge);
+    }
+
+    $rendered = inboxRows(renderInbox());
+    $contract = app(ApprovalSurfaceContract::class);
+
+    foreach ($rows as $toolCallId => $approval) {
+        $contract->assertRendered(renderedVerbs($rendered[$approval->id]), $approval, $challenges[$toolCallId]);
+    }
+
+    expect(count($rendered))->toBe(3);
+});
+
+/** ADR 0001 §5: four disclosure states plus the pre-capture era, never collapsed and never silent. */
+it('renders every provenance disclosure state distinctly', function (?ProposalProvenance $provenance, string $state, array $fragments): void {
+    $approval = $this->store->ingest('call_1', conversationId: 'c1', receiptId: 'receipt-call_1', resumability: Resumability::Drivable);
+    $this->challenges->with('call_1', inboxChallenge('call_1', $provenance));
+
+    $row = inboxRows(renderInbox())[$approval->id];
+
+    expect($row)->toContain('data-provenance="'.$state.'"');
+
+    foreach ($fragments as $fragment) {
+        expect($row)->toContain($fragment);
+    }
+})->with([
+    'declared with an untrusted external source' => [
+        ProposalProvenance::declared([
+            new UpstreamSource(Source::external('search'), Trust::Untrusted, DataClass::Public, ContextChannel::RetrievedDocument),
+            new UpstreamSource(Source::user('customer'), Trust::Trusted, DataClass::PII, ContextChannel::UserInput),
+        ]),
+        'declared',
+        ['data-source-warning="true"', 'data-source-warning="false"', 'external', 'search', 'untrusted', 'retrieved_document'],
+    ],
+    'declared with withheld and undescribed sources' => [
+        ProposalProvenance::declared([], undescribedSourceCount: 2, withheldSourceCount: 1),
+        'declared',
+        ['2 upstream sources undescribed', '1 upstream source withheld by release policy'],
+    ],
+    'unknown' => [ProposalProvenance::unknown(), 'unknown', ['provenance unknown — no derivation was declared']],
+    'unreleased' => [ProposalProvenance::unreleased(), 'unreleased', ['the application has not configured provenance release to approvers']],
+    'issued before capture' => [null, 'issued_before_provenance_capture', ['issued before provenance capture']],
+]);
+
+/** The reason is labelled as what it is, and expiry is the challenge's, never the stored presentation's. */
+it('labels the gating reason and shows live expiry from the challenge', function (): void {
+    $approval = $this->store->ingest('call_1', conversationId: 'c1', receiptId: 'receipt-call_1', presentation: [...inboxPresentation(), 'expires_at' => '1999-01-01T00:00:00+00:00'], resumability: Resumability::Drivable);
+    $this->challenges->with('call_1', inboxChallenge('call_1', expiresAt: '2030-01-02T03:04:05+00:00'));
+
+    $row = inboxRows(renderInbox())[$approval->id];
+
+    expect($row)->toContain('Why this capability is gated')
+        ->and($row)->toContain('Cancelling an order needs confirmation.')
+        ->and($row)->toContain('datetime="2030-01-02T03:04:05+00:00"')
+        ->and($row)->not->toContain('1999-01-01');
+});
+
+/** ADR 0001 §5's last bullet: the affordances that manufacture fatigue are not shipped. */
+it('ships no default-selected verb, no autofocus, and no bulk control', function (): void {
+    VerdictConsoleRoutes::register();
+    $this->store->ingest('call_1', conversationId: 'c1', receiptId: 'receipt-call_1', resumability: Resumability::Drivable);
+    $this->store->ingest('call_2', conversationId: 'c2', receiptId: 'receipt-call_2', resumability: Resumability::Drivable);
+    $this->challenges->with('call_1', inboxChallenge('call_1'))->with('call_2', inboxChallenge('call_2'));
+
+    $html = renderInbox();
+
+    expect($html)->not->toContain('autofocus')
+        ->and($html)->not->toContain('type="checkbox"')
+        ->and($html)->not->toContain('<select')
+        ->and(substr_count($html, 'data-verb="approve"'))->toBe(2, 'One approve control per row; nothing acts on more than one row.');
+});
+
+it('renders nothing for a row outside the host scope, not even a disabled one', function (): void {
+    $visible = $this->store->ingest('call_visible', conversationId: 'tenant-a', receiptId: 'receipt-call_visible', resumability: Resumability::Drivable);
+    $hidden = $this->store->ingest('call_hidden', conversationId: 'tenant-b', receiptId: 'receipt-call_hidden', resumability: Resumability::Drivable);
+    $this->challenges->with('call_visible', inboxChallenge('call_visible'))->with('call_hidden', inboxChallenge('call_hidden'));
+    app()->instance(ApprovalScope::class, new InboxConversationScope('tenant-a'));
+
+    $html = renderInbox();
+
+    expect(array_keys(inboxRows($html)))->toBe([$visible->id])
+        ->and($html)->not->toContain($hidden->id)
+        ->and($html)->not->toContain('call_hidden')
+        // Scope is applied to the query, not to the output: a hidden row is never read from Verdict.
+        ->and($this->challenges->reads)->toBe(['call_visible']);
+});
+
+it('says when nothing is waiting instead of rendering an empty list', function (): void {
+    $html = renderInbox();
+
+    expect($html)->toContain('data-verdict-console="approvals"')
+        ->and($html)->toContain('No approvals are waiting.')
+        ->and(inboxRows($html))->toBe([]);
+});
+
+/**
+ * Route mounting is optional (the host's decision, never auto-registered). Until the host mounts
+ * the routes, the widget still renders every row honestly but posts nowhere: no form whose action
+ * would be a guess, and a visible statement of why the controls are absent.
+ */
+it('renders rows without forms and says so while the console routes are not mounted', function (): void {
+    $approval = $this->store->ingest('call_1', conversationId: 'c1', receiptId: 'receipt-call_1', resumability: Resumability::Drivable);
+    $this->challenges->with('call_1', inboxChallenge('call_1'));
+
+    expect(Route::has('verdict-console.approvals.approve'))->toBeFalse('Nothing mounts routes by default.');
+
+    $html = renderInbox();
+    $row = inboxRows($html)[$approval->id];
+
+    expect($html)->toContain('data-routes="unmounted"')
+        ->and($row)->not->toContain('<form')
+        ->and($row)->toContain('console routes are not registered')
+        ->and(rowAttribute($row, 'data-state'))->toBe('pending');
+
+    VerdictConsoleRoutes::register();
+
+    $mounted = inboxRows(renderInbox())[$approval->id];
+
+    expect(renderInbox())->toContain('data-routes="mounted"')
+        ->and($mounted)->toContain('action="'.route('verdict-console.approvals.approve', $approval->id).'"')
+        ->and($mounted)->toContain('action="'.route('verdict-console.approvals.reject', $approval->id).'"')
+        ->and($mounted)->toContain('method="post"')
+        ->and($mounted)->toContain('_token');
+});
+
+/** The persisted presentation is shown as a summary; nothing here reaches for raw arguments. */
+it('shows the presentation summary and the host details, never raw arguments', function (): void {
+    $approval = $this->store->ingest('call_1', conversationId: 'c1', receiptId: 'receipt-call_1', presentation: inboxPresentation(), resumability: Resumability::Drivable);
+    $this->challenges->with('call_1', inboxChallenge('call_1'));
+
+    $row = inboxRows(renderInbox())[$approval->id];
+
+    expect($row)->toContain('CancelOrderTool')
+        ->and($row)->toContain('sha256:'.str_repeat('a', 64))
+        ->and($row)->toContain('#1001');
+});
+
+it('renders a row whose presentation could not be captured without failing the whole widget', function (): void {
+    $approval = $this->store->ingest('call_1', conversationId: 'c1', receiptId: 'receipt-call_1', presentation: null, resumability: Resumability::Drivable);
+    $this->challenges->with('call_1', inboxChallenge('call_1'));
+
+    $row = inboxRows(renderInbox())[$approval->id];
+
+    expect(rowAttribute($row, 'data-state'))->toBe('pending')
+        ->and($row)->toContain('orders.cancel');
+});
+
+it('is a class-based component registered under the verdict-console namespace', function (): void {
+    expect(class_exists(Approvals::class))->toBeTrue()
+        ->and(PendingApproval::query()->count())->toBe(0)
+        ->and(renderInbox())->toContain('data-verdict-console="approvals"');
+});

--- a/tests/Feature/ApprovalInboxComponentTest.php
+++ b/tests/Feature/ApprovalInboxComponentTest.php
@@ -20,6 +20,7 @@ use Fissible\VerdictConsole\Contracts\ApprovalScope;
 use Fissible\VerdictConsole\Http\VerdictConsoleRoutes;
 use Fissible\VerdictConsole\View\Components\Approvals;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Schema;
 
@@ -206,9 +207,15 @@ it('renders drivable, not-console-actionable, and expired-or-already-decided row
  */
 it('matches the snapshot of the three-state matrix', function (): void {
     VerdictConsoleRoutes::register();
+    // Distinct ingestion instants: the inbox lists newest first, and three rows ingested within one
+    // second would otherwise tie and fall back to their random ids.
+    Carbon::setTestNow('2026-08-30 10:00:00');
     $drivable = $this->store->ingest('call_drivable', conversationId: 'c1', receiptId: 'receipt-call_drivable', presentation: inboxPresentation(), resumability: Resumability::Drivable);
+    Carbon::setTestNow('2026-08-30 10:00:01');
     $unresumable = $this->store->ingest('call_unresumable', conversationId: 'c2', receiptId: 'receipt-call_unresumable', presentation: inboxPresentation('RefundTool'), resumability: Resumability::Unresumable, unresumableReason: UnresumableReason::AgentUnresolvable);
+    Carbon::setTestNow('2026-08-30 10:00:02');
     $lapsed = $this->store->ingest('call_lapsed', conversationId: 'c3', receiptId: 'receipt-call_lapsed', presentation: inboxPresentation('CloseAccountTool'), resumability: Resumability::Drivable);
+    Carbon::setTestNow();
     $this->challenges
         ->with('call_drivable', inboxChallenge('call_drivable', ProposalProvenance::declared([
             new UpstreamSource(Source::external('search'), Trust::Untrusted, DataClass::Public, ContextChannel::RetrievedDocument),

--- a/tests/Feature/ConsoleRoutesTest.php
+++ b/tests/Feature/ConsoleRoutesTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\VerdictConsole\Http\VerdictConsoleRoutes;
+use Fissible\VerdictConsole\VerdictConsoleServiceProvider;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Route;
+
+const CONSOLE_ROUTE_NAMES = ['verdict-console.approvals.approve', 'verdict-console.approvals.reject', 'verdict-console.approvals.close'];
+
+/**
+ * Mounting the console's routes is the host's decision. Nothing registers them behind the host's
+ * back: not the provider by default, and not a command without asking.
+ */
+it('registers no routes by default', function (): void {
+    foreach (CONSOLE_ROUTE_NAMES as $name) {
+        expect(Route::has($name))->toBeFalse($name.' must not exist until the host mounts the console routes.');
+    }
+
+    expect(config('verdict-console.routes.register'))->toBeFalse()
+        ->and(config('verdict-console.routes.prefix'))->toBe('verdict-console')
+        ->and(config('verdict-console.routes.middleware'))->toBe(['web']);
+});
+
+it('mounts the three approval routes under the configured prefix and middleware when asked explicitly', function (): void {
+    VerdictConsoleRoutes::register();
+
+    foreach (CONSOLE_ROUTE_NAMES as $name) {
+        expect(Route::has($name))->toBeTrue($name.' must be mounted.');
+    }
+
+    foreach (['approve', 'reject', 'close'] as $verb) {
+        $route = Route::getRoutes()->getByName('verdict-console.approvals.'.$verb);
+
+        expect($route->methods())->toBe(['POST'])
+            ->and($route->uri())->toBe('verdict-console/approvals/{approval}/'.$verb)
+            ->and($route->gatherMiddleware())->toContain('web');
+    }
+});
+
+it('honours a host prefix and middleware, from arguments or from config', function (): void {
+    VerdictConsoleRoutes::register(prefix: 'ops/verdict', middleware: ['api', 'auth:sanctum']);
+
+    $reject = Route::getRoutes()->getByName('verdict-console.approvals.reject');
+
+    expect($reject->uri())->toBe('ops/verdict/approvals/{approval}/reject')
+        ->and($reject->gatherMiddleware())->toContain('auth:sanctum')
+        ->and($reject->gatherMiddleware())->not->toContain('web');
+});
+
+/**
+ * The config switch is the same mount, taken at boot: a host that sets it gets the routes without
+ * writing a line in its routes file. It is off in the shipped config so an install can never
+ * expose an action endpoint the host did not choose.
+ */
+it('mounts the routes at boot only when the config switch is on', function (): void {
+    config()->set('verdict-console.routes.register', true);
+    config()->set('verdict-console.routes.prefix', 'console');
+    config()->set('verdict-console.routes.middleware', ['api']);
+
+    app()->register(VerdictConsoleServiceProvider::class, force: true);
+
+    $close = Route::getRoutes()->getByName('verdict-console.approvals.close');
+
+    expect(Route::has('verdict-console.approvals.close'))->toBeTrue()
+        ->and($close->uri())->toBe('console/approvals/{approval}/close')
+        ->and($close->gatherMiddleware())->toContain('api')
+        ->and($close->gatherMiddleware())->not->toContain('web');
+});
+
+it('publishes the views under their own tag, into the vendor views directory', function (): void {
+    $target = resource_path('views/vendor/verdict-console');
+
+    File::exists($target) && File::deleteDirectory($target);
+
+    $this->artisan('vendor:publish', ['--tag' => 'verdict-console-views', '--force' => true])->assertSuccessful();
+
+    expect(File::exists($target.'/components/approvals.blade.php'))->toBeTrue();
+
+    File::deleteDirectory($target);
+});
+
+/** A Blade component and routes need the view and routing packages; the manifest must say so. */
+it('declares the view and routing packages the widget needs', function (): void {
+    $require = json_decode((string) file_get_contents(dirname(__DIR__, 2).'/composer.json'), true)['require'];
+
+    expect($require)->toHaveKeys(['illuminate/view', 'illuminate/routing']);
+});

--- a/tests/Feature/DocumentationCorrectionsTest.php
+++ b/tests/Feature/DocumentationCorrectionsTest.php
@@ -101,6 +101,17 @@ it('names the chat-entry contract in the design of record', function (): void {
         ->toContain('`verdict-console.chat.entry_key`');
 });
 
+/**
+ * Route mounting is the host's decision. The design must name the mount helper and the config
+ * switch, and must carry the rule for any future command: it asks before registering routes.
+ */
+it('records that console routes are opt-in and that commands must ask before mounting them', function (): void {
+    expect(documentation('docs/design/0001-verdict-console-design.md'))
+        ->toContain('`VerdictConsoleRoutes`')
+        ->toContain('`verdict-console.routes.register`')
+        ->toContain('must ask before registering routes');
+});
+
 /** Folded in from the VC-13 review: the UTC reading is a contract from verdict#335 onward, not a hope. */
 it('cites the Verdict change that makes the evidence timestamp reading a UTC contract', function (): void {
     expect(documentation('src/Evidence/DatabaseEvidenceQuery.php'))->toContain('fissible/verdict#335');


### PR DESCRIPTION
## Summary

The first Blade surface: `<x-verdict-console::approvals />`, server-rendered, form-post, no build step, publishable views (`verdict-console-views`).

- **Three row states, told apart by what they offer** (data-attribute contract `data-state`): `pending` → exactly the verbs VC-41's resolver returns (approve + reject), `expired_or_already_decided` → only the non-authorizing `close`, and `not_console_actionable` (row not drivable) → no control at all, with the recorded reason. The verb set is pinned against `ApprovalSurfaceContract` per row, as the issue comment requires.
- **ADR 0001 §5 rendered live from the challenge**: expiry via `<time datetime>`, the gating reason labelled "Why this capability is gated", and provenance in its four disclosure states plus the pre-capture era — sources listed with a warning flag for non-user untrusted upstream content, withheld/undescribed counts shown as counts, `Unknown` never silent. No default-selected verb, no autofocus, no bulk control.
- **Routes are opt-in — the host's decision, per your direction.** Nothing registers them by default. `VerdictConsoleRoutes::register(prefix?, middleware?)` or `verdict-console.routes.register` mounts three POST endpoints (`{prefix}/approvals/{approval}/{approve|reject|close}`, default middleware `['web']`). Unmounted, the widget still renders every row honestly and posts nowhere, with `data-routes="unmounted"` and a visible note. The design of record now states that **any future install or setup command must ask before registering routes**; no such command is added here.
- **Form-posts relay to VC-6** behind the host's Gate: 404 for an unknown *or scoped-out* row before any authority check (VC-12 anti-enumeration), 403 on refusal (including unauthenticated), flashed `verdict-console.status` (`approved` / `rejected` / `not_actionable` / the `CloseOutcome` value) on redirect-back, root fallback without a referer.
- `ApprovalItem` gains `resumability` / `unresumableReason` (additive); `PendingApprovalStore` gains scoped `visible()` / `findVisible()` — the only scoped reads, because they serve an operator.
- New composer requirements: `illuminate/view`, `illuminate/routing`.

## Linked issue

Closes #19

## Trust and failure behavior

- Untrusted input: the route's `{approval}` id and the POST itself. The id is resolved only through the host-scoped store; a hidden row is indistinguishable from a missing one and never reaches the Gate.
- No authority lives in the widget or the controller: `ApprovalResolutionService` (VC-6) authorizes every verb; a forged POST to approve/reject on a lapsed receipt decides nothing, executes nothing, resumes nothing (tested), and the close verb never mutates the receipt.
- Fail-closed while unmounted: no forms, no guessed action URLs.
- Measured against Laravel AI rather than assumed: a bare rejection ends the turn with no second model call (`TextGenerationLoop::resumeFromApproval` → `shouldContinue = false`), so reject and close send exactly one request.

## Evidence and data handling

- The widget shows the persisted presentation (tool, capability, argument fingerprint, host `details`) and the live challenge (reason, expiry, provenance disclosure). Raw arguments never reach the view; every value is Blade-escaped.

## Verification

- [x] Success, denial, and relevant failure paths are tested.
- [x] Security containment and legitimate utility are both covered where applicable.
- [x] Documentation and `CHANGELOG.md` are updated.
- [x] `composer test` passes locally — phpstan clean, pint passed, type coverage 100%, **308 passed (1566 assertions)**.
- [x] No credentials, real customer data, or unredacted evidence are included.

HTTP + snapshot tested as the issue asks: an end-to-end suite posts approve (executes once, receipt `consumed`), reject (executes zero, `rejected_by` recorded), Gate-denied approve/close (403, nothing spent), scoped-out and unknown rows (404 before Gate), a lapsed receipt's close (`closed`, receipt untouched) and forged approve/reject against it (`not_actionable`); a normalized snapshot of the three-state matrix is committed as the widget's regression baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
