### PR TITLE
feat: capture the receipt's approval_context at ingestion (VC-68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Capture `approval_context` at ingestion (VC-68).** The pause row gains a nullable
+  `approval_context` column (its own published migration — released migrations are never amended)
+  holding the receipt's application-owned binding identifiers, read once at ingestion through
+  `ApprovalStatusReader::statusFor()` and captured verbatim; Verdict documents the field as
+  immutable after issue, so the one-time copy cannot go stale and mirrors no receipt status or
+  expiry. An identifier-less issuance records `[]`; `null` is reserved for receipts predating
+  capture. A host that composer-updates before running the migration still indexes every pause —
+  the store omits the column it cannot write instead of failing ingestion.
+
 - **Adopt Verdict's approval read contract (VC-45).** Approval status is now read through
   `ApprovalStatusReader` (verdict#298, ADR 0031): the inbox and chat interrupt render
   `already_decided` (with the persisted receipt status), `lapsed_undecided` (deadline compared by

--- a/database/migrations/add_approval_context_to_verdict_console_pending_approvals_table.php.stub
+++ b/database/migrations/add_approval_context_to_verdict_console_pending_approvals_table.php.stub
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Immutable receipt correlation annotation (VC-68, design §5).
+ *
+ * **A second migration, not an amendment to the first.** Released migrations have run for every
+ * adopter, so adding a column to an earlier stub reaches new installs only and silently divides
+ * their schema from existing installations.
+ *
+ * Verdict's approval context is captured once at ingestion because its contract makes it immutable
+ * after issue. It is a correlation annotation, not mirrored receipt status or expiry; those remain
+ * live Verdict reads (design §5).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('verdict_console_pending_approvals', function (Blueprint $table): void {
+            $table->json('approval_context')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('verdict_console_pending_approvals', function (Blueprint $table): void {
+            $table->dropColumn('approval_context');
+        });
+    }
+};

--- a/src/Approvals/PendingApproval.php
+++ b/src/Approvals/PendingApproval.php
@@ -25,6 +25,7 @@ use Illuminate\Support\Carbon;
  * @property string|null $invocation_id
  * @property string|null $resolver_key
  * @property array<string, mixed>|null $presentation
+ * @property array<string, string|int>|null $approval_context
  * @property Resumability $resumability
  * @property UnresumableReason|null $unresumable_reason
  * @property int $resume_attempts
@@ -63,6 +64,7 @@ final class PendingApproval extends Model
     {
         return [
             'presentation' => 'array',
+            'approval_context' => 'array',
             'resumability' => Resumability::class,
             'unresumable_reason' => UnresumableReason::class,
             'last_resume_attempt_at' => 'datetime',

--- a/src/Approvals/PendingApprovalStore.php
+++ b/src/Approvals/PendingApprovalStore.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Fissible\VerdictConsole\Approvals;
 
 use Fissible\VerdictConsole\Contracts\ApprovalScope;
+use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use LogicException;
 
 /**
  * Writes and reads the console's index of paused approvals.
@@ -19,6 +21,15 @@ use Illuminate\Support\Str;
 final class PendingApprovalStore
 {
     private ApprovalScope $scope;
+
+    /**
+     * Null until the first insert checks whether the host has run VC-68's published migration.
+     *
+     * Composer can update package code before the host runs its migrations. During that interval
+     * this console must still index a pause rather than fail every ingestion; after migration, a
+     * worker restart gives the process the new schema as usual.
+     */
+    private ?bool $hasApprovalContextColumn = null;
 
     public function __construct(?ApprovalScope $scope = null)
     {
@@ -65,6 +76,8 @@ final class PendingApprovalStore
      * Laravel AI's participant object and never interprets it — see the migration for why.
      *
      * @param  array<string, mixed>|null  $presentation
+     * @param  array<string, string|int>|null  $approvalContext  Host/application-owned binding
+     *                                                           identifiers, captured verbatim. Like every other ingest field, it is first-write-wins.
      */
     public function ingest(
         string $toolCallId,
@@ -76,6 +89,7 @@ final class PendingApprovalStore
         ?array $presentation = null,
         Resumability $resumability = Resumability::Unresumable,
         ?UnresumableReason $unresumableReason = null,
+        ?array $approvalContext = null,
     ): PendingApproval {
         return $this->ingestWithOutcome(
             toolCallId: $toolCallId,
@@ -87,6 +101,7 @@ final class PendingApprovalStore
             presentation: $presentation,
             resumability: $resumability,
             unresumableReason: $unresumableReason,
+            approvalContext: $approvalContext,
         )->pendingApproval;
     }
 
@@ -97,6 +112,8 @@ final class PendingApprovalStore
      * concurrent redelivery. Callers that only need the durable row use {@see ingest()}.
      *
      * @param  array<string, mixed>|null  $presentation
+     * @param  array<string, string|int>|null  $approvalContext  Host/application-owned binding
+     *                                                           identifiers, captured verbatim. Like every other ingest field, it is first-write-wins.
      */
     public function ingestWithOutcome(
         string $toolCallId,
@@ -108,12 +125,13 @@ final class PendingApprovalStore
         ?array $presentation = null,
         Resumability $resumability = Resumability::Unresumable,
         ?UnresumableReason $unresumableReason = null,
+        ?array $approvalContext = null,
     ): PendingApprovalIngestion {
         $ingestKey = PendingApproval::ingestKey($toolCallId, $conversationId);
         $now = now();
 
         try {
-            PendingApproval::query()->insert([
+            $attributes = [
                 'id' => Str::uuid()->toString(),
                 'ingest_key' => $ingestKey,
                 'receipt_id' => $receiptId,
@@ -127,7 +145,13 @@ final class PendingApprovalStore
                 'unresumable_reason' => $resumability === Resumability::Drivable ? null : $unresumableReason?->value,
                 'created_at' => $now,
                 'updated_at' => $now,
-            ]);
+            ];
+
+            if ($this->hasApprovalContextColumn()) {
+                $attributes['approval_context'] = $approvalContext === null ? null : json_encode($approvalContext, JSON_THROW_ON_ERROR);
+            }
+
+            PendingApproval::query()->insert($attributes);
         } catch (UniqueConstraintViolationException $e) {
             // Read back by the natural key rather than trusting the id generated above: whoever won
             // the race wrote a different one, and theirs is the row that matters.
@@ -144,6 +168,25 @@ final class PendingApprovalStore
             $this->correlationQuery()->where('ingest_key', $ingestKey)->sole(),
             true,
         );
+    }
+
+    /**
+     * Whether the current host schema includes VC-68's published column.
+     *
+     * The result is deliberately memoized. A long-running worker started before the migration must
+     * be restarted after it, just as it must be for any schema change.
+     */
+    private function hasApprovalContextColumn(): bool
+    {
+        $connection = PendingApproval::query()->getConnection();
+
+        if (! $connection instanceof Connection) {
+            throw new LogicException('The pending approval connection does not support schema inspection.');
+        }
+
+        return $this->hasApprovalContextColumn ??= $connection
+            ->getSchemaBuilder()
+            ->hasColumn((new PendingApproval)->getTable(), 'approval_context');
     }
 
     /**

--- a/src/Listeners/IngestToolApprovalRequests.php
+++ b/src/Listeners/IngestToolApprovalRequests.php
@@ -6,6 +6,7 @@ namespace Fissible\VerdictConsole\Listeners;
 
 use Fissible\Verdict\Approvals\ApprovalChallenge;
 use Fissible\Verdict\Approvals\ApprovalManager;
+use Fissible\Verdict\Contracts\ApprovalStatusReader;
 use Fissible\VerdictConsole\Approvals\ApprovalNotificationDispatcher;
 use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
 use Fissible\VerdictConsole\Approvals\Resumability;
@@ -30,6 +31,7 @@ final readonly class IngestToolApprovalRequests
 {
     public function __construct(
         private ApprovalManager $approvals,
+        private ApprovalStatusReader $statuses,
         private ResumableAgents $resumableAgents,
         private ConversationParticipants $participants,
         private ApprovalPresenter $presenter,
@@ -72,6 +74,7 @@ final readonly class IngestToolApprovalRequests
         // all collapse here and no permitted public API separates them.
         $challenge = $this->approvals->challengeForToolCall($approval->id);
         [$resolverKey, $participantReference, $reason] = $this->resumability($event, $challenge);
+        $approvalContext = $this->approvalContext($challenge);
 
         try {
             $outcome = $this->pendingApprovals->ingestWithOutcome(
@@ -84,6 +87,7 @@ final readonly class IngestToolApprovalRequests
                 presentation: $this->presentation($approval, $challenge),
                 resumability: $reason === null ? Resumability::Drivable : Resumability::Unresumable,
                 unresumableReason: $reason,
+                approvalContext: $approvalContext,
             );
         } catch (UniqueConstraintViolationException $e) {
             throw ApprovalReceiptCollision::forToolCall($approval->id, $e);
@@ -101,6 +105,23 @@ final readonly class IngestToolApprovalRequests
         if ($reason !== null && $outcome->created) {
             $this->events->dispatch(new ApprovalIngestionIncident($outcome->pendingApproval, $reason));
         }
+    }
+
+    /**
+     * Capture the immutable context through Verdict's read boundary.
+     *
+     * `ApprovalChallenge` does not carry this field, and design §5 forbids a store read. A null
+     * status from a challenged receipt that predates capture is a storage era, not a disclosure
+     * state. Reading by the exact receipt answered by the challenge also means an ambiguous tool
+     * call id cannot attach another receipt's context.
+     *
+     * @return array<string, string|int>|null
+     */
+    private function approvalContext(?ApprovalChallenge $challenge): ?array
+    {
+        return $challenge === null
+            ? null
+            : $this->statuses->statusFor($challenge->receiptId)?->approvalContext;
     }
 
     /** @return array{0: string|null, 1: string|null, 2: UnresumableReason|null} */

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -174,6 +174,9 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
             __DIR__.'/../database/migrations/create_verdict_console_conversation_invocations_table.php.stub' => database_path(
                 'migrations/2026_08_29_000001_create_verdict_console_conversation_invocations_table.php',
             ),
+            __DIR__.'/../database/migrations/add_approval_context_to_verdict_console_pending_approvals_table.php.stub' => database_path(
+                'migrations/2026_08_30_000001_add_approval_context_to_verdict_console_pending_approvals_table.php',
+            ),
         ], ['verdict-console', 'verdict-console-migrations']);
     }
 }

--- a/tests/Configuration/IncidentLoggingConfigurationTest.php
+++ b/tests/Configuration/IncidentLoggingConfigurationTest.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Schema;
 beforeEach(function (): void {
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
     (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_approval_context_to_verdict_console_pending_approvals_table.php.stub')->up();
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_incidents_table.php.stub')->up();
 });
 

--- a/tests/EndToEnd/ApprovalInboxHttpTest.php
+++ b/tests/EndToEnd/ApprovalInboxHttpTest.php
@@ -545,15 +545,17 @@ it('relays a close that found a live decision still available, deciding nothing'
 });
 
 /**
- * VC-68's null half against a real receipt: this file's fixture binds a plain ActionContext, so
- * Verdict stores the receipt with no `approval_context` — the pre-adoption storage era. The row
- * records null, a storage era rather than a disclosure state, and invents nothing.
+ * VC-68's empty half against a real receipt, measured rather than assumed: `ActionContext`'s
+ * `approvalContext` is a non-nullable array defaulting to `[]`, and Verdict persists that as
+ * `'[]'` and hydrates it back as `[]` — so a plain fixture yields an empty context captured
+ * verbatim. Null stays reserved for the true pre-capture storage era: rows written before the
+ * column existed, which no freshly issued receipt can produce.
  */
-it('records a null approval context for a receipt issued without one', function (): void {
+it('records an empty approval context for a receipt issued without identifiers', function (): void {
     $row = pausedInboxRow();
 
     expect($row->receipt_id)->not->toBeNull()
-        ->and($row->approval_context)->toBeNull();
+        ->and($row->approval_context)->toBe([]);
 });
 
 /** The widget over a real pause: the row is drivable and offers exactly approve and reject. */

--- a/tests/EndToEnd/ApprovalInboxHttpTest.php
+++ b/tests/EndToEnd/ApprovalInboxHttpTest.php
@@ -189,6 +189,7 @@ beforeEach(function (): void {
     $console = dirname(__DIR__, 2).'/database/migrations';
     (require $console.'/create_verdict_console_pending_approvals_table.php.stub')->up();
     (require $console.'/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require $console.'/add_approval_context_to_verdict_console_pending_approvals_table.php.stub')->up();
     (require $console.'/create_verdict_console_approval_notifications_table.php.stub')->up();
     (require $console.'/create_verdict_console_approval_reconciliations_table.php.stub')->up();
 
@@ -541,6 +542,18 @@ it('relays a close that found a live decision still available, deciding nothing'
         ->and(app(VerdictManager::class)->approvals()->challengeForToolCall('call_inbox'))->not->toBeNull();
 
     Http::assertSentCount(1);
+});
+
+/**
+ * VC-68's null half against a real receipt: this file's fixture binds a plain ActionContext, so
+ * Verdict stores the receipt with no `approval_context` — the pre-adoption storage era. The row
+ * records null, a storage era rather than a disclosure state, and invents nothing.
+ */
+it('records a null approval context for a receipt issued without one', function (): void {
+    $row = pausedInboxRow();
+
+    expect($row->receipt_id)->not->toBeNull()
+        ->and($row->approval_context)->toBeNull();
 });
 
 /** The widget over a real pause: the row is drivable and offers exactly approve and reject. */

--- a/tests/EndToEnd/ApprovalRoundTripTest.php
+++ b/tests/EndToEnd/ApprovalRoundTripTest.php
@@ -9,11 +9,14 @@ use Fissible\Verdict\Approvals\ApprovalChallenge;
 use Fissible\Verdict\Approvals\ApprovalDecisionKind;
 use Fissible\Verdict\Approvals\ApprovalOutcome;
 use Fissible\Verdict\Approvals\ApprovalReceipt;
+use Fissible\Verdict\Approvals\ApprovalReceiptStatus;
+use Fissible\Verdict\Approvals\ApprovalStatusView;
 use Fissible\Verdict\Approvals\ApprovalTransition;
 use Fissible\Verdict\Capabilities\Capability;
 use Fissible\Verdict\Capabilities\CapabilityRegistry;
 use Fissible\Verdict\Contracts\ApprovalDecisionAuthorizer;
 use Fissible\Verdict\Contracts\ApprovalReceiptStore;
+use Fissible\Verdict\Contracts\ApprovalStatusReader;
 use Fissible\Verdict\Contracts\CapabilityAuthorizer;
 use Fissible\Verdict\Decisions\Decision;
 use Fissible\Verdict\Exceptions\ApprovalAuthorizerMissing;
@@ -89,6 +92,52 @@ const ORDER_ID = 1001;
 final class RoundTripLedger
 {
     public int $executions = 0;
+}
+
+/** Forces context per read path, so which reader method ingestion used is observable in the row. */
+final class RoundTripForcedStatuses implements ApprovalStatusReader
+{
+    /** @var list<string> every read made through this reader, in order, as "method:key" */
+    public array $reads = [];
+
+    public function statusFor(string $receiptId): ?ApprovalStatusView
+    {
+        $this->reads[] = 'statusFor:'.$receiptId;
+
+        return $this->view($receiptId, ['captured' => 'by-receipt-id']);
+    }
+
+    public function statusForToolCall(string $toolCallId): ?ApprovalStatusView
+    {
+        $this->reads[] = 'statusForToolCall:'.$toolCallId;
+
+        return $this->view('receipt-of-'.$toolCallId, ['captured' => 'by-tool-call']);
+    }
+
+    public function pendingWithin(array $scope): array
+    {
+        return [];
+    }
+
+    /** @param array<string, string|int> $context */
+    private function view(string $receiptId, array $context): ApprovalStatusView
+    {
+        return new ApprovalStatusView(
+            receiptId: $receiptId,
+            toolCallId: TOOL_CALL_ID,
+            capability: 'orders.cancel',
+            status: ApprovalReceiptStatus::Pending,
+            reason: null,
+            expiresAt: new DateTimeImmutable('2030-01-02T03:04:05+00:00'),
+            approvedBy: null,
+            approvedAt: null,
+            rejectedBy: null,
+            rejectedAt: null,
+            consumedAt: null,
+            createdAt: new DateTimeImmutable('2026-08-30T09:00:00+00:00'),
+            approvalContext: $context,
+        );
+    }
 }
 
 final readonly class RoundTripOrder
@@ -333,7 +382,8 @@ function roundTripTool(): Tool
         );
     }
 
-    return $verdict->bound(new CancelOrderTool, 'orders.cancel', new ActionContext('customer-7'));
+    // The application-owned binding identifiers Verdict stamps onto the receipt (verdict#305).
+    return $verdict->bound(new CancelOrderTool, 'orders.cancel', new ActionContext('customer-7', approvalContext: ['tenant' => 'acme', 'workspace' => 7]));
 }
 
 /**
@@ -476,6 +526,7 @@ beforeEach(function (): void {
     $this->migrateRoundTripTables();
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
     (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_approval_context_to_verdict_console_pending_approvals_table.php.stub')->up();
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_approval_notifications_table.php.stub')->up();
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_approval_reconciliations_table.php.stub')->up();
 
@@ -882,6 +933,60 @@ it('persists an ingestion incident when the paused approval cannot be resumed', 
         ->source->toBe('approval_ingestion')
         ->cause->toBe(UnresumableReason::ChallengeUnavailable->value)
         ->context->toBe(json_encode(['tool_call_id' => 'warning-log-call']));
+});
+
+/**
+ * VC-68: the receipt's `approval_context` is captured onto the row at ingestion through the
+ * boundary-respecting read (`ApprovalStatusReader::statusFor()`), verbatim, ints included. It is
+ * a correlation annotation for host scoping (VC-69), never mirrored status: Verdict documents the
+ * field as immutable after issue, which is exactly why a one-time copy cannot go stale.
+ */
+it('captures the receipt approval context onto the row at ingestion', function (): void {
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->toolCallResponse(TOOL_CALL_ID, 'CancelOrderTool', ['order_id' => ORDER_ID])),
+    ]);
+
+    pauseForApproval((new RoundTripAgent)->forParticipant(new RoundTripCustomer(7)));
+
+    $row = StoredPendingApproval::query()->sole();
+
+    expect($row->receipt_id)->not->toBeNull()
+        ->and($row->approval_context)->toBe(['tenant' => 'acme', 'workspace' => 7]);
+});
+
+/** A pause with no receipt has no context to read; the column stays null rather than inventing one. */
+it('records a null approval context for a receiptless pause', function (): void {
+    event(new ToolApprovalRequested(
+        invocationId: 'context-less-invocation',
+        agent: new RoundTripAgent,
+        pendingApprovals: collect([new LaravelPendingApproval('context-less-call', 'host_only_tool', [])]),
+        conversationId: 'context-less-conversation',
+    ));
+
+    expect(StoredPendingApproval::query()->sole()->approval_context)->toBeNull();
+});
+
+/**
+ * The capture read is `statusFor()` keyed by the exact receipt the challenge answered for — never
+ * the ambiguous tool-call lookup and never another source. A reader whose two methods return
+ * different context makes the routing observable: the row must carry the receipt-id answer, and
+ * the read trace must show exactly that one call.
+ */
+it('captures context through statusFor with the challenged receipt id, nothing else', function (): void {
+    $statuses = new RoundTripForcedStatuses;
+    app()->instance(ApprovalStatusReader::class, $statuses);
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->toolCallResponse(TOOL_CALL_ID, 'CancelOrderTool', ['order_id' => ORDER_ID])),
+    ]);
+
+    pauseForApproval((new RoundTripAgent)->forParticipant(new RoundTripCustomer(7)));
+
+    $row = StoredPendingApproval::query()->sole();
+
+    expect($row->approval_context)->toBe(['captured' => 'by-receipt-id'])
+        ->and($statuses->reads)->toBe(['statusFor:'.$row->receipt_id]);
 });
 
 /** The manager intentionally collapses an expired receipt and an absent one into the same null. */

