### PR TITLE
feat: Blade chat thread with the approval interrupt inline (VC-21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Blade basic chat thread (VC-21).** `<x-verdict-console::chat />` posts through the new
+  `verdict-console.chat.send` route, renders an owned thread without streaming, and places its
+  conversation-scoped approval interrupt inline. Resolving that interrupt continues the thread on
+  reload; the approvals widget now accepts a `conversation` prop for this scoped read.
+
 - **Blade approval inbox widget (VC-19).** `<x-verdict-console::approvals />` renders the ADR 0001
   verb and provenance contract in its pending, expired-or-already-decided, and
   not-console-actionable states, and form-posts each offered verb through VC-6. Routes mount at

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -358,9 +358,14 @@ free.
   the first-party convention here despite publishing (not loading) its migrations: mounting exposes
   nothing an unauthorized caller can use, whereas a migration changes the host's schema.
   Approval widget + paginated audit page + basic (non-streaming) chat thread. Publishable views.
-  Chat surfaces start and continue conversations through the host's `ChatEntry` contract (participant
-  plus resumable-agent key, `verdict-console.chat.entry_key`), check ownership against Laravel AI's
-  recorded participant, and read the thread through the host's `ConversationStore`.
+  Chat surfaces start and continue conversations through the host's `ChatEntry` contract
+  (participant plus resumable-agent key, `verdict-console.chat.entry_key`), check ownership
+  against Laravel AI's recorded participant, and read the thread through the host's
+  `ConversationStore`.
+  `<x-verdict-console::chat />` posts messages to `verdict-console.chat.send`, then renders the
+  thread again on reload. Its approval interrupt is inline through the approvals widget scoped to
+  the conversation; resolution through VC-6's forms continues that thread on reload.
+  It does not stream: streaming is the Livewire surface's job.
 - **Livewire (end-user, flagship):** chat with **inline approval cards** (stream → card mid-thread →
   resolve in-flow → resume), live inbox, live decision feed. *Feed depends on §6.6/§6.7.*
 - **Filament (ops console, a plugin):** approval **queue** Resource; evidence **browser** Resource

--- a/resources/views/components/approvals.blade.php
+++ b/resources/views/components/approvals.blade.php
@@ -1,4 +1,4 @@
-<section data-verdict-console="approvals" data-routes="{{ $mounted ? 'mounted' : 'unmounted' }}">
+<section data-verdict-console="approvals"@if ($conversation !== null) data-conversation="{{ $conversation }}"@endif data-routes="{{ $mounted ? 'mounted' : 'unmounted' }}">
     @forelse ($items as $item)
         @php
             $state = $item->resumability !== 'drivable' ? 'not_console_actionable' : $item->state;
@@ -60,6 +60,8 @@
             @endif
         </article>
     @empty
-        <p data-empty>No approvals are waiting.</p>
+        @if ($conversation === null)
+            <p data-empty>No approvals are waiting.</p>
+        @endif
     @endforelse
 </section>

--- a/resources/views/components/chat.blade.php
+++ b/resources/views/components/chat.blade.php
@@ -1,0 +1,27 @@
+<section data-verdict-console="chat" data-conversation="{{ $conversation ?? '' }}" data-routes="{{ $mounted ? 'mounted' : 'unmounted' }}" data-streaming="false">
+    <ol data-messages>
+        @foreach ($thread?->messages ?? [] as $message)
+            @if (in_array($message->role, ['user', 'assistant'], true) && $message->content !== null && $message->content !== '')
+                <li data-role="{{ $message->role }}">{{ $message->content }}</li>
+            @endif
+        @endforeach
+    </ol>
+
+    @if ($hasInterrupt)
+        <div data-interrupt><x-verdict-console::approvals :conversation="$conversation" /></div>
+    @endif
+
+    @if ($mounted)
+        <form method="post" action="{{ route('verdict-console.chat.send') }}" data-chat-form>
+            @csrf
+            @if ($conversation !== null)
+                <input type="hidden" name="conversation" value="{{ $conversation }}">
+            @endif
+            <textarea name="prompt"></textarea><button type="submit">Send</button>
+        </form>
+    @else
+        <p data-actions-unavailable>Actions are unavailable: the console routes are not registered.</p>
+    @endif
+
+    <p data-limitation>This thread does not stream; it updates when the page reloads.</p>
+</section>

--- a/src/Approvals/ApprovalInbox.php
+++ b/src/Approvals/ApprovalInbox.php
@@ -17,4 +17,15 @@ final readonly class ApprovalInbox
     {
         return array_map($this->items->make(...), $this->pendingApprovals->visible());
     }
+
+    /**
+     * Read only the visible pauses for a thread, so a chat interrupt cannot disclose another
+     * conversation's work even when both belong to the same operator scope.
+     *
+     * @return list<ApprovalItem>
+     */
+    public function itemsForConversation(string $conversationId): array
+    {
+        return array_map($this->items->make(...), $this->pendingApprovals->visibleForConversation($conversationId));
+    }
 }

