### PR TITLE
feat: Blade audit page over the evidence read boundary (VC-20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Blade audit / evidence page (VC-20).** `<x-verdict-console::evidence />` renders the VC-13
+  evidence boundary as a read-only, newest-first paginated audit table, preserving its recording and
+  conversation-correlation states instead of reading configuration or Verdict tables directly.
+
 - **Blade basic chat thread (VC-21).** `<x-verdict-console::chat />` posts through the new
   `verdict-console.chat.send` route, renders an owned thread without streaming, and places its
   conversation-scoped approval interrupt inline. Resolving that interrupt continues the thread on

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -358,6 +358,10 @@ free.
   the first-party convention here despite publishing (not loading) its migrations: mounting exposes
   nothing an unauthorized caller can use, whereas a migration changes the host's schema.
   Approval widget + paginated audit page + basic (non-streaming) chat thread. Publishable views.
+  `<x-verdict-console::evidence />` is the paginated audit table over the VC-13 boundary: when
+  §6.6 says "recording is off — blank by config," it stays blank rather than implying no decisions.
+  Its evidence-display audience is host-governed: the host embeds it behind its own authorization;
+  the page adds no gate of its own.
   Chat surfaces start and continue conversations through the host's `ChatEntry` contract
   (participant plus resumable-agent key, `verdict-console.chat.entry_key`), check ownership
   against Laravel AI's recorded participant, and read the thread through the host's

--- a/resources/views/components/evidence.blade.php
+++ b/resources/views/components/evidence.blade.php
@@ -1,0 +1,44 @@
+<section data-verdict-console="evidence" data-recording="{{ $result->recording->value }}" data-page="{{ $page }}" data-pages="{{ $pages }}"@if ($conversation !== null) data-conversation="{{ $result->conversation?->value ?? 'unknown' }}"@endif>
+    @if ($result->recording->value === 'off')
+        <p data-recording-off>recording is off — blank by config.</p>
+    @elseif ($result->recording->value === 'elsewhere')
+        <p data-recording-elsewhere>Evidence is recorded elsewhere by {{ $result->recordedBy }}.</p>
+    @elseif ($conversation !== null && $result->conversation?->value === 'unknown')
+        <p data-conversation-unknown>This conversation was never observed by the console.</p>
+    @elseif ($result->records === [])
+        <p data-empty>No decisions have been recorded.</p>
+    @else
+        <table data-evidence>
+            <thead>
+                <tr>
+                    <th>Recorded at</th><th>Capability</th><th>Stage</th><th>Disposition</th><th>Claim type</th><th>Record digest</th><th>Invocation ID</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach ($pageRecords as $record)
+                    <tr data-record="{{ $record->id }}" data-disposition="{{ $record->disposition }}">
+                        <td data-field="recorded_at"><time datetime="{{ $record->recordedAt->format(DATE_ATOM) }}">{{ $record->recordedAt->format(DATE_ATOM) }}</time></td>
+                        <td data-field="capability">{{ $record->capability }}</td>
+                        <td data-field="stage">{{ $record->stage }}</td>
+                        <td data-field="disposition">{{ $record->disposition }}</td>
+                        <td data-field="claim_type">{{ $record->claimType }}</td>
+                        <td data-field="record_digest">{{ $record->recordDigest }}</td>
+                        <td data-field="invocation_id">{{ $record->invocationId }}</td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+
+        @if ($pages > 1)
+            <nav data-pagination>
+                @for ($number = 1; $number <= $pages; $number++)
+                    @if ($number !== $page)
+                        <a data-page-link="{{ $number }}" href="{{ request()->fullUrlWithQuery(['page' => $number]) }}">{{ $number }}</a>
+                    @else
+                        <span>{{ $number }}</span>
+                    @endif
+                @endfor
+            </nav>
+        @endif
+    @endif
+</section>

--- a/src/View/Components/Evidence.php
+++ b/src/View/Components/Evidence.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\View\Components;
+
+use Fissible\VerdictConsole\Contracts\EvidenceQuery;
+use Fissible\VerdictConsole\Evidence\EvidenceFilter;
+use Fissible\VerdictConsole\Evidence\EvidenceRecord;
+use Illuminate\Contracts\View\View;
+use Illuminate\Pagination\Paginator;
+use Illuminate\View\Component;
+
+/**
+ * Server-rendered audit table over the VC-13 evidence read boundary.
+ *
+ * Pagination deliberately happens in memory: VC-13 specifies one complete filtered projection and
+ * has no limit/offset contract. A host with a table too large for that projection replaces
+ * EvidenceQuery with a boundary suited to its own storage and audience rules.
+ */
+final class Evidence extends Component
+{
+    public function __construct(
+        private EvidenceQuery $evidence,
+        private ?string $disposition = null,
+        private ?string $capability = null,
+        private ?string $conversation = null,
+        private int $perPage = 25,
+    ) {}
+
+    public function render(): View
+    {
+        $result = $this->evidence->search(new EvidenceFilter(
+            disposition: $this->disposition,
+            capability: $this->capability,
+            conversationId: $this->conversation,
+        ));
+
+        $records = $result->records;
+
+        usort($records, fn (EvidenceRecord $left, EvidenceRecord $right): int => $right->recordedAt <=> $left->recordedAt);
+
+        $perPage = max(1, $this->perPage);
+        $page = Paginator::resolveCurrentPage('page');
+        $pages = max(1, (int) ceil(count($records) / $perPage));
+        $pageRecords = array_slice($records, ($page - 1) * $perPage, $perPage);
+
+        return view('verdict-console::components.evidence', [
+            'conversation' => $this->conversation,
+            'page' => $page,
+            'pageRecords' => $pageRecords,
+            'pages' => $pages,
+            'result' => $result,
+        ]);
+    }
+}

--- a/tests/Feature/DocumentationCorrectionsTest.php
+++ b/tests/Feature/DocumentationCorrectionsTest.php
@@ -124,6 +124,14 @@ it('documents the Blade chat threads non-streaming limitation', function (): voi
         ->toContain('`verdict-console.chat.send`');
 });
 
