### PR TITLE
feat: mount the console routes at boot by default, with Laravel's opt-outs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ All notable changes to Verdict Console will be documented in this file.
 
 - **Blade approval inbox widget (VC-19).** `<x-verdict-console::approvals />` renders the ADR 0001
   verb and provenance contract in its pending, expired-or-already-decided, and
-  not-console-actionable states, and form-posts each offered verb through VC-6. Routes remain
-  opt-in through `VerdictConsoleRoutes` and `verdict-console.routes.register`; unmounted widgets
-  explain that actions are unavailable. Views are publishable, and the package now requires
-  `illuminate/view` and `illuminate/routing`.
+  not-console-actionable states, and form-posts each offered verb through VC-6. Routes mount at
+  boot by default, with opt-out through `VerdictConsoleRoutes::ignoreRoutes()` or
+  `verdict-console.routes.register`; the boot mount is guarded under route:cache and the helper is
+  idempotent. Unmounted rendering is retained for opted-out hosts. Views are publishable, and the
+  package now requires `illuminate/view` and `illuminate/routing`.
 
 - **Host chat-entry contract (VC-18).** `ChatEntry` lets a host name the participant and a
   resumable-agent key — a key rather than an agent instance, so VC-2 can rebuild a chat after a

--- a/config/verdict-console.php
+++ b/config/verdict-console.php
@@ -36,11 +36,12 @@ return [
     |--------------------------------------------------------------------------
     | Approval routes
     |--------------------------------------------------------------------------
-    | Mounting is the host's decision. The shipped default exposes no action
-    | endpoint; a host may opt in here or call VerdictConsoleRoutes directly.
+    | Routes mount by default: every endpoint is fail-closed behind the host's
+    | Gate. Hosts may opt out with VerdictConsoleRoutes::ignoreRoutes() or by
+    | setting this register switch false, then mount their own route shape.
     */
     'routes' => [
-        'register' => false,
+        'register' => true,
         'prefix' => 'verdict-console',
         'middleware' => ['web'],
     ],

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -350,9 +350,13 @@ free.
 
 - **Blade (embed):** `<x-verdict-console::approvals />`, server-rendered, form-post, no build step.
   The approval-inbox widget renders ADR 0001's state, verb, and provenance contract from its live
-  read model; `VerdictConsoleRoutes` mounts its forms only when the host opts in through
-  `verdict-console.routes.register`. Routes are opt-in, and any future install or setup command
-  must ask before registering routes. Until then the widget renders its rows without forms.
+  read model; `VerdictConsoleRoutes` mounts its forms at boot by default because
+  every endpoint is fail-closed behind the host's Gate.
+  A host opts out with `VerdictConsoleRoutes::ignoreRoutes()`
+  or `verdict-console.routes.register`; an opted-out widget renders its rows without forms, and any
+  future install or setup command must ask whether to mount the console routes. The package follows
+  the first-party convention here despite publishing (not loading) its migrations: mounting exposes
+  nothing an unauthorized caller can use, whereas a migration changes the host's schema.
   Approval widget + paginated audit page + basic (non-streaming) chat thread. Publishable views.
   Chat surfaces start and continue conversations through the host's `ChatEntry` contract (participant
   plus resumable-agent key, `verdict-console.chat.entry_key`), check ownership against Laravel AI's

--- a/src/Http/VerdictConsoleRoutes.php
+++ b/src/Http/VerdictConsoleRoutes.php
@@ -8,14 +8,21 @@ use Fissible\VerdictConsole\Http\Controllers\ApprovalActionController;
 use Illuminate\Support\Facades\Route;
 
 /**
- * Opt-in route helper for the Blade approval inbox's single-row action forms.
+ * Route helper for the Blade approval inbox's single-row action forms.
  *
- * Mounting is opt-in and the host's decision: this package registers no routes unless the host calls this helper
- * or sets the verdict-console.routes.register configuration. Any future install or setup command must ask the user
- * before registering these routes.
+ * Routes mount at boot by default because every endpoint is fail-closed behind the host's Gate, following the
+ * Horizon/Telescope convention. A host opts out with ignoreRoutes() or verdict-console.routes.register, then may
+ * call register() with its own prefix and middleware. Any future install or setup command must ask whether to mount.
  */