--- a/src/Approvals/PendingApprovalStore.php
+++ b/src/Approvals/PendingApprovalStore.php
@@ -183,6 +183,24 @@ final class PendingApprovalStore
     }
 
     /**
+     * List one conversation's approvals inside the host's visibility boundary, newest first.
+     *
+     * The conversation predicate belongs in the query rather than a post-read filter: a thread
+     * must neither render nor ask Verdict to resolve rows belonging to another conversation.
+     *
+     * @return list<PendingApproval>
+     */
+    public function visibleForConversation(string $conversationId): array
+    {
+        return array_values($this->scope->apply(PendingApproval::query())
+            ->where('conversation_id', $conversationId)
+            ->orderByDesc('created_at')
+            ->orderBy('id')
+            ->get()
+            ->all());
+    }
+
+    /**
      * Record that a resume attempt is beginning, and say which attempt it is.
      *
      * **Locked rather than incremented-then-read.** `increment()` followed by a separate `value()`

--- a/src/Http/Controllers/ChatController.php
+++ b/src/Http/Controllers/ChatController.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Http\Controllers;
+
+use Fissible\VerdictConsole\Chat\ChatService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/** Relays a non-streaming thread form post to the host-owned chat service. */
+final readonly class ChatController
+{
+    public function __construct(private ChatService $chat) {}
+
+    public function send(Request $request): RedirectResponse
+    {
+        abort_if($request->user() === null, 403);
+
+        $validated = $request->validate([
+            'prompt' => [
+                'required',
+                'string',
+                static function (string $attribute, mixed $value, \Closure $fail): void {
+                    if (trim((string) $value) === '') {
+                        $fail('The '.$attribute.' field must not be blank.');
+                    }
+                },
+            ],
+            'conversation' => ['nullable', 'string'],
+        ]);
+
+        $turn = array_key_exists('conversation', $validated) && $validated['conversation'] !== null
+            ? $this->chat->continue($request->user(), $validated['conversation'], $validated['prompt'])
+            : $this->chat->start($request->user(), $validated['prompt']);
+
+        return redirect()->back()
+            ->with('verdict-console.chat.conversation', $turn->conversationId)
+            ->with('verdict-console.status', $turn->paused ? 'paused' : 'sent');
+    }
+}

--- a/src/Http/VerdictConsoleRoutes.php
+++ b/src/Http/VerdictConsoleRoutes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fissible\VerdictConsole\Http;
 
 use Fissible\VerdictConsole\Http\Controllers\ApprovalActionController;