--- a/tests/EndToEnd/ChatServiceTest.php
+++ b/tests/EndToEnd/ChatServiceTest.php
@@ -244,6 +244,7 @@ beforeEach(function (): void {
     $console = dirname(__DIR__, 2).'/database/migrations';
     (require $console.'/create_verdict_console_pending_approvals_table.php.stub')->up();
     (require $console.'/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require $console.'/add_approval_context_to_verdict_console_pending_approvals_table.php.stub')->up();
     (require $console.'/create_verdict_console_approval_notifications_table.php.stub')->up();
     (require $console.'/create_verdict_console_approval_reconciliations_table.php.stub')->up();
 

--- a/tests/EndToEnd/ChatThreadTest.php
+++ b/tests/EndToEnd/ChatThreadTest.php
@@ -230,6 +230,7 @@ beforeEach(function (): void {
     $console = dirname(__DIR__, 2).'/database/migrations';
     (require $console.'/create_verdict_console_pending_approvals_table.php.stub')->up();
     (require $console.'/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require $console.'/add_approval_context_to_verdict_console_pending_approvals_table.php.stub')->up();
     (require $console.'/create_verdict_console_approval_notifications_table.php.stub')->up();
     (require $console.'/create_verdict_console_approval_reconciliations_table.php.stub')->up();
 

--- a/tests/EndToEnd/EvidenceCorrelationTest.php
+++ b/tests/EndToEnd/EvidenceCorrelationTest.php
@@ -164,6 +164,7 @@ beforeEach(function (): void {
     $console = dirname(__DIR__, 2).'/database/migrations';
     (require $console.'/create_verdict_console_pending_approvals_table.php.stub')->up();
     (require $console.'/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require $console.'/add_approval_context_to_verdict_console_pending_approvals_table.php.stub')->up();
     (require $console.'/create_verdict_console_approval_notifications_table.php.stub')->up();
     (require $console.'/create_verdict_console_approval_reconciliations_table.php.stub')->up();
 

--- a/tests/Feature/ApprovalInboxComponentTest.php
+++ b/tests/Feature/ApprovalInboxComponentTest.php
@@ -224,6 +224,7 @@ function renderedVerbs(string $row): array
 beforeEach(function (): void {
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
     (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_approval_context_to_verdict_console_pending_approvals_table.php.stub')->up();
 
     $this->statuses = new InboxStatuses;
     $this->challenges = new InboxChallenges;

--- a/tests/Feature/ApprovalItemTest.php
+++ b/tests/Feature/ApprovalItemTest.php
@@ -120,6 +120,7 @@ function challenge(?ProposalProvenance $provenance = null): ApprovalChallenge
 beforeEach(function (): void {
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
     (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_approval_context_to_verdict_console_pending_approvals_table.php.stub')->up();
 
     $this->store = new PendingApprovalStore;
     $this->approval = $this->store->ingest(

--- a/tests/Feature/ApprovalNotificationStoreTest.php
+++ b/tests/Feature/ApprovalNotificationStoreTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Schema;
 beforeEach(function (): void {
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
     (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_approval_context_to_verdict_console_pending_approvals_table.php.stub')->up();
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_approval_notifications_table.php.stub')->up();
 
     $this->approvals = new PendingApprovalStore;

--- a/tests/Feature/ApprovalReconciliationStoreTest.php
+++ b/tests/Feature/ApprovalReconciliationStoreTest.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Schema;
 beforeEach(function (): void {
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
     (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_approval_context_to_verdict_console_pending_approvals_table.php.stub')->up();
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_approval_reconciliations_table.php.stub')->up();
 
     $this->approvals = new PendingApprovalStore;

--- a/tests/Feature/ApprovalScopeTest.php
+++ b/tests/Feature/ApprovalScopeTest.php
@@ -22,6 +22,7 @@ final readonly class ConversationApprovalScope implements ApprovalScope
 
 beforeEach(function (): void {
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_approval_context_to_verdict_console_pending_approvals_table.php.stub')->up();
 });
 
 it('keeps correlation reads available while hiding another tenant approval', function (): void {

--- a/tests/Feature/ApprovalVerbsTest.php
+++ b/tests/Feature/ApprovalVerbsTest.php
@@ -45,6 +45,7 @@ function verbsStatusView(
 beforeEach(function (): void {
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
     (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_approval_context_to_verdict_console_pending_approvals_table.php.stub')->up();
 
     $this->approvals = new PendingApprovalStore;
     $this->verbs = new ApprovalVerbs($this->approvals);

--- a/tests/Feature/MigrationPublishingTest.php
+++ b/tests/Feature/MigrationPublishingTest.php
@@ -49,12 +49,14 @@ it('publishes every migration, in an order that can actually run', function (): 
         ->sort()
         ->values();
 
-    expect($published)->toHaveCount(6);
+    expect($published)->toHaveCount(7);
 
     $position = fn (string $fragment): int => $published->search(fn (string $name): bool => str_contains($name, $fragment));
 
     expect($position('create_verdict_console_pending_approvals_table'))
         ->toBeLessThan($position('add_operational_state_to_verdict_console_pending_approvals_table'), 'A column cannot be added to a table that does not exist yet.')
+        ->and($position('create_verdict_console_pending_approvals_table'))
+        ->toBeLessThan($position('add_approval_context_to_verdict_console_pending_approvals_table'), 'A column cannot be added to a table that does not exist yet.')
         ->and($position('create_verdict_console_pending_approvals_table'))
         ->toBeLessThan($position('create_verdict_console_approval_notifications_table'), 'The notifications foreign key requires the pause table.')
         ->and($position('create_verdict_console_pending_approvals_table'))
@@ -77,11 +79,17 @@ it('leaves the released create migration alone and adds operational state separa
     $create = file_get_contents(dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub');
     $added = file_get_contents(dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub');
 
+    $context = file_get_contents(dirname(__DIR__, 2).'/database/migrations/add_approval_context_to_verdict_console_pending_approvals_table.php.stub');
+
     expect($create)->not->toContain('resume_attempts', 'v0.1.0 shipped without this column; adding it here reaches new installs only.')
         ->and($create)->not->toContain('last_resume_attempt_at')
         ->and($create)->not->toContain('conversation_invocations', 'The correlation projection is its own table in its own migration, not a fold-in.')
+        ->and($create)->not->toContain('approval_context', 'The v0.4.0-era create migration has run for every adopter; VC-68 is its own file.')
         ->and($added)->toContain('resume_attempts')
-        ->and($added)->toContain('last_resume_attempt_at');
+        ->and($added)->toContain('last_resume_attempt_at')
+        ->and($added)->not->toContain('approval_context', 'The operational-state migration shipped in v0.2.0; VC-68 must not be folded into it.')
+        ->and($context)->toContain('approval_context')
+        ->and($context)->toContain('nullable');
 });
 
 /**

--- a/tests/Feature/PendingApprovalStoreTest.php
+++ b/tests/Feature/PendingApprovalStoreTest.php
@@ -182,6 +182,28 @@ it('keeps the originally captured approval context when the same pause is redeli
         ->and(PendingApproval::query()->count())->toBe(1);
 });
 
+/**
+ * Composer can update this package before the host runs VC-68's published migration. During that
+ * interval a pause must still be indexed — a lost row is a stranded human decision — so the store
+ * omits the column it cannot write rather than failing every ingestion. Verdict's own receipt
+ * store tolerates the same interval the same way.
+ */
+it('still indexes a pause when the host has not yet run the approval-context migration', function (): void {
+    Schema::dropIfExists('verdict_console_pending_approvals');
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+
+    $row = (new PendingApprovalStore)->ingest(
+        toolCallId: 'call_1',
+        conversationId: 'conv_1',
+        approvalContext: ['tenant' => 'acme'],
+    );
+
+    expect(Schema::hasColumn('verdict_console_pending_approvals', 'approval_context'))->toBeFalse()
+        ->and($row->exists)->toBeTrue()
+        ->and(PendingApproval::query()->count())->toBe(1);
+});
+
 /** A literal conversation id must not be able to impersonate the absence of one. */
 it('separates a null conversation from a conversation literally named like a sentinel', function (): void {
     $this->store->ingest(toolCallId: 'call_1', conversationId: null);

--- a/tests/Feature/PendingApprovalStoreTest.php
+++ b/tests/Feature/PendingApprovalStoreTest.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Str;
 beforeEach(function (): void {
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
     (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_approval_context_to_verdict_console_pending_approvals_table.php.stub')->up();
 
     $this->store = new PendingApprovalStore;
 });
@@ -147,6 +148,40 @@ it('records distinct pauses separately', function (): void {
     expect(PendingApproval::query()->count())->toBe(3);
 });
 
+/**
+ * VC-68: `approval_context` is a correlation annotation copied once at ingestion — Verdict
+ * documents the field as immutable after issue, which is what distinguishes it from the receipt
+ * status and expiry this table deliberately never copies. Scalars only, ints surviving the round
+ * trip, and null when the receipt predates capture: a storage era, not a disclosure state.
+ */
+it('captures approval context verbatim and defaults it to null', function (): void {
+    $with = $this->store->ingest(
+        toolCallId: 'call_1',
+        conversationId: 'conv_1',
+        receiptId: 'receipt_1',
+        approvalContext: ['tenant' => 'acme', 'workspace' => 7],
+    );
+    $without = $this->store->ingest(toolCallId: 'call_2', conversationId: 'conv_2');
+    // The store writes what it was handed: an explicit empty context is a datum, not an absence,
+    // even though Verdict itself never issues one (it stores [] as NULL at issuance).
+    $empty = $this->store->ingest(toolCallId: 'call_3', conversationId: 'conv_3', approvalContext: []);
+
+    expect(PendingApproval::query()->find($with->id)?->approval_context)
+        ->toBe(['tenant' => 'acme', 'workspace' => 7])
+        ->and(PendingApproval::query()->find($without->id)?->approval_context)->toBeNull()
+        ->and(PendingApproval::query()->find($empty->id)?->approval_context)->toBe([]);
+});
+
+/** First-write-wins covers the annotation too: a redelivery must not swap or erase the captured context. */
+it('keeps the originally captured approval context when the same pause is redelivered', function (): void {
+    $this->store->ingest(toolCallId: 'call_1', conversationId: 'conv_1', approvalContext: ['tenant' => 'acme']);
+
+    $redelivered = $this->store->ingest(toolCallId: 'call_1', conversationId: 'conv_1', approvalContext: ['tenant' => 'imposter']);
+
+    expect($redelivered->approval_context)->toBe(['tenant' => 'acme'])
+        ->and(PendingApproval::query()->count())->toBe(1);
+});
+
 /** A literal conversation id must not be able to impersonate the absence of one. */
 it('separates a null conversation from a conversation literally named like a sentinel', function (): void {
     $this->store->ingest(toolCallId: 'call_1', conversationId: null);
@@ -209,6 +244,8 @@ it('adds only console work to the row, never a second copy of Verdict state', fu
 
     expect($columns)->toContain('resume_attempts')
         ->and($columns)->toContain('last_resume_attempt_at')
+        // A correlation annotation, immutable after issue — not mirrored, cache-prone state.
+        ->and($columns)->toContain('approval_context')
         ->and($columns)->not->toContain('approved_at')
         ->and($columns)->not->toContain('rejected_at')
         ->and($columns)->not->toContain('receipt_expires_at')

--- a/tests/Feature/PendingApprovalStoreTest.php
+++ b/tests/Feature/PendingApprovalStoreTest.php
@@ -162,8 +162,10 @@ it('captures approval context verbatim and defaults it to null', function (): vo
         approvalContext: ['tenant' => 'acme', 'workspace' => 7],
     );
     $without = $this->store->ingest(toolCallId: 'call_2', conversationId: 'conv_2');
-    // The store writes what it was handed: an explicit empty context is a datum, not an absence,
-    // even though Verdict itself never issues one (it stores [] as NULL at issuance).
+    // The store writes what it was handed: an explicit empty context is a datum, not an absence.
+    // Measured upstream: Verdict persists an identifier-less issuance as '[]' too — only rows
+    // predating the column hydrate null. The [] -> omitted collapse exists solely in Verdict's
+    // binding fingerprint, not in storage.
     $empty = $this->store->ingest(toolCallId: 'call_3', conversationId: 'conv_3', approvalContext: []);
 
     expect(PendingApproval::query()->find($with->id)?->approval_context)


### PR DESCRIPTION
Closes #68.

ADR 0001 §4 (as amended) assigns the console the capture of Verdict's `approval_context` — the application-owned binding identifiers (`array<string, string|int>`) Verdict stamps onto a receipt at issuance and documents as immutable after issue. Verdict 0.13's `ApprovalStatusReader` (verdict#327 / ADR 0031) opened the boundary-respecting route, and #45's adoption made it this package's read seam; this captures the field onto the pause row at ingestion as a correlation annotation for host scoping (#69).

## What changed

- **A nullable `approval_context` column in its own published migration** (`2026_08_30_000001_…`). Released migrations are never amended: the create and operational-state stubs have run for every adopter, and the publishing test now pins that neither contains the new column while the new stub does.
- **Captured once, verbatim, through `ApprovalStatusReader::statusFor()`** keyed by the exact receipt the ingestion challenge answered for — `ApprovalChallenge` doesn't carry the field, a store read is the §5 boundary violation, and the receipt-id read means an ambiguous tool-call id can't attach another receipt's context. A diverging-reader e2e pins the routing (row value + exact read trace), the same falsifiability technique as #88.
- **Measured semantics, not assumed**: `ActionContext::approvalContext` is a non-nullable array defaulting to `[]`, and Verdict persists an identifier-less issuance as `'[]'` and hydrates it back as `[]` — so an empty context is captured as `[]`; `null` is reserved for the true pre-capture storage era (rows predating Verdict's column). The `[] → omitted` collapse exists only in Verdict's binding fingerprint, not in storage. Receiptless pauses record `null`.
- **First-write-wins covers the annotation**: a redelivered pause cannot swap or erase the captured context.
- **Rolling-migration tolerance**: a host that composer-updates before running the published migration still indexes every pause — the store omits the column it cannot write instead of failing ingestion (the same interval tolerance Verdict's own receipt store ships), pinned by its own test.
- **No mirrored state**: the VC-9 schema assertion now includes the new column on the allowed side and still refuses any copy of receipt status or expiry.

Suite: 389 passed (2096 assertions); phpstan clean, pint passed, type coverage 100%.