-final readonly class VerdictConsoleRoutes
+final class VerdictConsoleRoutes
 {
+    public static bool $registersRoutes = true;
+
+    public static function ignoreRoutes(): void
+    {
+        self::$registersRoutes = false;
+    }
+
     /**
      * Register the console's action endpoints using host-supplied or configured mount settings.
      *
@@ -23,6 +30,12 @@ final readonly class VerdictConsoleRoutes
      */
     public static function register(?string $prefix = null, ?array $middleware = null): void
     {
+        if (Route::has('verdict-console.approvals.approve')
+            || Route::has('verdict-console.approvals.reject')
+            || Route::has('verdict-console.approvals.close')) {
+            return;
+        }
+
         Route::middleware($middleware ?? config('verdict-console.routes.middleware'))
             ->prefix($prefix ?? config('verdict-console.routes.prefix'))
             ->group(function (): void {

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -103,7 +103,10 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'verdict-console');
         Blade::componentNamespace('Fissible\\VerdictConsole\\View\\Components', 'verdict-console');
 
-        if (config('verdict-console.routes.register')) {
+        // route:cache already holds the mounted routes, so boot must not register replacements.
+        if (VerdictConsoleRoutes::$registersRoutes
+            && config('verdict-console.routes.register', true)
+            && ! $this->app->routesAreCached()) {
             VerdictConsoleRoutes::register();
         }
 

--- a/tests/EndToEnd/ApprovalInboxHttpTest.php
+++ b/tests/EndToEnd/ApprovalInboxHttpTest.php
@@ -16,7 +16,6 @@ use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
 use Fissible\VerdictConsole\Approvals\PendingApproval as StoredPendingApproval;
 use Fissible\VerdictConsole\Contracts\ApprovalScope;
 use Fissible\VerdictConsole\Contracts\ResumableAgents;
-use Fissible\VerdictConsole\Http\VerdictConsoleRoutes;
 use Fissible\VerdictConsole\Tests\EndToEndTestCase;
 use Illuminate\Auth\GenericUser;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
@@ -27,6 +26,7 @@ use Illuminate\JsonSchema\Types\Type;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Route;
 use Laravel\Ai\Concerns\RemembersConversations as RemembersConversationsTrait;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasMiddleware;
@@ -178,9 +178,9 @@ beforeEach(function (): void {
     // a fixed test-only key keeps the suite hermetic and deterministic.
     config()->set('app.key', 'base64:'.base64_encode(str_repeat('k', 32)));
 
-    // The host mounts the routes; the browser-shaped requests below carry no CSRF token. Both
+    // The routes mounted at boot. The browser-shaped requests below carry no CSRF token; both
     // framework names are bypassed so the suite holds across the Laravel versions in the matrix.
-    VerdictConsoleRoutes::register();
+    expect(Route::has('verdict-console.approvals.approve'))->toBeTrue('The routes mount at boot by default.');
     $this->withoutMiddleware([PreventRequestForgery::class, ValidateCsrfToken::class]);
 });
 

--- a/tests/Feature/ApprovalInboxComponentTest.php
+++ b/tests/Feature/ApprovalInboxComponentTest.php
@@ -20,6 +20,7 @@ use Fissible\VerdictConsole\Contracts\ApprovalScope;
 use Fissible\VerdictConsole\Http\VerdictConsoleRoutes;
 use Fissible\VerdictConsole\View\Components\Approvals;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Routing\RouteCollection;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Schema;
@@ -160,6 +161,7 @@ beforeEach(function (): void {
 
 afterEach(function (): void {
     Schema::dropIfExists('verdict_console_pending_approvals');
+    VerdictConsoleRoutes::$registersRoutes = true;
 });
 
 /** The three rows the issue names, and only those, each told apart by its state attribute. */
@@ -336,15 +338,20 @@ it('says when nothing is waiting instead of rendering an empty list', function (
 });
 
 /**
- * Route mounting is optional (the host's decision, never auto-registered). Until the host mounts
- * the routes, the widget still renders every row honestly but posts nowhere: no form whose action
- * would be a guess, and a visible statement of why the controls are absent.
+ * Routes mount at boot by default, and a host may opt out (`VerdictConsoleRoutes::ignoreRoutes()`
+ * or the config switch). For a host that did, the widget still renders every row honestly but
+ * posts nowhere: no form whose action would be a guess, and a visible statement of why the
+ * controls are absent.
  */
-it('renders rows without forms and says so while the console routes are not mounted', function (): void {
+it('renders rows without forms and says so for a host that opted out of the console routes', function (): void {
     $approval = $this->store->ingest('call_1', conversationId: 'c1', receiptId: 'receipt-call_1', resumability: Resumability::Drivable);
     $this->challenges->with('call_1', inboxChallenge('call_1'));
 
-    expect(Route::has('verdict-console.approvals.approve'))->toBeFalse('Nothing mounts routes by default.');
+    expect(Route::has('verdict-console.approvals.approve'))->toBeTrue('The routes mount at boot by default.');
+
+    // The opted-out host: it ignored the routes, so nothing of the console's is in the router.
+    VerdictConsoleRoutes::ignoreRoutes();
+    Route::setRoutes(new RouteCollection);
 
     $html = renderInbox();
     $row = inboxRows($html)[$approval->id];

--- a/tests/Feature/ConsoleRoutesTest.php
+++ b/tests/Feature/ConsoleRoutesTest.php
@@ -132,13 +132,12 @@ it('registers the routes once, however many times mounting is requested', functi
  * what every first-party package guards against with `routesAreCached()`.
  */
 it('does not mount at boot when the application routes are cached', function (): void {
-    // Point the framework at an existing file as its route cache; the guard only checks existence.
-    // The answer is memoized as the `routes.cached` instance at boot, so it is forgotten first, and
-    // whatever the environment held before is put back afterwards.
-    $original = getenv('APP_ROUTES_CACHE');
+    // The framework memoizes its answer as the `routes.cached` container instance (testbench
+    // evaluates it at boot), and that instance is what the guard reads — so the fixture binds it
+    // directly. Pointing APP_ROUTES_CACHE at a file is not portable: Laravel treats only `/` and
+    // `\\` prefixes as absolute, so a Windows drive-letter path resolves under basePath() instead.
     $originallyCached = app()->routesAreCached();
-    putenv('APP_ROUTES_CACHE='.__FILE__);
-    app()->forgetInstance('routes.cached');
+    app()->instance('routes.cached', true);
 
     try {
         expect(app()->routesAreCached())->toBeTrue('Fixture: the framework must believe its routes are cached.');
@@ -147,7 +146,6 @@ it('does not mount at boot when the application routes are cached', function ():
 
         expect(consoleRouteNames())->toBe([]);
     } finally {
-        putenv($original === false ? 'APP_ROUTES_CACHE' : 'APP_ROUTES_CACHE='.$original);
         app()->forgetInstance('routes.cached');
         expect(app()->routesAreCached())->toBe($originallyCached);
     }

--- a/tests/Feature/ConsoleRoutesTest.php
+++ b/tests/Feature/ConsoleRoutesTest.php
@@ -4,42 +4,102 @@ declare(strict_types=1);
 
 use Fissible\VerdictConsole\Http\VerdictConsoleRoutes;
 use Fissible\VerdictConsole\VerdictConsoleServiceProvider;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Routing\RouteCollection;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
 
 const CONSOLE_ROUTE_NAMES = ['verdict-console.approvals.approve', 'verdict-console.approvals.reject', 'verdict-console.approvals.close'];
 
 /**
- * Mounting the console's routes is the host's decision. Nothing registers them behind the host's
- * back: not the provider by default, and not a command without asking.
+ * The Laravel first-party shape: routes mount at boot, safe because every endpoint is fail-closed
+ * behind the host's Gate, and a host opts OUT — `VerdictConsoleRoutes::ignoreRoutes()` (the
+ * Passport / Fortify / Sanctum idiom) or the config switch — rather than in.
  */
-it('registers no routes by default', function (): void {
-    foreach (CONSOLE_ROUTE_NAMES as $name) {
-        expect(Route::has($name))->toBeFalse($name.' must not exist until the host mounts the console routes.');
-    }
-
-    expect(config('verdict-console.routes.register'))->toBeFalse()
-        ->and(config('verdict-console.routes.prefix'))->toBe('verdict-console')
-        ->and(config('verdict-console.routes.middleware'))->toBe(['web']);
+afterEach(function (): void {
+    // The ignore flag is static, and Pest runs every file in one process.
+    VerdictConsoleRoutes::$registersRoutes = true;
 });
 
-it('mounts the three approval routes under the configured prefix and middleware when asked explicitly', function (): void {
-    VerdictConsoleRoutes::register();
+/**
+ * Simulate a boot on which nothing mounted: clear the router, then boot the provider again. The
+ * forced registration re-runs boot(), which would also re-register every listener on the live
+ * dispatcher — so boot() is handed a throwaway dispatcher and the real one is restored after.
+ */
+function rebootConsoleRoutes(): void
+{
+    Route::setRoutes(new RouteCollection);
 
-    foreach (CONSOLE_ROUTE_NAMES as $name) {
-        expect(Route::has($name))->toBeTrue($name.' must be mounted.');
+    $events = app('events');
+    app()->instance('events', new Dispatcher(app()));
+
+    try {
+        app()->register(VerdictConsoleServiceProvider::class, force: true);
+    } finally {
+        app()->instance('events', $events);
     }
+}
+
+/** @return list<string> every registered route name under the console's namespace, duplicates included */
+function consoleRouteNames(): array
+{
+    return array_values(array_filter(
+        array_map(fn ($route): ?string => $route->getName(), Route::getRoutes()->getRoutes()),
+        fn (?string $name): bool => $name !== null && str_starts_with($name, 'verdict-console.approvals.'),
+    ));
+}
+
+it('mounts the three approval routes at boot by default, under the configured prefix and middleware', function (): void {
+    expect(config('verdict-console.routes.register'))->toBeTrue()
+        ->and(config('verdict-console.routes.prefix'))->toBe('verdict-console')
+        ->and(config('verdict-console.routes.middleware'))->toBe(['web'])
+        ->and(VerdictConsoleRoutes::$registersRoutes)->toBeTrue();
 
     foreach (['approve', 'reject', 'close'] as $verb) {
         $route = Route::getRoutes()->getByName('verdict-console.approvals.'.$verb);
 
-        expect($route->methods())->toBe(['POST'])
+        expect($route)->not->toBeNull($verb.' must be mounted at boot.')
+            ->and($route->methods())->toBe(['POST'])
             ->and($route->uri())->toBe('verdict-console/approvals/{approval}/'.$verb)
             ->and($route->gatherMiddleware())->toContain('web');
     }
 });
 
-it('honours a host prefix and middleware, from arguments or from config', function (): void {
+it('does not mount when the host ignores the routes', function (): void {
+    VerdictConsoleRoutes::ignoreRoutes();
+
+    rebootConsoleRoutes();
+
+    expect(VerdictConsoleRoutes::$registersRoutes)->toBeFalse()
+        ->and(consoleRouteNames())->toBe([]);
+});
+
+it('does not mount when the config switch is off', function (): void {
+    config()->set('verdict-console.routes.register', false);
+
+    rebootConsoleRoutes();
+
+    expect(consoleRouteNames())->toBe([]);
+});
+
+it('honours a host prefix and middleware from config at boot', function (): void {
+    config()->set('verdict-console.routes.prefix', 'console');
+    config()->set('verdict-console.routes.middleware', ['api']);
+
+    rebootConsoleRoutes();
+
+    $close = Route::getRoutes()->getByName('verdict-console.approvals.close');
+
+    expect($close->uri())->toBe('console/approvals/{approval}/close')
+        ->and($close->gatherMiddleware())->toContain('api')
+        ->and($close->gatherMiddleware())->not->toContain('web');
+});
+
+/** The Passport pattern: ignore the default mount, then mount yourself where and how you like. */
+it('lets a host that ignored the default mount register its own prefix and middleware', function (): void {
+    VerdictConsoleRoutes::ignoreRoutes();
+    rebootConsoleRoutes();
+
     VerdictConsoleRoutes::register(prefix: 'ops/verdict', middleware: ['api', 'auth:sanctum']);
 
     $reject = Route::getRoutes()->getByName('verdict-console.approvals.reject');
@@ -50,23 +110,47 @@ it('honours a host prefix and middleware, from arguments or from config', functi
 });
 
 /**
- * The config switch is the same mount, taken at boot: a host that sets it gets the routes without
- * writing a line in its routes file. It is off in the shipped config so an install can never
- * expose an action endpoint the host did not choose.
+ * Mounting is idempotent: a host that calls the helper after the default mount gets the routes it
+ * already had. RouteCollection keys entries by method and URI, so a re-registration would replace
+ * the objects rather than duplicate them — object identity is the observable.
  */
-it('mounts the routes at boot only when the config switch is on', function (): void {
-    config()->set('verdict-console.routes.register', true);
-    config()->set('verdict-console.routes.prefix', 'console');
-    config()->set('verdict-console.routes.middleware', ['api']);
+it('registers the routes once, however many times mounting is requested', function (): void {
+    $mountedAtBoot = array_map(fn (string $name): object => Route::getRoutes()->getByName($name), CONSOLE_ROUTE_NAMES);
 
-    app()->register(VerdictConsoleServiceProvider::class, force: true);
+    VerdictConsoleRoutes::register();
+    VerdictConsoleRoutes::register();
 
-    $close = Route::getRoutes()->getByName('verdict-console.approvals.close');
+    foreach (CONSOLE_ROUTE_NAMES as $i => $name) {
+        expect(Route::getRoutes()->getByName($name))->toBe($mountedAtBoot[$i], $name.' must be the route mounted at boot, not a replacement.');
+    }
 
-    expect(Route::has('verdict-console.approvals.close'))->toBeTrue()
-        ->and($close->uri())->toBe('console/approvals/{approval}/close')
-        ->and($close->gatherMiddleware())->toContain('api')
-        ->and($close->gatherMiddleware())->not->toContain('web');
+    expect(consoleRouteNames())->toHaveCount(3);
+});
+
+/**
+ * Under `route:cache` the cached file already holds the routes; registering them again at boot is
+ * what every first-party package guards against with `routesAreCached()`.
+ */
+it('does not mount at boot when the application routes are cached', function (): void {
+    // Point the framework at an existing file as its route cache; the guard only checks existence.
+    // The answer is memoized as the `routes.cached` instance at boot, so it is forgotten first, and
+    // whatever the environment held before is put back afterwards.
+    $original = getenv('APP_ROUTES_CACHE');
+    $originallyCached = app()->routesAreCached();
+    putenv('APP_ROUTES_CACHE='.__FILE__);
+    app()->forgetInstance('routes.cached');
+
+    try {
+        expect(app()->routesAreCached())->toBeTrue('Fixture: the framework must believe its routes are cached.');
+
+        rebootConsoleRoutes();
+
+        expect(consoleRouteNames())->toBe([]);
+    } finally {
+        putenv($original === false ? 'APP_ROUTES_CACHE' : 'APP_ROUTES_CACHE='.$original);
+        app()->forgetInstance('routes.cached');
+        expect(app()->routesAreCached())->toBe($originallyCached);
+    }
 });
 
 it('publishes the views under their own tag, into the vendor views directory', function (): void {

--- a/tests/Feature/DocumentationCorrectionsTest.php
+++ b/tests/Feature/DocumentationCorrectionsTest.php
@@ -102,14 +102,18 @@ it('names the chat-entry contract in the design of record', function (): void {
 });
 
 /**
- * Route mounting is the host's decision. The design must name the mount helper and the config
- * switch, and must carry the rule for any future command: it asks before registering routes.
+ * The routes follow Laravel's first-party shape — mounted at boot, opt-out — and the design must
+ * say so, name both opt-outs, give the reason it is safe (every endpoint is fail-closed behind the
+ * host's Gate), and carry the rule for any future install command: it asks whether to mount.
  */
-it('records that console routes are opt-in and that commands must ask before mounting them', function (): void {
+it('records that console routes mount by default with an opt-out, and that an install command must ask', function (): void {
     expect(documentation('docs/design/0001-verdict-console-design.md'))
-        ->toContain('`VerdictConsoleRoutes`')
+        ->toContain('`VerdictConsoleRoutes::ignoreRoutes()`')
         ->toContain('`verdict-console.routes.register`')
-        ->toContain('must ask before registering routes');
+        ->toContain('every endpoint is fail-closed behind the host\'s Gate')
+        ->toContain('must ask whether to mount the console routes')
+        ->not->toContain('must ask before registering routes')
+        ->not->toContain('Routes are opt-in');
 });
 
 /** Folded in from the VC-13 review: the UTC reading is a contract from verdict#335 onward, not a hope. */


### PR DESCRIPTION
## Summary

Adopts Laravel's first-party shape for the console's approval routes, reversing the opt-in default that merged in #81 an hour earlier (unreleased, so the CHANGELOG bullet is amended in place rather than layered).

- **Routes mount at boot by default** — the shape Horizon, Telescope, Fortify, Sanctum, and (since v11) Passport converged on. Safe for the same reason those packages give: **every endpoint is fail-closed behind the host's Gate** (`GateApproverAuthority` denies until the ability is defined; unauthenticated → 403; scoped-out row → 404 before the Gate), so mounting exposes nothing an unauthorized caller can use.
- **Two opt-outs**: `VerdictConsoleRoutes::ignoreRoutes()` (the `$registersRoutes` static idiom) and `verdict-console.routes.register` (now shipped `true`). An opted-out host may call `VerdictConsoleRoutes::register(prefix, middleware)` itself.
- **`routesAreCached()` guard** on the boot mount — the edge the original helper lacked — and an **idempotent** `register()` (a later call returns the routes mounted at boot, not replacements; asserted by object identity).
- The widget's unmounted rendering is retained for opted-out hosts.
- Design §8 states the rationale and why the package follows the first-party convention here despite publishing (not loading) its migrations; the install-command rule is reframed as **"must ask whether to mount the console routes"**.

## Linked issue

Follow-up to #19 / #81 (design decision, no issue).

## Trust and failure behavior

- Nothing changes in authority or the controller. The only new behaviour is *when* routes exist; authorization is unchanged and fail-closed.
- Tests prove: default mount with method/URI/middleware; no mount when ignored, when the config switch is off, or when routes are cached (fixture makes `routesAreCached()` true and restores the prior environment); config prefix/middleware honoured at boot; an opted-out host's own mount; idempotency by object identity; the opted-out widget renders forms-free and says why. The provider re-boot fixture hands `boot()` a throwaway dispatcher so listeners are not re-registered on the live one.

## Evidence and data handling

No change.

## Verification

- [x] Success, denial, and relevant failure paths are tested.
- [x] Security containment and legitimate utility are both covered where applicable.
- [x] Documentation and `CHANGELOG.md` are updated.
- [x] `composer test` passes locally — phpstan clean, pint passed, type coverage 100%, **311 passed (1589 assertions)**.
- [x] No credentials, real customer data, or unredacted evidence are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