+use Fissible\VerdictConsole\Http\Controllers\ChatController;
 use Illuminate\Support\Facades\Route;
 
 /**
@@ -45,6 +46,8 @@ final class VerdictConsoleRoutes
                     ->post('approvals/{approval}/reject', [ApprovalActionController::class, 'reject']);
                 Route::name('verdict-console.approvals.close')
                     ->post('approvals/{approval}/close', [ApprovalActionController::class, 'close']);
+                Route::name('verdict-console.chat.send')
+                    ->post('chat', [ChatController::class, 'send']);
             });
     }
 }

--- a/src/View/Components/Approvals.php
+++ b/src/View/Components/Approvals.php
@@ -12,12 +12,15 @@ use Illuminate\View\Component;
 /** Server-rendered inbox for the approvals currently visible to the host operator. */
 final class Approvals extends Component
 {
-    public function __construct(private ApprovalInbox $inbox) {}
+    public function __construct(private ApprovalInbox $inbox, private ?string $conversation = null) {}
 
     public function render(): View
     {
         return view('verdict-console::components.approvals', [
-            'items' => $this->inbox->items(),
+            'conversation' => $this->conversation,
+            'items' => $this->conversation === null
+                ? $this->inbox->items()
+                : $this->inbox->itemsForConversation($this->conversation),
             'mounted' => Route::has('verdict-console.approvals.approve'),
             'routes' => [
                 'approve' => 'verdict-console.approvals.approve',

--- a/src/View/Components/Chat.php
+++ b/src/View/Components/Chat.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\View\Components;
+
+use Fissible\VerdictConsole\Approvals\ApprovalInbox;
+use Fissible\VerdictConsole\Chat\ChatService;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Route;
+use Illuminate\View\Component;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * Server-rendered, reload-driven chat thread with a scoped approval interrupt.
+ *
+ * Refusals are HttpExceptions rather than AuthorizationExceptions because Blade wraps the latter
+ * in a ViewException, which a host exception handler would otherwise render as a 500.
+ */
+final class Chat extends Component
+{
+    private const string AUTHORIZATION_REFUSAL_MESSAGE = 'This participant may not use this conversation.';
+
+    public function __construct(
+        private ChatService $chat,
+        private ApprovalInbox $inbox,
+        private Guard $auth,
+        private ?string $conversation = null,
+    ) {}
+
+    public function render(): View
+    {
+        $conversation = $this->conversation ?? session('verdict-console.chat.conversation');
+        $thread = null;
+        $hasInterrupt = false;
+
+        if ($conversation !== null) {
+            $user = $this->auth->user();
+
+            if ($user === null) {
+                throw new AccessDeniedHttpException(self::AUTHORIZATION_REFUSAL_MESSAGE);
+            }
+
+            // ChatService owns the indistinguishable foreign/unknown refusal; do not turn it into
+            // an empty thread, which would leak a different result to an unauthorized reader.
+            try {
+                $thread = $this->chat->thread($user, $conversation);
+            } catch (AuthorizationException) {
+                throw new AccessDeniedHttpException(self::AUTHORIZATION_REFUSAL_MESSAGE);
+            }
+            // An indexed row survives a decision for audit/expiry rendering, but it no longer
+            // interrupts the thread once Verdict's live read says it is not pending. A lapsed
+            // receipt whose thread remains paused no longer interrupts it: its close verb is in
+            // the inbox widget, while an inline close remains a possible follow-up.
+            foreach ($this->inbox->itemsForConversation($conversation) as $item) {
+                if ($item->state === 'pending') {
+                    $hasInterrupt = true;
+
+                    break;
+                }
+            }
+        }
+
+        return view('verdict-console::components.chat', [
+            'conversation' => $conversation,
+            'hasInterrupt' => $hasInterrupt,
+            'mounted' => Route::has('verdict-console.chat.send'),
+            'thread' => $thread,
+        ]);
+    }
+}

--- a/tests/EndToEnd/ChatThreadTest.php
+++ b/tests/EndToEnd/ChatThreadTest.php
@@ -37,6 +37,7 @@ use Laravel\Ai\Contracts\RemembersConversations as RemembersConversationsContrac
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Promptable;
 use Laravel\Ai\Tools\Request;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
  * The non-streaming Blade thread: post a message, reload, see the reply — and when the reply is a
@@ -358,7 +359,13 @@ it('escapes message content instead of rendering it as markup', function (): voi
  * its place, through the same widget the inbox uses, offering exactly the verbs VC-41 resolves.
  */
 it('shows the approval interrupt inline when a message triggers a confirmation', function (): void {
-    Http::fake(['*/chat/completions' => Http::response($this->toolCallResponse('call_thread', 'ThreadCancelOrderTool', ['order_id' => THREAD_ORDER_ID]))]);
+    // One sequence for both pauses below: Http::fake() consults stubs first-registered-first, so a
+    // second fake() for the same pattern would never be reached.
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->toolCallResponse('call_thread', 'ThreadCancelOrderTool', ['order_id' => THREAD_ORDER_ID]))
+            ->push($this->toolCallResponse('call_theirs', 'ThreadCancelOrderTool', ['order_id' => 9999])),
+    ]);
 
     $response = sendMessage(threadUser(7), 'Please cancel order '.THREAD_ORDER_ID.'.');
 
@@ -372,7 +379,6 @@ it('shows the approval interrupt inline when a message triggers a confirmation',
         ->and(app(ThreadLedger::class)->executions)->toBe(0);
 
     // Somebody else's pause, on the same install: it must not appear in this user's interrupt.
-    Http::fake(['*/chat/completions' => Http::response($this->toolCallResponse('call_theirs', 'ThreadCancelOrderTool', ['order_id' => 9999]))]);
     sendMessage(threadUser(8), 'Please cancel order 9999.')->assertSessionHas('verdict-console.status', 'paused');
     $theirs = StoredPendingApproval::query()->where('tool_call_id', 'call_theirs')->sole();
 
@@ -451,8 +457,10 @@ it('removes the interrupt after a rejection and executes nothing', function (): 
 
 /**
  * Ownership is VC-18's: rendering or continuing someone else's conversation is refused the same way
- * an unknown one is, and a refused render is an exception the host's page turns into a 403 — the
- * component must not quietly draw an empty thread.
+ * an unknown one is, and a refused render must reach the host's page as a 403 — never an empty
+ * thread. Blade wraps every exception a view throws in ViewException EXCEPT HttpExceptions, and
+ * Laravel's handler does not unwrap it, so a bare AuthorizationException from a component would
+ * surface as a 500. The component therefore raises a 403 HttpException, which passes through.
  */
 it('refuses to render or continue a conversation the user does not own', function (): void {
     Http::fake(['*/chat/completions' => Http::response($this->textResponse('Hi there.'))]);
@@ -461,8 +469,14 @@ it('refuses to render or continue a conversation the user does not own', functio
 
     $this->actingAs(threadUser(8));
 
-    expect(fn (): string => renderThread($theirs))->toThrow(AuthorizationException::class)
-        ->and(fn (): string => renderThread('no-such-conversation'))->toThrow(AuthorizationException::class);
+    foreach ([$theirs, 'no-such-conversation'] as $conversationId) {
+        try {
+            renderThread($conversationId);
+            $this->fail('Rendering ['.$conversationId.'] must be refused.');
+        } catch (HttpException $e) {
+            expect($e->getStatusCode())->toBe(403);
+        }
+    }
 
     sendMessage(threadUser(8), 'Show me everything.', $theirs)->assertForbidden();
 

--- a/tests/EndToEnd/ChatThreadTest.php
+++ b/tests/EndToEnd/ChatThreadTest.php
@@ -1,0 +1,522 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Actions\ActionContext;
+use Fissible\Verdict\Actions\ActionEnvelope;
+use Fissible\Verdict\Actions\AuthorizedAction;
+use Fissible\Verdict\Capabilities\Capability;
+use Fissible\Verdict\Capabilities\CapabilityRegistry;
+use Fissible\Verdict\Contracts\CapabilityAuthorizer;
+use Fissible\Verdict\Decisions\Decision;
+use Fissible\Verdict\LaravelAi\VerdictApprovalMiddleware;
+use Fissible\Verdict\Targets\ExecutionTargetPolicy;
+use Fissible\Verdict\VerdictManager;
+use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
+use Fissible\VerdictConsole\Approvals\PendingApproval as StoredPendingApproval;
+use Fissible\VerdictConsole\Contracts\ConversationParticipants;
+use Fissible\VerdictConsole\Contracts\ResumableAgents;
+use Fissible\VerdictConsole\Http\VerdictConsoleRoutes;
+use Fissible\VerdictConsole\Tests\EndToEndTestCase;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\GenericUser;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
+use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
+use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Testing\TestResponse;
+use Laravel\Ai\Concerns\RemembersConversations as RemembersConversationsTrait;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasMiddleware;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Contracts\RemembersConversations as RemembersConversationsContract;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Tools\Request;
+
+/**
+ * The non-streaming Blade thread: post a message, reload, see the reply — and when the reply is a
+ * pause, see the approval interrupt inline and resolve it through the same forms the inbox uses.
+ * Driven over the real Laravel AI + Verdict stack; fixtures are this file's own.
+ */
+const THREAD_ORDER_ID = 8101;
+
+const THREAD_ENTRY_KEY = 'thread@v1';
+
+final class ThreadLedger
+{
+    public int $executions = 0;
+}
+
+final readonly class ThreadOrder
+{
+    public function __construct(public int $id) {}
+}
+
+final class ThreadCancelOrderTool implements Tool
+{
+    public function description(): Stringable|string
+    {
+        return 'Cancel an order by id.';
+    }
+
+    public function handle(Request $request): Stringable|string
+    {
+        return 'The Verdict-bound tool handles this.';
+    }
+
+    /** @return array<string, Type> */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}
+
+function threadBoundTool(): Tool
+{
+    $verdict = app(VerdictManager::class);
+
+    if (! app(CapabilityRegistry::class)->has('orders.cancel')) {
+        $verdict->capability(
+            Capability::usingPolicy(
+                name: 'orders.cancel',
+                ability: 'update',
+                resolveTarget: fn (ActionEnvelope $e): ThreadOrder => new ThreadOrder((int) $e->proposal->arguments['order_id']),
+            )
+                ->executionTarget(ExecutionTargetPolicy::acceptStaleSnapshot(
+                    name: 'thread-target',
+                    identityUsing: fn (ActionEnvelope $e, ThreadOrder $t): array => ['id' => $t->id],
+                ))
+                ->requiresConfirmation(fn (ActionEnvelope $e, ThreadOrder $t): array => ['order_id' => $t->id], reason: 'Cancelling an order needs confirmation.')
+                ->executeUsing(function (AuthorizedAction $a): string {
+                    app(ThreadLedger::class)->executions++;
+
+                    return 'Order cancelled.';
+                }),
+        );
+    }
+
+    return $verdict->bound(new ThreadCancelOrderTool, 'orders.cancel', new ActionContext('customer'));
+}
+
+final class ThreadAgent implements Agent, HasMiddleware, HasTools, RemembersConversationsContract
+{
+    use Promptable;
+    use RemembersConversationsTrait;
+
+    public function instructions(): Stringable|string
+    {
+        return 'Help customers with their orders.';
+    }
+
+    /** @return array<int, Tool> */
+    public function tools(): array
+    {
+        return [threadBoundTool()];
+    }
+
+    /** @return array<int, object> */
+    public function middleware(): array
+    {
+        return [app(VerdictApprovalMiddleware::class)];
+    }
+
+    public function provider(): string
+    {
+        return EndToEndTestCase::PROVIDER;
+    }
+
+    public function maxSteps(): int
+    {
+        return 3;
+    }
+}
+
+/** Faithful round trip for the integer-keyed GenericUser participants below. */
+final class ThreadParticipants implements ConversationParticipants
+{
+    public function referenceFor(object $participant): string
+    {
+        return (string) $participant->id;
+    }
+
+    public function resolve(string $reference): object
+    {
+        return new GenericUser(['id' => (int) $reference]);
+    }
+}
+
+function threadUser(int $id = 7): GenericUser
+{
+    return new GenericUser(['id' => $id]);
+}
+
+function renderThread(?string $conversationId = null): string
+{
+    return $conversationId === null
+        ? (string) test()->blade('<x-verdict-console::chat />')
+        : (string) test()->blade('<x-verdict-console::chat :conversation="$id" />', ['id' => $conversationId]);
+}
+
+function threadDocument(string $html): DOMXPath
+{
+    $document = new DOMDocument;
+    libxml_use_internal_errors(true);
+    $document->loadHTML('<?xml encoding="utf-8" ?>'.$html);
+    libxml_clear_errors();
+
+    return new DOMXPath($document);
+}
+
+/**
+ * The bubbles, structurally: `<li data-role>` items that are direct children of the thread's
+ * `<ol data-messages>`, with their text as the DOM decoded it — so escaped markup reads back as
+ * the literal the user typed, and a bubble outside the list is not a bubble.
+ *
+ * @return list<array{role: string, content: string}>
+ */
+function renderedBubbles(string $html): array
+{
+    $bubbles = [];
+
+    foreach (threadDocument($html)->query('//ol[@data-messages]/li[@data-role]') ?: [] as $node) {
+        if ($node instanceof DOMElement) {
+            $bubbles[] = ['role' => $node->getAttribute('data-role'), 'content' => trim($node->textContent)];
+        }
+    }
+
+    return $bubbles;
+}
+
+/** The HTML of the interrupt block, or null when the thread renders none. */
+function renderedInterrupt(string $html): ?string
+{
+    $xpath = threadDocument($html);
+    $node = ($xpath->query('//*[@data-interrupt]') ?: [])[0] ?? null;
+
+    return $node instanceof DOMElement ? (string) $node->ownerDocument?->saveHTML($node) : null;
+}
+
+/** Whether the approvals widget scoped to this conversation is a DESCENDANT of the interrupt block. */
+function interruptWrapsWidget(string $html, string $conversationId): bool
+{
+    $matches = threadDocument($html)->query(
+        '//*[@data-interrupt]//*[@data-verdict-console="approvals"][@data-conversation="'.$conversationId.'"]',
+    );
+
+    return $matches !== false && $matches->length === 1;
+}
+
+/** Send one message as the user through the console's route and return the response. */
+function sendMessage(GenericUser $user, string $prompt, ?string $conversationId = null): TestResponse
+{
+    $payload = ['prompt' => $prompt];
+
+    if ($conversationId !== null) {
+        $payload['conversation'] = $conversationId;
+    }
+
+    return test()->actingAs($user)->from('/chat')->post(route('verdict-console.chat.send'), $payload);
+}
+
+beforeEach(function (): void {
+    $this->migrateRoundTripTables();
+
+    $console = dirname(__DIR__, 2).'/database/migrations';
+    (require $console.'/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require $console.'/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require $console.'/create_verdict_console_approval_notifications_table.php.stub')->up();
+    (require $console.'/create_verdict_console_approval_reconciliations_table.php.stub')->up();
+
+    config()->set('app.key', 'base64:'.base64_encode(str_repeat('k', 32)));
+    config()->set('verdict-console.chat.entry_key', THREAD_ENTRY_KEY);
+
+    $this->app->instance(ThreadLedger::class, new ThreadLedger);
+    $this->app->instance(ConversationParticipants::class, new ThreadParticipants);
+    $this->app->instance(CapabilityAuthorizer::class, new class implements CapabilityAuthorizer
+    {
+        public function decide(Capability $capability, ActionEnvelope $envelope, mixed $target): Decision
+        {
+            return Decision::permit('thread test');
+        }
+    });
+
+    /** @var AgentResolverRegistry $resolvers */
+    $resolvers = app(ResumableAgents::class);
+    $resolvers->register(THREAD_ENTRY_KEY, fn (): ThreadAgent => new ThreadAgent, fn (Agent $agent): bool => $agent instanceof ThreadAgent);
+
+    expect(Route::has('verdict-console.chat.send'))->toBeTrue('The chat route mounts at boot with the approval routes.');
+    $this->withoutMiddleware([PreventRequestForgery::class, ValidateCsrfToken::class]);
+});
+
+it('mounts the chat send route beside the approval routes', function (): void {
+    $send = Route::getRoutes()->getByName('verdict-console.chat.send');
+
+    expect($send->methods())->toBe(['POST'])
+        ->and($send->uri())->toBe('verdict-console/chat')
+        ->and($send->gatherMiddleware())->toContain('web');
+});
+
+/** A thread with nothing in it is still a thread: a form to start one, and no bubbles. */
+it('renders an empty new thread with a send form and no conversation', function (): void {
+    $html = renderThread();
+
+    expect($html)->toContain('data-verdict-console="chat"')
+        ->and($html)->toContain('data-conversation=""')
+        ->and($html)->toContain('data-routes="mounted"')
+        ->and($html)->toContain('data-streaming="false"')
+        ->and(renderedBubbles($html))->toBe([])
+        ->and($html)->toContain('action="'.route('verdict-console.chat.send').'"')
+        ->and($html)->toContain('method="post"')
+        ->and($html)->toContain('name="prompt"')
+        ->and($html)->toContain('_token')
+        ->and($html)->not->toContain('name="conversation"')
+        ->and($html)->not->toContain('data-interrupt');
+});
+
+it('starts a conversation on the first send and renders the exchange after reload', function (): void {
+    Http::fake(['*/chat/completions' => Http::response($this->textResponse('Hi there. How can I help?'))]);
+
+    $response = sendMessage(threadUser(7), 'Hello');
+
+    $response->assertRedirect('/chat')->assertSessionHas('verdict-console.status', 'sent');
+    $conversationId = session('verdict-console.chat.conversation');
+
+    expect($conversationId)->toBeString()->not->toBe('');
+
+    $html = renderThread($conversationId);
+
+    expect($html)->toContain('data-conversation="'.$conversationId.'"')
+        ->and(renderedBubbles($html))->toBe([
+            ['role' => 'user', 'content' => 'Hello'],
+            ['role' => 'assistant', 'content' => 'Hi there. How can I help?'],
+        ])
+        ->and($html)->toContain('name="conversation" value="'.$conversationId.'"')
+        ->and($html)->not->toContain('data-interrupt');
+});
+
+/** The host page that has no conversation id of its own still shows the thread it just started. */
+it('falls back to the conversation flashed by the last send when no conversation is given', function (): void {
+    Http::fake(['*/chat/completions' => Http::response($this->textResponse('Hi there.'))]);
+    sendMessage(threadUser(7), 'Hello')->assertSessionHas('verdict-console.chat.conversation');
+    $conversationId = (string) session('verdict-console.chat.conversation');
+
+    // Nothing re-flashes: the render that follows the redirect reads what the send left behind.
+    $this->actingAs(threadUser(7));
+
+    $html = renderThread();
+
+    expect($html)->toContain('data-conversation="'.$conversationId.'"')
+        ->and(renderedBubbles($html))->toHaveCount(2);
+});
+
+it('continues an owned conversation on the next send', function (): void {
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->textResponse('Hi there.'))
+            ->push($this->textResponse('Order 8101 ships tomorrow.')),
+    ]);
+    sendMessage(threadUser(7), 'Hello')->assertSessionHas('verdict-console.chat.conversation');
+    $conversationId = (string) session('verdict-console.chat.conversation');
+
+    sendMessage(threadUser(7), 'Where is order 8101?', $conversationId)
+        ->assertRedirect('/chat')
+        ->assertSessionHas('verdict-console.status', 'sent')
+        ->assertSessionHas('verdict-console.chat.conversation', $conversationId);
+
+    expect(array_column(renderedBubbles(renderThread($conversationId)), 'content'))
+        ->toBe(['Hello', 'Hi there.', 'Where is order 8101?', 'Order 8101 ships tomorrow.']);
+
+    Http::assertSentCount(2);
+});
+
+/** What the user typed is drawn as text, never as markup — on both sides of the exchange. */
+it('escapes message content instead of rendering it as markup', function (): void {
+    Http::fake(['*/chat/completions' => Http::response($this->textResponse('Sure: <em>done</em>'))]);
+    sendMessage(threadUser(7), 'Show <b>bold</b> & "quotes"')->assertSessionHas('verdict-console.chat.conversation');
+    $conversationId = (string) session('verdict-console.chat.conversation');
+
+    $html = renderThread($conversationId);
+
+    expect(renderedBubbles($html))->toBe([
+        ['role' => 'user', 'content' => 'Show <b>bold</b> & "quotes"'],
+        ['role' => 'assistant', 'content' => 'Sure: <em>done</em>'],
+    ])
+        ->and($html)->toContain('&lt;b&gt;bold&lt;/b&gt; &amp; &quot;quotes&quot;')
+        ->and($html)->toContain('&lt;em&gt;done&lt;/em&gt;')
+        ->and($html)->not->toContain('<b>bold</b>')
+        ->and($html)->not->toContain('<em>done</em>');
+});
+
+/**
+ * The acceptance criterion: a message that triggers a confirmation shows the interrupt inline. The
+ * paused assistant turn has no text, so it is not drawn as a bubble; the approval row is drawn in
+ * its place, through the same widget the inbox uses, offering exactly the verbs VC-41 resolves.
+ */
+it('shows the approval interrupt inline when a message triggers a confirmation', function (): void {
+    Http::fake(['*/chat/completions' => Http::response($this->toolCallResponse('call_thread', 'ThreadCancelOrderTool', ['order_id' => THREAD_ORDER_ID]))]);
+
+    $response = sendMessage(threadUser(7), 'Please cancel order '.THREAD_ORDER_ID.'.');
+
+    $response->assertRedirect('/chat')
+        ->assertSessionHas('verdict-console.status', 'paused')
+        ->assertSessionHas('verdict-console.chat.conversation');
+    $conversationId = (string) session('verdict-console.chat.conversation');
+    $row = StoredPendingApproval::query()->where('tool_call_id', 'call_thread')->sole();
+
+    expect($row->conversation_id)->toBe($conversationId)
+        ->and(app(ThreadLedger::class)->executions)->toBe(0);
+
+    // Somebody else's pause, on the same install: it must not appear in this user's interrupt.
+    Http::fake(['*/chat/completions' => Http::response($this->toolCallResponse('call_theirs', 'ThreadCancelOrderTool', ['order_id' => 9999]))]);
+    sendMessage(threadUser(8), 'Please cancel order 9999.')->assertSessionHas('verdict-console.status', 'paused');
+    $theirs = StoredPendingApproval::query()->where('tool_call_id', 'call_theirs')->sole();
+
+    $this->actingAs(threadUser(7));
+    $html = renderThread($conversationId);
+    $interrupt = renderedInterrupt($html);
+
+    expect(renderedBubbles($html))->toBe([['role' => 'user', 'content' => 'Please cancel order '.THREAD_ORDER_ID.'.']])
+        ->and($interrupt)->not->toBeNull()
+        // The interrupt wraps the approvals widget, scoped to this conversation — a descendant,
+        // not the same element wearing both attributes.
+        ->and(interruptWrapsWidget($html, $conversationId))->toBeTrue()
+        ->and($interrupt)->toContain('data-approval="'.$row->id.'"')
+        ->and($interrupt)->not->toContain('data-approval="'.$theirs->id.'"')
+        ->and($interrupt)->toContain('data-state="pending"')
+        ->and($interrupt)->toContain('action="'.route('verdict-console.approvals.approve', $row->id).'"')
+        ->and($interrupt)->toContain('action="'.route('verdict-console.approvals.reject', $row->id).'"')
+        ->and($interrupt)->not->toContain('data-verb="close"')
+        ->and($interrupt)->toContain('Cancelling an order needs confirmation.')
+        ->and($html)->not->toContain($theirs->id);
+});
+
+/** The other half: resolving the interrupt through VC-6 continues the thread, and the reload shows it. */
+it('continues the thread after the interrupt is approved, and the interrupt is gone', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->toolCallResponse('call_thread', 'ThreadCancelOrderTool', ['order_id' => THREAD_ORDER_ID]))
+            ->push($this->textResponse('Done — order '.THREAD_ORDER_ID.' is cancelled.')),
+    ]);
+    sendMessage(threadUser(7), 'Please cancel order '.THREAD_ORDER_ID.'.')->assertSessionHas('verdict-console.chat.conversation');
+    $conversationId = (string) session('verdict-console.chat.conversation');
+    $row = StoredPendingApproval::query()->sole();
+
+    $this->actingAs(threadUser(7))->from('/chat')->post(route('verdict-console.approvals.approve', $row->id))
+        ->assertRedirect('/chat')
+        ->assertSessionHas('verdict-console.status', 'approved');
+
+    expect(app(ThreadLedger::class)->executions)->toBe(1, 'Approving the interrupt executes the action exactly once.');
+
+    $html = renderThread($conversationId);
+
+    expect(renderedBubbles($html))->toBe([
+        ['role' => 'user', 'content' => 'Please cancel order '.THREAD_ORDER_ID.'.'],
+        ['role' => 'assistant', 'content' => 'Done — order '.THREAD_ORDER_ID.' is cancelled.'],
+    ])
+        ->and($html)->not->toContain('data-interrupt')
+        ->and($html)->not->toContain('data-approval=');
+
+    Http::assertSentCount(2);
+});
+
+it('removes the interrupt after a rejection and executes nothing', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    Http::fake(['*/chat/completions' => Http::response($this->toolCallResponse('call_thread', 'ThreadCancelOrderTool', ['order_id' => THREAD_ORDER_ID]))]);
+    sendMessage(threadUser(7), 'Please cancel order '.THREAD_ORDER_ID.'.')->assertSessionHas('verdict-console.chat.conversation');
+    $conversationId = (string) session('verdict-console.chat.conversation');
+    $row = StoredPendingApproval::query()->sole();
+
+    $this->actingAs(threadUser(7))->from('/chat')->post(route('verdict-console.approvals.reject', $row->id))
+        ->assertRedirect('/chat')
+        ->assertSessionHas('verdict-console.status', 'rejected');
+
+    $html = renderThread($conversationId);
+
+    expect(app(ThreadLedger::class)->executions)->toBe(0)
+        ->and(renderedInterrupt($html))->toBeNull()
+        ->and(renderedBubbles($html))->toBe(
+            [['role' => 'user', 'content' => 'Please cancel order '.THREAD_ORDER_ID.'.']],
+            'A bare rejection ends the turn without a reply; the thread shows exactly what was said.',
+        );
+
+    // Measured: a bare rejection makes no second model call.
+    Http::assertSentCount(1);
+});
+
+/**
+ * Ownership is VC-18's: rendering or continuing someone else's conversation is refused the same way
+ * an unknown one is, and a refused render is an exception the host's page turns into a 403 — the
+ * component must not quietly draw an empty thread.
+ */
+it('refuses to render or continue a conversation the user does not own', function (): void {
+    Http::fake(['*/chat/completions' => Http::response($this->textResponse('Hi there.'))]);
+    sendMessage(threadUser(7), 'Hello')->assertSessionHas('verdict-console.chat.conversation');
+    $theirs = (string) session('verdict-console.chat.conversation');
+
+    $this->actingAs(threadUser(8));
+
+    expect(fn (): string => renderThread($theirs))->toThrow(AuthorizationException::class)
+        ->and(fn (): string => renderThread('no-such-conversation'))->toThrow(AuthorizationException::class);
+
+    sendMessage(threadUser(8), 'Show me everything.', $theirs)->assertForbidden();
+
+    Http::assertSentCount(1);
+});
+
+it('refuses an unauthenticated send', function (): void {
+    Http::fake();
+
+    $this->from('/chat')->post(route('verdict-console.chat.send'), ['prompt' => 'Hello'])->assertForbidden();
+
+    Http::assertNothingSent();
+});
+
+it('rejects a blank or missing prompt with a validation error and sends nothing', function (): void {
+    Http::fake();
+
+    sendMessage(threadUser(7), '   ')
+        ->assertRedirect('/chat')
+        ->assertSessionHasErrors('prompt');
+
+    $this->actingAs(threadUser(7))->from('/chat')->post(route('verdict-console.chat.send'), [])
+        ->assertRedirect('/chat')
+        ->assertSessionHasErrors('prompt');
+
+    Http::assertNothingSent();
+});
+
+/** An opted-out host gets the thread without a form, and a reason. */
+it('renders the thread without a send form for a host that opted out of the console routes', function (): void {
+    Http::fake(['*/chat/completions' => Http::response($this->textResponse('Hi there.'))]);
+    sendMessage(threadUser(7), 'Hello')->assertSessionHas('verdict-console.chat.conversation');
+    $conversationId = (string) session('verdict-console.chat.conversation');
+    $this->actingAs(threadUser(7));
+
+    VerdictConsoleRoutes::ignoreRoutes();
+    Route::setRoutes(new RouteCollection);
+
+    try {
+        $html = renderThread($conversationId);
+    } finally {
+        VerdictConsoleRoutes::$registersRoutes = true;
+    }
+
+    expect($html)->toContain('data-routes="unmounted"')
+        ->and($html)->not->toContain('<form')
+        ->and($html)->toContain('console routes are not registered')
+        ->and(renderedBubbles($html))->toHaveCount(2);
+});
+
+/** The thread says what it is: it does not stream, and it updates on reload. */
+it('states its non-streaming limitation in the markup', function (): void {
+    $html = renderThread();
+
+    expect($html)->toContain('data-limitation')
+        ->and($html)->toContain('does not stream');
+});

--- a/tests/Feature/ApprovalInboxComponentTest.php
+++ b/tests/Feature/ApprovalInboxComponentTest.php
@@ -399,3 +399,25 @@ it('is a class-based component registered under the verdict-console namespace', 
         ->and(PendingApproval::query()->count())->toBe(0)
         ->and(renderInbox())->toContain('data-verdict-console="approvals"');
 });
+
+/**
+ * The chat thread draws its interrupt through this widget, scoped to one conversation. Rows of
+ * other conversations are neither rendered nor read from Verdict, and the empty state is silent —
+ * an empty interrupt is no interrupt.
+ */
+it('renders only one conversations rows when given a conversation, and nothing when it has none', function (): void {
+    $mine = $this->store->ingest('call_mine', conversationId: 'conversation-a', receiptId: 'receipt-call_mine', resumability: Resumability::Drivable);
+    $this->store->ingest('call_other', conversationId: 'conversation-b', receiptId: 'receipt-call_other', resumability: Resumability::Drivable);
+    $this->challenges->with('call_mine', inboxChallenge('call_mine'))->with('call_other', inboxChallenge('call_other'));
+
+    $html = (string) $this->blade('<x-verdict-console::approvals :conversation="$conversation" />', ['conversation' => 'conversation-a']);
+
+    expect(array_keys(inboxRows($html)))->toBe([$mine->id])
+        ->and($this->challenges->reads)->toBe(['call_mine'])
+        ->and($html)->toContain('data-conversation="conversation-a"');
+
+    $empty = (string) $this->blade('<x-verdict-console::approvals :conversation="$conversation" />', ['conversation' => 'conversation-none']);
+
+    expect(inboxRows($empty))->toBe([])
+        ->and($empty)->not->toContain('No approvals are waiting.');
+});

--- a/tests/Feature/ConsoleRoutesTest.php
+++ b/tests/Feature/ConsoleRoutesTest.php
@@ -158,7 +158,8 @@ it('publishes the views under their own tag, into the vendor views directory', f
 
     $this->artisan('vendor:publish', ['--tag' => 'verdict-console-views', '--force' => true])->assertSuccessful();
 
-    expect(File::exists($target.'/components/approvals.blade.php'))->toBeTrue();
+    expect(File::exists($target.'/components/approvals.blade.php'))->toBeTrue()
+        ->and(File::exists($target.'/components/chat.blade.php'))->toBeTrue();
 
     File::deleteDirectory($target);
 });