+/** The audit page is the surface §6.6's blank-by-config rule was written for; the design must name it and its audience rule. */
+it('names the evidence page in the design of record', function (): void {
+    expect(documentation('docs/design/0001-verdict-console-design.md'))
+        ->toContain('`<x-verdict-console::evidence />`')
+        ->toContain('recording is off — blank by config')
+        ->toContain('the host embeds it behind its own authorization');
+});
+
 /** Folded in from the VC-13 review: the UTC reading is a contract from verdict#335 onward, not a hope. */
 it('cites the Verdict change that makes the evidence timestamp reading a UTC contract', function (): void {
     expect(documentation('src/Evidence/DatabaseEvidenceQuery.php'))->toContain('fissible/verdict#335');

--- a/tests/Feature/EvidencePageComponentTest.php
+++ b/tests/Feature/EvidencePageComponentTest.php
@@ -1,0 +1,474 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Evidence\DatabaseEvidenceRecorder;
+use Fissible\Verdict\Evidence\NullEvidenceRecorder;
+use Fissible\VerdictConsole\Contracts\EvidenceQuery;
+use Fissible\VerdictConsole\Evidence\ConversationInvocationStore;
+use Fissible\VerdictConsole\Evidence\EvidenceFilter;
+use Fissible\VerdictConsole\Evidence\EvidenceQueryResult;
+use Fissible\VerdictConsole\Evidence\EvidenceRecord;
+use Fissible\VerdictConsole\Evidence\EvidenceRecordingState;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The audit page is a pure function of the VC-13 read boundary: recording state, the records, and
+ * the VC-14 conversation correlation. Everything here renders from real rows in Verdict's published
+ * schema under a real recorder configuration; nothing is mocked.
+ */
+const AUDIT_EVIDENCE_STUBS = [
+    'create_verdict_evidence_table.php.stub',
+    'add_provenance_to_verdict_evidence_table.php.stub',
+    'add_invocation_id_to_verdict_evidence_table.php.stub',
+    'add_tool_kind_to_verdict_evidence_table.php.stub',
+    'add_configuration_fingerprint_to_verdict_evidence_table.php.stub',
+    'add_actor_and_subject_fingerprints_to_verdict_evidence_table.php.stub',
+    'add_target_source_to_verdict_evidence_table.php.stub',
+    'add_tool_description_fingerprints_to_verdict_evidence_table.php.stub',
+    'add_record_identity_to_verdict_evidence_table.php.stub',
+    'add_intent_id_to_verdict_evidence_table.php.stub',
+];
+
+beforeEach(function (): void {
+    config()->set('verdict.evidence.table', 'console_audit_evidence');
+    config()->set('verdict.evidence.recorder', NullEvidenceRecorder::class);
+
+    $migrations = dirname(__DIR__, 2).'/vendor/fissible/verdict/database/migrations';
+
+    foreach (AUDIT_EVIDENCE_STUBS as $stub) {
+        (require $migrations.'/'.$stub)->up();
+    }
+
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_conversation_invocations_table.php.stub')->up();
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists('console_audit_evidence');
+    Schema::dropIfExists('verdict_console_conversation_invocations');
+});
+
+/** Same guard the evidence-query suite carries: a new Verdict stub must not leave this fixture behind. */
+it('builds its fixture from every evidence-table stub the installed Verdict publishes', function (): void {
+    $published = array_map(basename(...), glob(dirname(__DIR__, 2).'/vendor/fissible/verdict/database/migrations/*verdict_evidence_table.php.stub') ?: []);
+
+    expect(AUDIT_EVIDENCE_STUBS)->toEqualCanonicalizing($published);
+});
+
+/** @param array<string, mixed> $attributes */
+function insertAuditEvidence(array $attributes): void
+{
+    DB::table('console_audit_evidence')->insert([
+        'id' => $attributes['id'],
+        'record_type' => $attributes['record_type'] ?? 'decision',
+        'capability' => $attributes['capability'] ?? 'orders.cancel',
+        'stage' => $attributes['stage'] ?? 'proposal',
+        'disposition' => $attributes['disposition'] ?? 'permit',
+        'reason' => $attributes['reason'] ?? null,
+        'claim_type' => $attributes['claim_type'] ?? null,
+        'record_digest' => $attributes['record_digest'] ?? null,
+        'invocation_id' => $attributes['invocation_id'] ?? null,
+        'recorded_at' => $attributes['recorded_at'],
+    ]);
+}
+
+/** Ten decisions, a minute apart, newest last in the table so "newest first" is a real ordering claim. */
+function seedAuditEvidence(int $count = 10): void
+{
+    for ($i = 1; $i <= $count; $i++) {
+        insertAuditEvidence([
+            'id' => sprintf('decision-%02d', $i),
+            'disposition' => $i % 3 === 0 ? 'deny' : 'permit',
+            'claim_type' => $i % 3 === 0 ? 'policy.denied' : null,
+            'record_digest' => 'canonicaljson-sha256:'.str_repeat((string) ($i % 10), 8),
+            'invocation_id' => 'invocation-'.(int) ceil($i / 5),
+            'recorded_at' => sprintf('2026-08-30 10:%02d:00', $i),
+        ]);
+    }
+}
+
+function renderEvidence(string $attributes = '', array $data = []): string
+{
+    return (string) test()->blade('<x-verdict-console::evidence '.$attributes.' />', $data);
+}
+
+/** The recorded rows in rendered order: [id, disposition] pairs read from the table's row attributes. */
+function renderedRecords(string $html): array
+{
+    return array_map(fn (array $row): array => [$row['id'], $row['disposition']], renderedRecordFields($html));
+}
+
+/**
+ * Every rendered row with its cells, associated: each row's id and disposition from the `<tr>` and
+ * a field => text map from its own `<td data-field>` children — so a value can be tied to the row
+ * it belongs to, and a field rendered outside the table counts for nothing.
+ *
+ * @return list<array{id: string, disposition: string, fields: array<string, string>}>
+ */
+function renderedRecordFields(string $html): array
+{
+    $document = new DOMDocument;
+    libxml_use_internal_errors(true);
+    $document->loadHTML('<?xml encoding="utf-8" ?>'.$html);
+    libxml_clear_errors();
+    $xpath = new DOMXPath($document);
+
+    $rows = [];
+
+    foreach ($xpath->query('//table[@data-evidence]//tr[@data-record]') ?: [] as $node) {
+        if (! $node instanceof DOMElement) {
+            continue;
+        }
+
+        $fields = [];
+
+        foreach ($xpath->query('.//td[@data-field]', $node) ?: [] as $cell) {
+            if ($cell instanceof DOMElement) {
+                $fields[$cell->getAttribute('data-field')] = trim($cell->textContent);
+            }
+        }
+
+        $rows[] = ['id' => $node->getAttribute('data-record'), 'disposition' => $node->getAttribute('data-disposition'), 'fields' => $fields];
+    }
+
+    return $rows;
+}
+
+function auditBoundaryRecord(string $id): EvidenceRecord
+{
+    return new EvidenceRecord(
+        id: $id,
+        capability: 'orders.cancel',
+        stage: 'proposal',
+        disposition: 'permit',
+        claimType: null,
+        recordDigest: null,
+        argumentFingerprint: null,
+        idempotencyKeyFingerprint: null,
+        approvalReceiptFingerprint: null,
+        configurationFingerprint: null,
+        actorFingerprint: null,
+        subjectFingerprint: null,
+        proposalTargetIdentityFingerprint: null,
+        executionTargetIdentityFingerprint: null,
+        rateLimitKeyFingerprint: null,
+        executionClaimFingerprint: null,
+        executionClaimBindingFingerprint: null,
+        invocationId: null,
+        rateLimitResetAt: null,
+        recordedAt: new DateTimeImmutable('2026-08-30 12:00:00+00:00'),
+    );
+}
+
+/** A canned read-boundary answer, recording what the component asked for. */
+final class RecordingEvidenceQuery implements EvidenceQuery
+{
+    public ?EvidenceFilter $filter = null;
+
+    public function __construct(private readonly EvidenceQueryResult $result) {}
+
+    public function search(EvidenceFilter $filter): EvidenceQueryResult
+    {
+        $this->filter = $filter;
+
+        return $this->result;
+    }
+}
+
+function rootAttribute(string $html, string $attribute): ?string
+{
+    return preg_match('/<section\b[^>]*\bdata-verdict-console="evidence"[^>]*\b'.preg_quote($attribute, '/').'="([^"]*)"/', $html, $m) === 1 ? $m[1] : null;
+}
+
+/**
+ * The issue's second acceptance criterion, and the design's hard constraint (§6.6): the default
+ * recorder is the null one, so a fresh install's audit page is blank BY CONFIG. It must say that,
+ * in the design's own words, and must not draw a table that reads as "nothing happened".
+ */
+it('says recording is off — blank by config — instead of rendering an empty table', function (): void {
+    $html = renderEvidence();
+
+    expect(rootAttribute($html, 'data-recording'))->toBe('off')
+        ->and($html)->toContain('recording is off — blank by config.')
+        ->and($html)->not->toContain('<table')
+        ->and($html)->not->toContain('data-empty')
+        ->and($html)->not->toContain('No decisions')
+        ->and($html)->not->toContain('<form', 'The audit page is read-only: nothing to submit.');
+});
+
+/**
+ * The page is a consumer of the VC-13 boundary, not a second implementation of it: what it says
+ * about recording is what the boundary answered — even when config says otherwise — and the props
+ * are forwarded as the boundary's own filter.
+ */
+it('renders the read boundarys answer and forwards its props as the filter', function (): void {
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+    $boundary = new RecordingEvidenceQuery(new EvidenceQueryResult(EvidenceRecordingState::Off, []));
+    app()->instance(EvidenceQuery::class, $boundary);
+
+    $html = renderEvidence('disposition="deny" capability="orders.cancel" conversation="conversation-a"');
+
+    expect(rootAttribute($html, 'data-recording'))->toBe('off', 'Config says on; the boundary said off; the boundary wins.')
+        ->and($html)->toContain('recording is off — blank by config.')
+        ->and($boundary->filter?->disposition)->toBe('deny')
+        ->and($boundary->filter?->capability)->toBe('orders.cancel')
+        ->and($boundary->filter?->conversationId)->toBe('conversation-a');
+});
+
+/** And the rows are the boundary's rows: what is in the database is not what this page renders. */
+it('renders the records the boundary returned, not the tables contents', function (): void {
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+    insertAuditEvidence(['id' => 'in-the-database', 'recorded_at' => '2026-08-30 10:00:00']);
+    app()->instance(EvidenceQuery::class, new RecordingEvidenceQuery(new EvidenceQueryResult(EvidenceRecordingState::On, [
+        auditBoundaryRecord('from-the-boundary'),
+    ])));
+
+    $html = renderEvidence();
+
+    expect(array_column(renderedRecords($html), 0))->toBe(['from-the-boundary'])
+        ->and($html)->not->toContain('in-the-database');
+});
+
+it('names the writer when evidence is retained somewhere this page cannot read', function (): void {
+    config()->set('verdict.evidence.writer', 'App\\Evidence\\ExternalWriter');
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+
+    $html = renderEvidence();
+
+    expect(rootAttribute($html, 'data-recording'))->toBe('elsewhere')
+        ->and($html)->toContain('App\\Evidence\\ExternalWriter')
+        ->and($html)->not->toContain('<table')
+        ->and($html)->not->toContain('recording is off');
+});
+
+/** Recording on and nothing recorded is a different fact from recording off, and reads differently. */
+it('says nothing has been recorded when recording is on and the table is empty', function (): void {
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+
+    $html = renderEvidence();
+
+    expect(rootAttribute($html, 'data-recording'))->toBe('on')
+        ->and($html)->toContain('data-empty')
+        ->and($html)->toContain('No decisions have been recorded.')
+        ->and($html)->not->toContain('<table')
+        ->and($html)->not->toContain('recording is off');
+});
+
+/** The row surfaces what the issue names — claimType and recordDigest — beside the decision vocabulary. */
+it('renders decision records newest first with claim type and record digest', function (): void {
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+    insertAuditEvidence(['id' => 'older', 'disposition' => 'permit', 'recorded_at' => '2026-08-30 10:00:00', 'record_digest' => 'canonicaljson-sha256:older', 'invocation_id' => 'invocation-1']);
+    insertAuditEvidence(['id' => 'newer', 'disposition' => 'deny', 'claim_type' => 'policy.denied', 'record_digest' => 'canonicaljson-sha256:newer', 'recorded_at' => '2026-08-30 10:05:00', 'stage' => 'execution']);
+    insertAuditEvidence(['id' => 'provenance-row', 'record_type' => 'provenance', 'stage' => 'input', 'disposition' => 'recorded', 'recorded_at' => '2026-08-30 10:06:00']);
+
+    $html = renderEvidence();
+    $rows = renderedRecordFields($html);
+
+    expect($html)->not->toContain('<form', 'The audit page stays read-only when populated too.')
+        ->and(renderedRecords($html))->toBe([['newer', 'deny'], ['older', 'permit']])
+        ->and($rows[0]['fields'])->toMatchArray([
+            'capability' => 'orders.cancel',
+            'stage' => 'execution',
+            'disposition' => 'deny',
+            'claim_type' => 'policy.denied',
+            'record_digest' => 'canonicaljson-sha256:newer',
+        ])
+        ->and(array_keys($rows[0]['fields']))->toContain('recorded_at', 'invocation_id')
+        ->and($rows[1]['fields'])->toMatchArray([
+            'stage' => 'proposal',
+            'disposition' => 'permit',
+            'claim_type' => '',
+            'record_digest' => 'canonicaljson-sha256:older',
+            'invocation_id' => 'invocation-1',
+        ])
+        ->and($html)->toContain('datetime="2026-08-30T10:05:00+00:00"')
+        ->and($html)->not->toContain('provenance-row', 'Only decision records are audit rows; provenance is not.');
+});
+
+/** The first acceptance criterion: it paginates, from the query string, newest first, with links. */
+it('paginates newest first from the page query parameter', function (): void {
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+    seedAuditEvidence(10);
+
+    $first = renderEvidence(':per-page="4"');
+
+    expect(rootAttribute($first, 'data-page'))->toBe('1')
+        ->and(rootAttribute($first, 'data-pages'))->toBe('3')
+        ->and(array_column(renderedRecords($first), 0))->toBe(['decision-10', 'decision-09', 'decision-08', 'decision-07'])
+        ->and($first)->toContain('data-pagination')
+        ->and($first)->toContain('data-page-link="2"')
+        ->and($first)->toContain('page=2');
+
+    request()->merge(['page' => 2]);
+
+    $second = renderEvidence(':per-page="4"');
+
+    expect(rootAttribute($second, 'data-page'))->toBe('2')
+        ->and(array_column(renderedRecords($second), 0))->toBe(['decision-06', 'decision-05', 'decision-04', 'decision-03'], 'Page boundaries hold, not just the first page.');
+
+    request()->merge(['page' => 3]);
+
+    $last = renderEvidence(':per-page="4"');
+
+    expect(rootAttribute($last, 'data-page'))->toBe('3')
+        ->and(array_column(renderedRecords($last), 0))->toBe(['decision-02', 'decision-01'])
+        ->and($last)->toContain('data-page-link="2"')
+        ->and($last)->not->toContain('data-page-link="4"');
+
+    request()->merge(['page' => 99]);
+
+    $beyond = renderEvidence(':per-page="4"');
+
+    expect(renderedRecords($beyond))->toBe([], 'An out-of-range page renders no rows and does not crash.')
+        ->and(rootAttribute($beyond, 'data-pages'))->toBe('3')
+        ->and($beyond)->toContain('data-page-link="3"');
+});
+
+it('defaults to twenty-five records per page', function (): void {
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+    seedAuditEvidence(26);
+
+    $html = renderEvidence();
+
+    expect(renderedRecords($html))->toHaveCount(25)
+        ->and(rootAttribute($html, 'data-pages'))->toBe('2');
+});
+
+it('preserves other query parameters in its page links', function (): void {
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+    seedAuditEvidence(6);
+    request()->merge(['team' => 'ops']);
+
+    $html = renderEvidence(':per-page="4"');
+
+    preg_match('/<a\b[^>]*data-page-link="2"[^>]*href="([^"]+)"/', $html, $m);
+
+    expect($m[1] ?? null)->not->toBeNull()
+        ->and($m[1])->toContain('page=2')
+        ->and($m[1])->toContain('team=ops');
+});
+
+/** Filters narrow the whole result BEFORE slicing: the page count belongs to the filtered set. */
+it('paginates the filtered result, not a filtered page', function (): void {
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+    seedAuditEvidence(10);
+
+    $html = renderEvidence('disposition="deny" :per-page="2"');
+
+    expect(array_column(renderedRecords($html), 0))->toBe(['decision-09', 'decision-06'])
+        ->and(rootAttribute($html, 'data-pages'))->toBe('2', 'Three denies at two per page is two pages.');
+});
+
+it('shows a single page with no pagination controls when everything fits', function (): void {
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+    seedAuditEvidence(3);
+
+    $html = renderEvidence(':per-page="25"');
+
+    expect(rootAttribute($html, 'data-pages'))->toBe('1')
+        ->and(renderedRecords($html))->toHaveCount(3)
+        ->and($html)->not->toContain('data-page-link');
+});
+
+it('passes disposition and capability filters through to the read boundary', function (): void {
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+    seedAuditEvidence(6);
+    insertAuditEvidence(['id' => 'other-capability', 'capability' => 'billing.refund', 'disposition' => 'deny', 'recorded_at' => '2026-08-30 11:00:00']);
+
+    $denies = renderEvidence('disposition="deny"');
+    $billing = renderEvidence('capability="billing.refund"');
+
+    expect(array_column(renderedRecords($denies), 0))->toBe(['other-capability', 'decision-06', 'decision-03'])
+        ->and(array_column(renderedRecords($billing), 0))->toBe(['other-capability']);
+});
+
+/**
+ * Conversation scope rides on VC-14: a conversation the console never observed is reported as
+ * unknown — a statement about the console's projection, not about the evidence — never as empty.
+ */
+it('scopes to a conversation and states when the console never observed it', function (): void {
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+    seedAuditEvidence(10);
+    (new ConversationInvocationStore)->record('invocation-1', 'conversation-a');
+
+    $known = renderEvidence('conversation="conversation-a"');
+    $unknown = renderEvidence('conversation="conversation-never-seen"');
+
+    expect(rootAttribute($known, 'data-conversation'))->toBe('known')
+        ->and(array_column(renderedRecords($known), 0))->toBe(['decision-05', 'decision-04', 'decision-03', 'decision-02', 'decision-01'])
+        ->and(rootAttribute($unknown, 'data-conversation'))->toBe('unknown')
+        ->and($unknown)->toContain('never observed')
+        ->and($unknown)->not->toContain('<table')
+        ->and($unknown)->not->toContain('No decisions have been recorded.');
+});
+
+/** Fingerprints and digests are strings from a table a host controls; every one is drawn as text. */
+it('escapes every value it renders', function (): void {
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+    insertAuditEvidence([
+        'id' => 'escaped<u>id</u>',
+        'capability' => 'orders.<b>cancel</b>',
+        'stage' => 'pro<script>posal',
+        'disposition' => 'per"mit',
+        'claim_type' => 'policy.<i>denied</i> & "x"',
+        'record_digest' => 'digest<hr>value',
+        'invocation_id' => 'inv<img>ocation',
+        'recorded_at' => '2026-08-30 10:00:00',
+    ]);
+
+    $html = renderEvidence();
+
+    expect($html)->toContain('orders.&lt;b&gt;cancel&lt;/b&gt;')
+        ->and($html)->toContain('policy.&lt;i&gt;denied&lt;/i&gt; &amp; &quot;x&quot;')
+        ->and($html)->toContain('escaped&lt;u&gt;id&lt;/u&gt;')
+        ->and($html)->toContain('pro&lt;script&gt;posal')
+        ->and($html)->toContain('digest&lt;hr&gt;value')
+        ->and($html)->toContain('inv&lt;img&gt;ocation')
+        ->and($html)->not->toContain('<b>cancel</b>')
+        ->and($html)->not->toContain('<script>')
+        ->and($html)->not->toContain('<hr>')
+        ->and($html)->not->toContain('<img>')
+        ->and($html)->not->toContain('<u>id</u>')
+        ->and($html)->toContain('per&quot;mit')
+        ->and($html)->not->toContain('per"mit');
+});
+
+/**
+ * The recording-state statements outrank the correlation statement: a conversation filter under
+ * recording off or elsewhere still reports the recording fact — that is why the page is blank —
+ * while the correlation attribute stays visible for the UI that asked.
+ */
+it('reports the recording state first when a conversation filter meets recording off or elsewhere', function (): void {
+    (new ConversationInvocationStore)->record('invocation-1', 'conversation-a');
+
+    $off = renderEvidence('conversation="conversation-never-seen"');
+
+    expect(rootAttribute($off, 'data-recording'))->toBe('off')
+        ->and(rootAttribute($off, 'data-conversation'))->toBe('unknown')
+        ->and($off)->toContain('recording is off — blank by config.')
+        ->and($off)->not->toContain('never observed');
+
+    config()->set('verdict.evidence.writer', 'App\Evidence\ExternalWriter');
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+
+    $elsewhere = renderEvidence('conversation="conversation-a"');
+
+    expect(rootAttribute($elsewhere, 'data-recording'))->toBe('elsewhere')
+        ->and(rootAttribute($elsewhere, 'data-conversation'))->toBe('known')
+        ->and($elsewhere)->toContain('App\Evidence\ExternalWriter')
+        ->and($elsewhere)->not->toContain('<table');
+});
+
+it('publishes with the other views', function (): void {
+    $target = resource_path('views/vendor/verdict-console');
+
+    File::exists($target) && File::deleteDirectory($target);
+
+    $this->artisan('vendor:publish', ['--tag' => 'verdict-console-views', '--force' => true])->assertSuccessful();
+
+    expect(File::exists($target.'/components/evidence.blade.php'))->toBeTrue();
+
+    File::deleteDirectory($target);
+});


### PR DESCRIPTION
## Summary

The Blade audit/evidence page — the last v0.4.0 surface but one, and the one §6.6's blank-by-config rule was written for.

- **`<x-verdict-console::evidence />`** — a read-only, paginated audit table over the VC-13 read boundary, with `per-page` (default 25), `disposition`, `capability`, and `conversation` props. Everything it says — recording state, correlation, rows — is the **boundary's answer**, never config or Verdict's tables read directly (a test binds a fake boundary that contradicts both and the fake wins).
- **Four states, each a statement rather than an empty table**: recording off → the design's literal copy "recording is off — blank by config."; elsewhere → the configured writer named; a conversation the console never observed → "never observed" (a statement about the VC-14 projection, not the evidence); on-and-empty → "No decisions have been recorded."
- **Pagination**: newest first, from the `page` query parameter, over the *filtered* result (page count belongs to the filtered set); out-of-range pages render no rows without crashing; links preserve other query parameters; no controls on a single page. In-memory by design — VC-13 has no limit/offset, and a host with a huge table replaces `EvidenceQuery`, which is the seam (documented in the class docblock).
- Rows surface what the issue names — `claimType`, `recordDigest` — beside recorded-at (`<time datetime>`), capability, stage, disposition, and invocation id; decision records only; every value escaped (tested with hostile strings in all seven fields).
- **No gate of its own**: the evidence-display audience is host-governed; the design now says "the host embeds it behind its own authorization." No forms, no routes.

## Linked issue

Closes #20

## Trust and failure behavior

- Read-only: no untrusted input reaches anything but an `EvidenceFilter`; the `page`/query parameters affect slicing and links only.
- The fingerprint/digest values are host-table strings and are always Blade-escaped — attribute positions included (`data-disposition` with a quote in it is tested).
- Fail-honest rather than fail-silent: each unavailable state names its cause; none renders as "nothing happened".

## Evidence and data handling

- Shows only the display-safe projection VC-13 already exposes (fingerprints, digests, vocabulary). No reasons, no raw arguments, no identifiers beyond what Verdict's published schema carries.

## Verification

- [x] Success, denial, and relevant failure paths are tested.
- [x] Security containment and legitimate utility are both covered where applicable.
- [x] Documentation and `CHANGELOG.md` are updated.
- [x] `composer test` passes locally — phpstan clean, pint passed, type coverage 100%, **345 passed (1817 assertions)**.
- [x] No credentials, real customer data, or unredacted evidence are included.

The evidence fixture carries the same stub-parity guard as the query suite, so a new Verdict evidence migration fails these tests instead of silently leaving the fixture behind the real schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
