### PR TITLE
docs: the package split is by dependency, and completeness lives in core

### DIFF
--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -13,7 +13,7 @@ That convention **ended there** — the number space is shared with pull request
 after #48 (#51, #63, #67–#69) carry descriptive titles and no `VC-` prefix. Refer to them by issue
 number; do not mint new `VC-` numbers.
 
-Current version: `0.3.0` (released 2026-08-30; v0.1.0–v0.3.0 milestones closed). Release procedure: fissible standards in
+Current version: `0.4.0` (released 2026-08-30; v0.1.0–v0.4.0 milestones closed). Release procedure: fissible standards in
 [`fissible/.github`](https://github.com/fissible/.github).
 
 ## Core package `fissible/verdict-console`

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -391,13 +391,29 @@ free.
      [`src/VerdictManager.php` (requestConfirmation)]
   3. **Evidence-write / chain-gap alarms** off the §6.7 incident projection.
 
-## 9. Packaging — three packages
-- `fissible/verdict-console` — headless core (contracts, persistence, projections) **+ publishable
-  Blade stubs**, no Livewire types. Working UI on install.
+## 9. Packaging — three packages, one completeness rule
+- `fissible/verdict-console` — headless core (contracts, persistence, projections) **+ the complete
+  Blade surface set**, no Livewire types. Working UI on install.
 - `fissible/verdict-console-livewire`.
 - `fissible/verdict-console-filament` (heavy dep, correctly isolated).
 Blade forces no heavy dependency, so it lives in core, not a 4th package. Shared presentation goes in
 a small view/presenter layer, not by merging Livewire into core.
+
+**The split is by dependency, not by audience (amended 2026-08-30, at v0.4.0).** Bundling the
+adapters into core would make every host — API-only and Blade-only hosts included — carry
+`livewire/livewire` and `filament/filament`, and would couple a security-adjacent package's release
+stream to two fast-moving UI majors. §8's audience framing says where each engine *earns* an
+upgrade; it is not a coverage boundary, because every Livewire or Filament application is also a
+Blade application, so core's components already render inside both. The rule for all adapter work:
+
+- Core's Blade layer is the complete, dependency-free baseline. As of v0.4.0 it covers every
+  surface: inbox, chat thread, evidence page, doctor, execution-claim queue, incident list.
+- Every adapter surface is an upgrade of a core surface — liveness, streaming, panel-native
+  Resources — and never the only implementation of it.
+- A host on one engine installs core plus at most one adapter and has full coverage; a host with a
+  split architecture installs both adapters and leaves the duplicative tags unrendered.
+- No adapter issue is filed to reach "completeness"; completeness lives in core. An adapter issue
+  must name the upgrade its engine provides over the Blade baseline.
 
 ## 10. What it deliberately does NOT do
 Doesn't decide (Verdict) · doesn't persist conversations (Laravel AI) · doesn't define policy (app

--- a/tests/Feature/DocumentationCorrectionsTest.php
+++ b/tests/Feature/DocumentationCorrectionsTest.php
@@ -142,6 +142,18 @@ it('names the Blade ops views in the design of record', function (): void {
         ->toContain('a resolve form is follow-up work');
 });
 
+/**
+ * The adapter-layering decision (2026-08-30): the package split is by dependency, and single-engine
+ * completeness lives in core. Adapter planning must answer to this rule, so it is pinned.
+ */
+it('records that core is the complete baseline and adapters are upgrades', function (): void {
+    expect(documentation('docs/design/0001-verdict-console-design.md'))
+        ->toContain('complete, dependency-free baseline')
+        ->toContain('an upgrade of a core surface')
+        ->toContain('never the only implementation of it')
+        ->toContain('The split is by dependency, not by audience');
+});
+
 /** Folded in from the VC-13 review: the UTC reading is a contract from verdict#335 onward, not a hope. */
 it('cites the Verdict change that makes the evidence timestamp reading a UTC contract', function (): void {
     expect(documentation('src/Evidence/DatabaseEvidenceQuery.php'))->toContain('fissible/verdict#335');


### PR DESCRIPTION
## Summary

Design §9 amendment following the question raised after v0.4.0: why are the UI adapters separate packages, and must a project adopt the Blade/Livewire/Filament split to get full coverage?

- **The split is by dependency, not by audience**: bundling would make every host carry `livewire/livewire` and `filament/filament` and couple a security-adjacent package to two fast-moving UI majors.
- **Completeness lives in core**: as of v0.4.0 the Blade layer covers every surface, and every Livewire/Filament app is also a Blade app — so a single-engine host installs core plus at most one adapter and has full coverage.
- **Adapters are upgrades**: liveness, streaming, panel-native Resources — never the only implementation of a surface, and no adapter issue is filed for "completeness".
- Pinned by a DocumentationCorrectionsTest assertion, per the repo convention for decisions.
- Also records v0.4.0 as the current release in MILESTONES.md (v0.1.0–v0.4.0 milestones closed).

## Linked issue

None — design decision + release bookkeeping.

## Trust and failure behavior

Docs and a docs test only.

## Evidence and data handling

None.

## Verification

- [x] DocumentationCorrectionsTest green; docs-only otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)