--- a/tests/Feature/DocumentationCorrectionsTest.php
+++ b/tests/Feature/DocumentationCorrectionsTest.php
@@ -116,6 +116,14 @@ it('records that console routes mount by default with an opt-out, and that an in
         ->not->toContain('Routes are opt-in');
 });
 
+/** The Blade thread is the non-streaming surface, and the design must say so rather than imply parity with Livewire. */
+it('documents the Blade chat threads non-streaming limitation', function (): void {
+    expect(documentation('docs/design/0001-verdict-console-design.md'))
+        ->toContain('`<x-verdict-console::chat />`')
+        ->toContain('does not stream')
+        ->toContain('`verdict-console.chat.send`');
+});
+
 /** Folded in from the VC-13 review: the UTC reading is a contract from verdict#335 onward, not a hope. */
 it('cites the Verdict change that makes the evidence timestamp reading a UTC contract', function (): void {
     expect(documentation('src/Evidence/DatabaseEvidenceQuery.php'))->toContain('fissible/verdict#335');


### PR DESCRIPTION
## Summary

The Blade chat thread — the non-streaming end of the console's chat story (design §8), composed from VC-18's `ChatService` and VC-19's approvals widget and routes.

- **`<x-verdict-console::chat :conversation="$id" />`** renders an owned thread (user/assistant bubbles only; a paused assistant turn has no text and is not drawn) and a send form posting to the new **`verdict-console.chat.send`** route (start when no conversation, continue otherwise). With no prop it falls back to the conversation the last send flashed, so a host page without routing state still shows the thread it just started.
- **The approval interrupt is inline** — the acceptance criterion: when a message pauses on a confirmation, the conversation's pending rows are rendered *inside* `[data-interrupt]` through the approvals widget scoped to that conversation (new `conversation` prop: only that conversation's rows are listed *and* read from Verdict; no empty-state text when scoped). Approve/reject are therefore VC-19's forms posting through VC-6, and the reload shows the continuation. Tested end to end: pause → interrupt (another user's pause on the same install stays out of it) → approve → executes once → the post-approval reply is the next bubble and the interrupt is gone; reject → executes nothing, no reply bubble, interrupt gone (a bare rejection makes no second model call — measured).
- **Ownership** is VC-18's, and a refused render is a **403 `HttpException`**, not an `AuthorizationException`: Blade wraps every non-HTTP exception in `ViewException` and Laravel's handler never unwraps it, so a component throwing `AuthorizationException` would 500 the host page. Foreign and unknown conversations are refused identically; the controller 403s an unauthenticated send and validates a non-blank prompt.
- **Honest about not streaming**: `data-streaming="false"` and a visible `data-limitation` line in the markup; the design says streaming is the Livewire surface's job.

## Linked issue

Closes #21

## Trust and failure behavior

- Untrusted input: the prompt text and the `conversation` field. The prompt reaches the model only after validation, authentication, and ownership; the conversation id is only ever matched against the participant's own conversations.
- Everything the user typed and everything the model replied is Blade-escaped (tested with `<b>`, `&`, quotes, and `<em>` in a reply).
- The interrupt shows only rows Verdict still treats as pending; a decided or lapsed row stops interrupting the thread (its close verb lives in the inbox widget — an inline close is a possible follow-up).
- An opted-out host (PR #82's `ignoreRoutes()`) gets the thread without a form and a visible reason.

## Evidence and data handling

- The thread reads through the host's `ConversationStore`; the console owns no message table. Tool results are not drawn. Nothing from Verdict's evidence is shown here.

## Verification

- [x] Success, denial, and relevant failure paths are tested.
- [x] Security containment and legitimate utility are both covered where applicable.
- [x] Documentation and `CHANGELOG.md` are updated.
- [x] `composer test` passes locally — phpstan clean, pint passed, type coverage 100%, **327 passed (1709 assertions)**.
- [x] No credentials, real customer data, or unredacted evidence are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
