### PR TITLE
feat: Blade ops views — doctor, execution-claim queue, incident list (VC-22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Blade ops views (VC-22).** `<x-verdict-console::doctor />`,
+  `<x-verdict-console::execution-claims />`, and `<x-verdict-console::incidents />` render the
+  diagnostic findings, human-needed-first unresolved-claim queue, and durable incident ledger as
+  read-only operations views, closing the v0.4.0 Blade scope.
+
 - **Blade audit / evidence page (VC-20).** `<x-verdict-console::evidence />` renders the VC-13
   evidence boundary as a read-only, newest-first paginated audit table, preserving its recording and
   conversation-correlation states instead of reading configuration or Verdict tables directly.

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -370,6 +370,10 @@ free.
   thread again on reload. Its approval interrupt is inline through the approvals widget scoped to
   the conversation; resolution through VC-6's forms continues that thread on reload.
   It does not stream: streaming is the Livewire surface's job.
+  The read-only ops views are `<x-verdict-console::doctor />` for doctor findings including the #230
+  dead gate, `<x-verdict-console::execution-claims />` for the unresolved-claim queue with
+  human-needed work first, and `<x-verdict-console::incidents />` for the incident ledger;
+  a resolve form is follow-up work.
 - **Livewire (end-user, flagship):** chat with **inline approval cards** (stream → card mid-thread →
   resolve in-flow → resume), live inbox, live decision feed. *Feed depends on §6.6/§6.7.*
 - **Filament (ops console, a plugin):** approval **queue** Resource; evidence **browser** Resource

--- a/resources/views/components/doctor.blade.php
+++ b/resources/views/components/doctor.blade.php
@@ -1,0 +1,13 @@
+<section data-verdict-console="doctor" data-errors="{{ $errors }}" data-warnings="{{ $warnings }}">
+    @if ($findings === [])
+        <p data-clean>Every console precondition is satisfied.</p>
+    @else
+        @foreach ($findings as $finding)
+            <article data-finding="{{ $finding->code->value }}" data-severity="{{ $finding->severity->value }}">
+                <p data-field="subject">{{ $finding->subject }}</p>
+                <p data-field="summary">{{ $finding->summary }}</p>
+                <p data-field="fix">{{ $finding->fix }}</p>
+            </article>
+        @endforeach
+    @endif
+</section>

--- a/resources/views/components/execution-claims.blade.php
+++ b/resources/views/components/execution-claims.blade.php
@@ -1,0 +1,27 @@
+<section data-verdict-console="execution-claims">
+    @if ($claims === [])
+        <p data-empty>No unresolved Verdict execution claims.</p>
+    @else
+        <table>
+            <thead>
+                <tr>
+                    <th>ID</th><th>Capability</th><th>Policy</th><th>Status</th><th>Attempts</th><th>Fingerprint</th><th>Updated</th><th>Resolve</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach ($claims as $item)
+                    <tr data-claim="{{ $item->id }}" data-status="{{ $item->status }}">
+                        <td data-field="id">{{ $item->id }}</td>
+                        <td data-field="capability">{{ $item->capability }}</td>
+                        <td data-field="policy">{{ $item->policy }}</td>
+                        <td data-field="status">{{ $item->status }}</td>
+                        <td data-field="attempts">{{ $item->attemptCount }}</td>
+                        <td data-field="fingerprint">{{ $item->fingerprint }}</td>
+                        <td data-field="updated"><time datetime="{{ $item->updatedAt->format(DATE_ATOM) }}">{{ $item->updatedAt->format(DATE_ATOM) }}</time></td>
+                        <td><code>verdict:resolve-execution-claim {{ $item->id }}</code></td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    @endif
+</section>

--- a/resources/views/components/incidents.blade.php
+++ b/resources/views/components/incidents.blade.php
@@ -1,0 +1,20 @@
+<section data-verdict-console="incidents">
+    @if ($incidents === [])
+        <p data-empty>No incidents recorded.</p>
+    @else
+        <table>
+            <thead>
+                <tr><th>Source</th><th>Cause</th><th>Observed</th></tr>
+            </thead>
+            <tbody>
+                @foreach ($incidents as $incident)
+                    <tr data-incident="{{ $incident->id }}" data-source="{{ $incident->source }}">
+                        <td data-field="source">{{ $incident->source }}</td>
+                        <td data-field="cause">{{ $incident->cause }}</td>
+                        <td data-field="observed"><time datetime="{{ $incident->observed_at->utc()->format(DATE_ATOM) }}">{{ $incident->observed_at->utc()->format(DATE_ATOM) }}</time></td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    @endif
+</section>

--- a/src/Incidents/IncidentStore.php
+++ b/src/Incidents/IncidentStore.php
@@ -12,6 +12,21 @@ use Illuminate\Support\Str;
 /** Records anomaly observations without treating them as Verdict authority or workflow state. */
 final class IncidentStore
 {
+    /**
+     * The read the operations ledger draws from; inspecting a durable observation never records one.
+     *
+     * @return list<Incident>
+     */
+    public function latest(int $limit = 100): array
+    {
+        return array_values(Incident::query()
+            ->orderByDesc('observed_at')
+            ->orderByDesc('id')
+            ->limit(max(1, $limit))
+            ->get()
+            ->all());
+    }
+
     /** @param array<string, scalar|null> $context */
     public function record(string $source, string $cause, array $context = []): Incident
     {

--- a/src/View/Components/Doctor.php
+++ b/src/View/Components/Doctor.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\View\Components;
+
+use Fissible\VerdictConsole\Doctor\Doctor as DoctorService;
+use Fissible\VerdictConsole\Doctor\Finding;
+use Fissible\VerdictConsole\Doctor\Severity;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+/** Renders Doctor's single diagnostic run without deriving or changing any findings. */
+final class Doctor extends Component
+{
+    public function __construct(private DoctorService $doctor) {}
+
+    public function render(): View
+    {
+        $findings = $this->doctor->run();
+        $errors = count(array_filter($findings, fn (Finding $finding): bool => $finding->severity === Severity::Error));
+
+        return view('verdict-console::components.doctor', [
+            'errors' => $errors,
+            'findings' => $findings,
+            'warnings' => count($findings) - $errors,
+        ]);
+    }
+}

--- a/src/View/Components/ExecutionClaims.php
+++ b/src/View/Components/ExecutionClaims.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\View\Components;
+
+use Fissible\VerdictConsole\ExecutionClaims\ExecutionClaimItem;
+use Fissible\VerdictConsole\ExecutionClaims\ExecutionClaimService;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+/**
+ * Renders Verdict's unresolved-claim queue for operators.
+ *
+ * This component owns urgency ordering because the service preserves Verdict's raw updated_at
+ * order; indeterminate claims need human attention before merely claimed work. A resolve form is
+ * follow-up work, so this projection only names the existing authorized command.
+ */
+final class ExecutionClaims extends Component
+{
+    public function __construct(private ExecutionClaimService $claims) {}
+
+    public function render(): View
+    {
+        $claims = $this->claims->unresolved();
+
+        usort($claims, fn (ExecutionClaimItem $left, ExecutionClaimItem $right): int => [
+            $left->status !== 'indeterminate',
+            $left->updatedAt,
+        ] <=> [
+            $right->status !== 'indeterminate',
+            $right->updatedAt,
+        ]);
+
+        return view('verdict-console::components.execution-claims', ['claims' => $claims]);
+    }
+}

--- a/src/View/Components/Incidents.php
+++ b/src/View/Components/Incidents.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\View\Components;
+
+use Fissible\VerdictConsole\Incidents\IncidentStore;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+/** Reads the durable anomaly ledger; rendering it deliberately has no recording side effect. */
+final class Incidents extends Component
+{
+    public function __construct(
+        private IncidentStore $incidents,
+        private int $limit = 100,
+    ) {}
+
+    public function render(): View
+    {
+        return view('verdict-console::components.incidents', [
+            'incidents' => $this->incidents->latest($this->limit),
+        ]);
+    }
+}

--- a/tests/Feature/ConsoleRoutesTest.php
+++ b/tests/Feature/ConsoleRoutesTest.php
@@ -159,7 +159,10 @@ it('publishes the views under their own tag, into the vendor views directory', f
     $this->artisan('vendor:publish', ['--tag' => 'verdict-console-views', '--force' => true])->assertSuccessful();
 
     expect(File::exists($target.'/components/approvals.blade.php'))->toBeTrue()
-        ->and(File::exists($target.'/components/chat.blade.php'))->toBeTrue();
+        ->and(File::exists($target.'/components/chat.blade.php'))->toBeTrue()
+        ->and(File::exists($target.'/components/doctor.blade.php'))->toBeTrue()
+        ->and(File::exists($target.'/components/execution-claims.blade.php'))->toBeTrue()
+        ->and(File::exists($target.'/components/incidents.blade.php'))->toBeTrue();
 
     File::deleteDirectory($target);
 });

--- a/tests/Feature/DocumentationCorrectionsTest.php
+++ b/tests/Feature/DocumentationCorrectionsTest.php
@@ -132,6 +132,16 @@ it('names the evidence page in the design of record', function (): void {
         ->toContain('the host embeds it behind its own authorization');
 });
 
+/** The three ops screens close v0.4.0's Blade scope; the design must name them and their read-only stance. */
+it('names the Blade ops views in the design of record', function (): void {
+    expect(documentation('docs/design/0001-verdict-console-design.md'))
+        ->toContain('`<x-verdict-console::doctor />`')
+        ->toContain('`<x-verdict-console::execution-claims />`')
+        ->toContain('`<x-verdict-console::incidents />`')
+        ->toContain('read-only')
+        ->toContain('a resolve form is follow-up work');
+});
+
 /** Folded in from the VC-13 review: the UTC reading is a contract from verdict#335 onward, not a hope. */
 it('cites the Verdict change that makes the evidence timestamp reading a UTC contract', function (): void {
     expect(documentation('src/Evidence/DatabaseEvidenceQuery.php'))->toContain('fissible/verdict#335');

--- a/tests/Feature/IncidentListComponentTest.php
+++ b/tests/Feature/IncidentListComponentTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\VerdictConsole\Incidents\Incident;
+use Fissible\VerdictConsole\Incidents\IncidentStore;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The anomaly-incident list over the VC-15 ledger: Verdict's ephemeral events made durable, drawn
+ * newest first. Read-only; recording continues to happen in the listeners, never here.
+ */
+beforeEach(function (): void {
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_incidents_table.php.stub')->up();
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists('verdict_console_incidents');
+    Schema::dropIfExists('verdict_console_pending_approvals');
+});
+
+function opsIncident(string $source, string $cause, string $observedAt, array $context = []): Incident
+{
+    $incident = app(IncidentStore::class)->record($source, $cause, $context);
+    $incident->forceFill(['observed_at' => $observedAt])->save();
+
+    return $incident->fresh() ?? $incident;
+}
+
+it('lists incidents newest first with source, cause, and when they were observed', function (): void {
+    $older = opsIncident('evidence_write_failed', 'Write failed.', '2026-08-30 09:00:00', ['capability' => 'orders.refund']);
+    $newer = opsIncident('chain_write_failed', 'Append failed.', '2026-08-30 10:00:00');
+
+    // Rendering is a read: not one insert, update, or delete may run while the page draws.
+    $statements = [];
+    DB::listen(function (object $query) use (&$statements): void {
+        $statements[] = (string) $query->sql;
+    });
+
+    $html = (string) $this->blade('<x-verdict-console::incidents />');
+
+    expect(array_filter($statements, fn (string $sql): bool => preg_match('/^\s*(insert|update|delete)/i', $sql) === 1))
+        ->toBe([], 'The list must not write while rendering.');
+
+    preg_match_all('/<tr\b[^>]*\bdata-incident="([^"]+)"[^>]*\bdata-source="([^"]+)"/', $html, $m, PREG_SET_ORDER);
+
+    expect(array_map(fn (array $row): array => [$row[1], $row[2]], $m))->toBe([
+        [$newer->id, 'chain_write_failed'],
+        [$older->id, 'evidence_write_failed'],
+    ])
+        ->and($html)->toContain('data-field="cause"')
+        ->and($html)->toContain('Append failed.')
+        ->and($html)->toContain('datetime="2026-08-30T10:00:00+00:00"')
+        ->and($html)->not->toContain('<form');
+});
+
+/** The ledger's whole point (§6.7): an install with no incidents is a healthy statement, not a blank. */
+it('says no incidents have been recorded when the ledger is empty', function (): void {
+    $html = (string) $this->blade('<x-verdict-console::incidents />');
+
+    expect($html)->toContain('data-verdict-console="incidents"')
+        ->and($html)->toContain('data-empty')
+        ->and($html)->toContain('No incidents recorded.')
+        ->and($html)->not->toContain('<table');
+});
+
+it('honours a limit, newest first, and defaults to more than a handful', function (): void {
+    foreach (range(1, 6) as $i) {
+        opsIncident('evidence_write_failed', 'Failure '.$i, sprintf('2026-08-30 09:%02d:00', $i));
+    }
+
+    $limited = (string) $this->blade('<x-verdict-console::incidents :limit="2" />');
+
+    preg_match_all('/data-incident="([^"]+)"/', $limited, $m);
+
+    expect($m[1])->toHaveCount(2)
+        ->and($limited)->toContain('Failure 6')
+        ->and($limited)->toContain('Failure 5')
+        ->and($limited)->not->toContain('Failure 4');
+
+    $defaulted = (string) $this->blade('<x-verdict-console::incidents />');
+
+    preg_match_all('/data-incident="([^"]+)"/', $defaulted, $d);
+
+    expect($d[1])->toHaveCount(6, 'The default limit shows an ordinary ledger whole.');
+});
+
+/** Causes are host-adjacent free text; drawn as text, never markup. */
+it('escapes what it renders', function (): void {
+    opsIncident('approval_ingestion', 'cause <b>bold</b> & "quoted"', '2026-08-30 09:00:00', ['tool_call_id' => 'call<i>x</i>']);
+
+    $html = (string) $this->blade('<x-verdict-console::incidents />');
+
+    expect($html)->toContain('cause &lt;b&gt;bold&lt;/b&gt; &amp; &quot;quoted&quot;')
+        ->and($html)->not->toContain('<b>bold</b>')
+        ->and($html)->not->toContain('<i>x</i>');
+});

--- a/tests/Integration/OpsViewsTest.php
+++ b/tests/Integration/OpsViewsTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Actions\ActionEnvelope;
+use Fissible\Verdict\Capabilities\Capability;
+use Fissible\Verdict\Contracts\CapabilityAuthorizer;
+use Fissible\Verdict\Contracts\ExecutionClaimStore;
+use Fissible\Verdict\Decisions\Decision;
+use Fissible\Verdict\ExecutionClaims\ExecutionClaim;
+use Fissible\Verdict\ExecutionClaims\ExecutionClaimOutcome;
+use Fissible\Verdict\ExecutionClaims\ExecutionClaimStatus;
+use Fissible\Verdict\LaravelAi\VerdictApprovalMiddleware;
+use Fissible\Verdict\Testing\AllowAllApprovalAuthorizer;
+use Fissible\Verdict\VerdictManager;
+use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
+use Fissible\VerdictConsole\Contracts\ResumableAgents;
+use Fissible\VerdictConsole\Doctor\Doctor;
+use Fissible\VerdictConsole\Doctor\Finding;
+use Fissible\VerdictConsole\Doctor\Severity;
+use Laravel\Ai\Concerns\RemembersConversations as RemembersConversationsTrait;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasMiddleware;
+use Laravel\Ai\Contracts\RemembersConversations as RemembersConversationsContract;
+use Laravel\Ai\Promptable;
+
+/**
+ * The doctor screen and the execution-claim queue, rendered against the real Verdict container —
+ * the same tier their services are tested in. Both are read-only projections of VC-3 and VC-16.
+ */
+beforeEach(function (): void {
+    (require dirname(__DIR__, 2).'/vendor/laravel/ai/database/migrations/2026_01_11_000001_create_agent_conversations_table.php')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_conversation_invocations_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/vendor/fissible/verdict/database/migrations/create_verdict_execution_claims_table.php.stub')->up();
+
+    config()->set('verdict.approvals.authorizer', AllowAllApprovalAuthorizer::class);
+
+    $this->app->instance(CapabilityAuthorizer::class, new class implements CapabilityAuthorizer
+    {
+        public function decide(Capability $capability, ActionEnvelope $envelope, mixed $target): Decision
+        {
+            return Decision::permit('ops test');
+        }
+    });
+});
+
+/** Registered as resumable, has the approval middleware, binds nothing: two warnings by VC-3/#72. */
+final class OpsToollessAgent implements Agent, HasMiddleware, RemembersConversationsContract
+{
+    use Promptable;
+    use RemembersConversationsTrait;
+
+    public function instructions(): Stringable|string
+    {
+        return 'ops fixture';
+    }
+
+    /** @return array<int, object> */
+    public function middleware(): array
+    {
+        return [app(VerdictApprovalMiddleware::class)];
+    }
+}
+
+function opsClaimRow(string $id, ExecutionClaimStatus $status, string $recordedAt, string $capability = 'orders.refund', string $policy = 'refund-once'): ExecutionClaim
+{
+    $at = new DateTimeImmutable($recordedAt, new DateTimeZone('UTC'));
+
+    return new ExecutionClaim(
+        id: $id,
+        capability: $capability,
+        policy: $policy,
+        bindingFingerprint: hash('sha256', $id.'-binding'),
+        status: $status,
+        attemptCount: 1,
+        claimedAt: $at,
+        completedAt: null,
+        indeterminateAt: null,
+        releasedAt: null,
+        resolvedBy: null,
+        resolutionReason: null,
+        createdAt: $at,
+        updatedAt: $at,
+    );
+}
+
+function opsIndeterminateClaim(string $id, string $at, string $capability = 'orders.refund', string $policy = 'refund-once'): void
+{
+    $store = app(ExecutionClaimStore::class);
+    $store->claim(opsClaimRow($id, ExecutionClaimStatus::Claimed, $at, $capability, $policy));
+    $transition = $store->markIndeterminate($id, new DateTimeImmutable($at, new DateTimeZone('UTC')));
+
+    expect($transition->outcome)->toBe(ExecutionClaimOutcome::Indeterminate, 'Fixture: Verdict must have marked the claim indeterminate.');
+}
+
+function opsActiveClaim(string $id, string $at): void
+{
+    $transition = app(ExecutionClaimStore::class)->claim(opsClaimRow($id, ExecutionClaimStatus::Claimed, $at));
+
+    expect($transition->outcome)->toBe(ExecutionClaimOutcome::Claimed, 'Fixture: Verdict must have admitted the claim.');
+}
+
+function opsDocument(string $html): DOMXPath
+{
+    $document = new DOMDocument;
+    libxml_use_internal_errors(true);
+    $document->loadHTML('<?xml encoding="utf-8" ?>'.$html);
+    libxml_clear_errors();
+
+    return new DOMXPath($document);
+}
+
+/**
+ * The acceptance criterion the issue names: the doctor screen surfaces the #230 dead gate — a
+ * capability that asks for confirmation but declares no execution target, so it never pauses and
+ * never reaches the inbox. The screen renders VC-3's findings; it derives none of its own.
+ */
+it('surfaces a confirmable-without-target capability on the doctor screen', function (): void {
+    app(VerdictManager::class)->capability(
+        Capability::usingPolicy(
+            name: 'ops.dead-gate',
+            ability: 'update',
+            resolveTarget: fn (ActionEnvelope $e): object => new stdClass,
+        )
+            ->requiresConfirmation(fn (ActionEnvelope $e, object $t): array => ['id' => 1])
+            ->executeUsing(fn (): string => 'done'),
+    );
+
+    // A warning source alongside the error, so the screen is proven against a MIXED run.
+    $registry = new AgentResolverRegistry;
+    $registry->register('ops@v1', fn (): OpsToollessAgent => new OpsToollessAgent, fn (Agent $agent): bool => $agent instanceof OpsToollessAgent);
+    app()->instance(ResumableAgents::class, $registry);
+
+    // The screen is a projection of Doctor::run() — same rows, same order, same counts.
+    $expected = app(Doctor::class)->run();
+    $errors = count(array_filter($expected, fn (Finding $f): bool => $f->severity === Severity::Error));
+
+    expect($expected)->not->toBe([])
+        ->and($errors)->toBeGreaterThanOrEqual(1)
+        ->and(count($expected) - $errors)->toBeGreaterThanOrEqual(1, 'Fixture: the run must mix errors and warnings.');
+
+    $html = (string) $this->blade('<x-verdict-console::doctor />');
+    $xpath = opsDocument($html);
+    $rendered = [];
+
+    foreach ($xpath->query('//*[@data-finding]') ?: [] as $node) {
+        if ($node instanceof DOMElement) {
+            $rendered[] = [$node->getAttribute('data-finding'), $node->getAttribute('data-severity')];
+        }
+    }
+
+    expect($rendered)->toBe(array_map(fn (Finding $f): array => [$f->code->value, $f->severity->value], $expected));
+
+    $deadGate = $xpath->query('//*[@data-finding="confirmation_gate_cannot_pause"]');
+
+    expect($deadGate->length)->toBe(1)
+        ->and($deadGate[0]->getAttribute('data-severity'))->toBe('error')
+        ->and($deadGate[0]->textContent)->toContain('ops.dead-gate')
+        ->and($deadGate[0]->textContent)->toContain('never pauses')
+        // A finding renders its fix, or the screen is a list of problems with no way out.
+        ->and($deadGate[0]->textContent)->toContain('executionTarget');
+
+    preg_match('/<section\b[^>]*data-verdict-console="doctor"[^>]*data-errors="(\d+)"[^>]*data-warnings="(\d+)"/', $html, $m);
+
+    expect($m)->not->toBe([])
+        ->and((int) $m[1])->toBe($errors, 'The counts are the run\'s, not the rendered rows\'.')
+        ->and((int) $m[2])->toBe(count($expected) - $errors);
+});
+
+/** A clean wiring reads as the command's own words, not as an empty list of problems. */
+it('says every precondition is satisfied when the doctor finds nothing', function (): void {
+    $html = (string) $this->blade('<x-verdict-console::doctor />');
+
+    expect($html)->toContain('data-verdict-console="doctor"')
+        ->and($html)->toContain('data-errors="0"')
+        ->and($html)->toContain('Every console precondition is satisfied.')
+        ->and($html)->not->toContain('data-finding=');
+});
+
+it('lists unresolved claims with the indeterminate ones first', function (): void {
+    opsActiveClaim('claim-active-newer', '2026-08-30 12:05:00');
+    opsIndeterminateClaim('claim-needs-human', '2026-08-30 12:00:00');
+    opsIndeterminateClaim('claim-needs-human-too', '2026-08-30 12:03:00');
+    opsActiveClaim('claim-active-older', '2026-08-30 12:01:00');
+
+    $html = (string) $this->blade('<x-verdict-console::execution-claims />');
+    $xpath = opsDocument($html);
+    $order = [];
+
+    foreach ($xpath->query('//tr[@data-claim]') ?: [] as $row) {
+        if ($row instanceof DOMElement) {
+            $order[] = [$row->getAttribute('data-claim'), $row->getAttribute('data-status')];
+        }
+    }
+
+    // The indeterminate claim is the one that genuinely needs a person (design §8); it outranks
+    // recency. Within a status, oldest first: the longest-waiting work at the top.
+    expect($order)->toBe([
+        ['claim-needs-human', 'indeterminate'],
+        ['claim-needs-human-too', 'indeterminate'],
+        ['claim-active-older', 'claimed'],
+        ['claim-active-newer', 'claimed'],
+    ])
+        ->and($html)->toContain('data-field="capability"')
+        ->and($html)->toContain('orders.refund')
+        ->and($html)->toContain('data-field="policy"')
+        ->and($html)->toContain('refund-once')
+        ->and($html)->toContain('data-field="attempts"')
+        ->and($html)->toContain('datetime="2026-08-30T12:00:00+00:00"')
+        // The fingerprint is the evidence-correlation join (design §6.2), shown beside the raw id.
+        ->and($html)->toContain(hash('sha256', 'claim-needs-human'));
+});
+
+/**
+ * Read-only by scope: resolution stays with VC-16's authorized service, reached today through the
+ * artisan command the queue names per row. A resolve form is follow-up work, not this page.
+ */
+it('names the resolve command per claim instead of offering a form', function (): void {
+    opsIndeterminateClaim('claim-1', '2026-08-30 12:00:00');
+
+    $html = (string) $this->blade('<x-verdict-console::execution-claims />');
+
+    expect($html)->toContain('verdict:resolve-execution-claim claim-1')
+        ->and($html)->not->toContain('<form')
+        ->and($html)->not->toContain('<button');
+});
+
+/** Capability and policy names are host-authored strings; ids come from a table. All drawn as text. */
+it('escapes what the queue renders', function (): void {
+    opsIndeterminateClaim('claim-hostile', '2026-08-30 12:00:00', 'orders.<b>refund</b>', 'once & "only"');
+
+    $html = (string) $this->blade('<x-verdict-console::execution-claims />');
+
+    expect($html)->toContain('orders.&lt;b&gt;refund&lt;/b&gt;')
+        ->and($html)->toContain('once &amp; &quot;only&quot;')
+        ->and($html)->not->toContain('<b>refund</b>');
+});
+
+/** The doctor's subjects are host-authored too — a capability name renders as text, never markup. */
+it('escapes what the doctor screen renders', function (): void {
+    app(VerdictManager::class)->capability(
+        Capability::usingPolicy(
+            name: 'ops.<i>dead</i>-gate',
+            ability: 'update',
+            resolveTarget: fn (ActionEnvelope $e): object => new stdClass,
+        )
+            ->requiresConfirmation(fn (ActionEnvelope $e, object $t): array => ['id' => 1])
+            ->executeUsing(fn (): string => 'done'),
+    );
+
+    $html = (string) $this->blade('<x-verdict-console::doctor />');
+
+    expect($html)->toContain('ops.&lt;i&gt;dead&lt;/i&gt;-gate')
+        ->and($html)->not->toContain('<i>dead</i>');
+});
+
+it('says the queue is empty in the commands own words', function (): void {
+    $html = (string) $this->blade('<x-verdict-console::execution-claims />');
+
+    expect($html)->toContain('data-verdict-console="execution-claims"')
+        ->and($html)->toContain('data-empty')
+        ->and($html)->toContain('No unresolved Verdict execution claims.')
+        ->and($html)->not->toContain('<table');
+});


### PR DESCRIPTION
## Summary

The three read-only ops views — and the last issue in v0.4.0.

- **`<x-verdict-console::doctor />`** — a projection of `Doctor::run()`: same findings, same order, `data-errors`/`data-warnings` counted from the run rather than the rendered rows (tested against a mixed error-and-warning run). Each finding renders subject, summary, **and fix**; a clean wiring reads in the command's own words. The acceptance criterion is covered directly: a confirmable-without-target capability (#230's dead gate) surfaces as an error naming the capability and its fix.
- **`<x-verdict-console::execution-claims />`** — Verdict's unresolved-claim queue with the component-owned urgency ordering: **indeterminate before claimed** (the one bucket that genuinely needs a person — design §8), longest-waiting first within a bucket. Shows the sha256 fingerprint (the evidence-correlation join) beside the id, and names `verdict:resolve-execution-claim {id}` per row as the operator affordance — deliberately **no form**: resolution stays with VC-16's authorized service, and a resolve form is follow-up work (stated in the design).
- **`<x-verdict-console::incidents />`** — the VC-15 ledger newest first via a new `IncidentStore::latest(limit)` read (limit in the query, default 100). A test listens to every SQL statement during render and fails on any insert/update/delete — reading the ledger never writes it.
- All three: no forms, no routes, publishable views, everything escaped (hostile strings tested in doctor subjects, claim capability/policy, and incident causes).

## Linked issue

Closes #22

## Trust and failure behavior

- Read-only throughout; no untrusted input beyond a `limit` integer prop. Empty states are statements ("Every console precondition is satisfied." / "No unresolved Verdict execution claims." / "No incidents recorded."), never blank tables.
- The doctor screen derives nothing: the rendered list is asserted equal to `Doctor::run()`'s output, so presentation code cannot re-implement (or drift from) a diagnostic rule.

## Evidence and data handling

- Findings, claim metadata (names, counts, fingerprints, timestamps), and incident source/cause only. No arguments, no receipts, no evidence rows.

## Verification

- [x] Success, denial, and relevant failure paths are tested.
- [x] Security containment and legitimate utility are both covered where applicable.
- [x] Documentation and `CHANGELOG.md` are updated.
- [x] `composer test` passes locally — phpstan clean, pint passed, type coverage 100%, **357 passed (1887 assertions)**.
- [x] No credentials, real customer data, or unredacted evidence are included.

With this merged, every v0.4.0 issue is closed: the milestone is cuttable, and the `verdict-console-livewire` / `verdict-console-filament` adapter repos unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
