### PR TITLE
feat: durable retry for approved-but-unresumed reconciliations (VC-86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Durable retry for approved-but-unresumed reconciliations (VC-86).**
+  `ApprovalResolutionService::retry()` re-drives a continuation whose decision Verdict already
+  holds: the decision is re-read live through `ApprovalStatusReader` at retry time — never
+  persisted for replay — and re-sent as the same tool-call-id-keyed continuation. An approved
+  receipt executes its tool at most once (a consumed receipt refuses the retry, under every
+  failure geometry); a rejected one resumes to a clean refusal; a pending receipt has no decision
+  to re-send and is refused rather than auto-decided; Laravel AI's measured already-resolved
+  answer is relayed as `RetryOutcome::AlreadyResumed`. Retry requires the recorded failed
+  continuation, rides the existing `resume_attempts` counter, ignores (and preserves) an
+  operator's abandonment note, and announces nothing on refusal.
+
 - **Capture `approval_context` at ingestion (VC-68).** The pause row gains a nullable
   `approval_context` column (its own published migration — released migrations are never amended)
   holding the receipt's application-owned binding identifiers, read once at ingestion through

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -154,13 +154,16 @@ so recording one would mean this package inventing a version on the host's behal
 as reconstructing a participant from a class name and an id. It is deferred until that contract gains
 a way to report it (#51), and the column and its consumer are separately scheduled after that.
 
-**Reconciliation detects and abandons; it does not retry, and it names two phases rather than three.**
-A retry after `approve()`/`reject()` needs the decision back, and there is no read for it:
-`challengeForToolCall()` is pending-only by construction and `ApprovalManager` publishes no resolved
-status. Persisting the decision so it could be re-sent would be a second copy of authorization state
-under another name — the one thing §5 forbids — so retry waits on
-[verdict#298](https://github.com/fissible/verdict/issues/298)'s per-receipt read (VC-45), and is not
-built here in the meantime. Likewise the phase: a failure raised *before* `prompt()` is definitely
+**Reconciliation detects, abandons, and retries with two phases rather than three.** A durable
+reconciliation records that Verdict accepted a decision but Laravel AI did not complete its captured
+continuation. The decision is re-read live through `ApprovalStatusReader`; retry never persists the decision it re-sends.
+An approved or rejected live receipt is re-driven with the exact captured
+conversation and participant, while a pending receipt has no decision to re-send, an unavailable
+receipt cannot be guessed, and a consumed receipt refuses the retry because the tool already ran.
+Abandonment remains an operator's closure note for a stranded continuation; an explicit retry ignores
+that note and leaves it intact.
+
+The phase remains deliberately two-valued: a failure raised *before* `prompt()` is definitely
 pre-execution, and one raised *by* it is **indeterminate**, because Laravel AI executes the approved
 tools inside `prompt()` before handing results to the recorder. Execution-claim status would settle it
 and is not reachable — the raw claim id goes only to the executor, the claim row has no `tool_call_id`,

--- a/src/Approvals/ApprovalReconciliationStore.php
+++ b/src/Approvals/ApprovalReconciliationStore.php
@@ -8,7 +8,7 @@ use Fissible\VerdictConsole\Exceptions\ReconciliationRecordUnreadable;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Str;
 
-/** Durable detection and closure of continuations that failed after Verdict accepted a decision. */
+/** Durable detection, retry eligibility, and closure of continuations that failed after Verdict accepted a decision. */
 final class ApprovalReconciliationStore
 {
     /**

--- a/src/Approvals/ApprovalResolutionService.php
+++ b/src/Approvals/ApprovalResolutionService.php
@@ -17,6 +17,7 @@ use Fissible\VerdictConsole\Contracts\ResumableAgents;
 use Fissible\VerdictConsole\Events\ApprovalDecisionRefused;
 use Fissible\VerdictConsole\Exceptions\ApprovalNotDrivable;
 use Fissible\VerdictConsole\Exceptions\ApprovalResumeFailed;
+use Fissible\VerdictConsole\Exceptions\NoContinuationToRetry;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -56,6 +57,98 @@ final readonly class ApprovalResolutionService
     public function reject(PendingApproval $approval, ?Authenticatable $approver): ?ApprovalTransition
     {
         return $this->resolve($approval, $approver, false);
+    }
+
+    /**
+     * Re-drive a continuation whose Verdict decision succeeded but whose prior resume failed.
+     *
+     * Retry reads the receipt live and re-sends only an approved or rejected decision; it refuses
+     * unavailable, pending, and consumed receipts rather than reconstructing authorization state or
+     * risking another tool execution. An abandonment is an operator's closure note, so retry
+     * deliberately ignores it and leaves it intact.
+     */
+    public function retry(PendingApproval $approval, ?Authenticatable $approver): RetryOutcome
+    {
+        $this->assertVisible($approval);
+
+        if (! $this->authority->allows($approval, $approver)) {
+            throw new AuthorizationException(self::AUTHORIZATION_REFUSAL_MESSAGE);
+        }
+
+        if ($approval->resumability !== Resumability::Drivable) {
+            throw ApprovalNotDrivable::forApproval($approval);
+        }
+
+        if ($approval->resolver_key === null || $approval->conversation_id === null) {
+            throw ApprovalNotDrivable::forMissingResumeContext($approval);
+        }
+
+        if ($this->reconciliations->find($approval) === null) {
+            throw NoContinuationToRetry::forApproval($approval);
+        }
+
+        // Eloquent attributes are mutable. Preserve the context admitted above before resolving
+        // host-owned participant or agent code, which must not redirect this retry to another row.
+        $resolverKey = $approval->resolver_key;
+        $conversationId = $approval->conversation_id;
+
+        $view = $this->statusFor($approval);
+
+        if ($view === null) {
+            return RetryOutcome::ReceiptUnavailable;
+        }
+
+        if ($view->status === ApprovalReceiptStatus::Pending) {
+            return RetryOutcome::DecisionStillPending;
+        }
+
+        if ($view->status === ApprovalReceiptStatus::Consumed) {
+            return RetryOutcome::ReceiptConsumed;
+        }
+
+        $decision = match ($view->status) {
+            ApprovalReceiptStatus::Approved => Decision::approve(),
+            ApprovalReceiptStatus::Rejected => Decision::reject(),
+        };
+
+        $this->pendingApprovals->beginResumeAttempt($approval);
+
+        try {
+            $participant = $approval->participant_reference === null
+                ? null
+                : $this->participants->resolve($approval->participant_reference);
+
+            $agent = $this->agents->resolve($resolverKey)
+                ->continue($conversationId, $participant);
+        } catch (Throwable $e) {
+            // No prompt started, so retry cannot have reached the approved tool.
+            $this->reconciliations->detect($approval, ResumeFailurePhase::DefinitelyPreExecution);
+
+            throw ApprovalResumeFailed::forApproval($approval, $e);
+        }
+
+        try {
+            $agent->prompt(Decisions::from([
+                $approval->tool_call_id => $decision,
+            ]));
+        } catch (ApprovalMismatchException $e) {
+            if ($e->getMessage() === 'Approval decisions include already-resolved tool call ids.') {
+                return RetryOutcome::AlreadyResumed;
+            }
+
+            $this->reconciliations->detect($approval, ResumeFailurePhase::Indeterminate);
+
+            throw ApprovalResumeFailed::forApproval($approval, $e);
+        } catch (Throwable $e) {
+            // prompt() owns tool execution, so every other failure remains indeterminate.
+            $this->reconciliations->detect($approval, ResumeFailurePhase::Indeterminate);
+
+            throw ApprovalResumeFailed::forApproval($approval, $e);
+        }
+
+        return $view->status === ApprovalReceiptStatus::Approved
+            ? RetryOutcome::ResumedApproval
+            : RetryOutcome::ResumedRejection;
     }
 
     /**

--- a/src/Approvals/RetryOutcome.php
+++ b/src/Approvals/RetryOutcome.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+/**
+ * The observable result of re-driving a continuation whose decision Verdict already holds.
+ *
+ * The decision re-sent is re-read live at retry time and never persisted; a consumed receipt
+ * refuses the retry because the tool already ran; a pending receipt has no decision to re-send and
+ * inventing one would be ADR 0029's forbidden auto-decision.
+ */
+enum RetryOutcome: string
+{
+    case ResumedApproval = 'resumed_approval';
+    case ResumedRejection = 'resumed_rejection';
+    case AlreadyResumed = 'already_resumed';
+    case DecisionStillPending = 'decision_still_pending';
+    case ReceiptConsumed = 'receipt_consumed';
+    case ReceiptUnavailable = 'receipt_unavailable';
+}

--- a/src/Exceptions/NoContinuationToRetry.php
+++ b/src/Exceptions/NoContinuationToRetry.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Exceptions;
+
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use LogicException;
+
+/** A retry was requested for a pause that has not recorded a failed continuation. */
+final class NoContinuationToRetry extends LogicException
+{
+    public static function forApproval(PendingApproval $approval): self
+    {
+        return new self('Approval ['.$approval->tool_call_id.'] has no recorded failed continuation to retry.');
+    }
+}

--- a/tests/EndToEnd/ApprovalRetryTest.php
+++ b/tests/EndToEnd/ApprovalRetryTest.php
@@ -710,8 +710,11 @@ it('reads a receiptless row by its tool call before retrying', function (): void
 
 /**
  * Only Laravel AI's measured already-resolved message may become AlreadyResumed. Every other
- * mismatch — here a participant-scoped conversation miss — leaves the turn untouched and must
- * surface as a failed continuation, not a false success.
+ * mismatch — here a participant-scoped conversation miss — must surface as a failed continuation,
+ * not a false success. Measured, not assumed: Laravel AI validates participant identity only
+ * AFTER the approved tool runs (`storeApprovalResults()`), so this geometry executes once and
+ * consumes the receipt before the mismatch throws — the same fact the resolve-path pins — and the
+ * consumed status is then exactly what stops any further retry.
  */
 it('does not report a participant mismatch as already resumed', function (): void {
     $row = decidedButUnresumed();
@@ -730,9 +733,16 @@ it('does not report a participant mismatch as already resumed', function (): voi
 
     expect(fn () => app(ApprovalResolutionService::class)->retry($row, new GenericUser(['id' => 'operator-1'])))
         ->toThrow(ApprovalResumeFailed::class);
-    expect(app(RetryLedger::class)->executions)->toBe(0)
+    expect(app(RetryLedger::class)->executions)->toBe(1, 'Laravel AI runs the approved tool before checking participant identity.')
         ->and(ApprovalReconciliation::query()->count())->toBe(1)
-        ->and(DB::table($this->approvalReceiptTable())->where('tool_call_id', RETRY_TOOL_CALL_ID)->value('status'))->toBe('approved');
+        ->and(DB::table($this->approvalReceiptTable())->where('tool_call_id', RETRY_TOOL_CALL_ID)->value('status'))->toBe('consumed');
+
+    // At-most-once still holds from here: the consumed receipt refuses the next retry.
+    $this->app->instance(ConversationParticipants::class, new RetryParticipants);
+
+    expect(app(ApprovalResolutionService::class)->retry($row->refresh(), new GenericUser(['id' => 'operator-1'])))
+        ->toBe(RetryOutcome::ReceiptConsumed)
+        ->and(app(RetryLedger::class)->executions)->toBe(1);
 });
 
 /** The retry drives the same exact continuation the original resolution would have: nothing widens. */

--- a/tests/EndToEnd/ApprovalRetryTest.php
+++ b/tests/EndToEnd/ApprovalRetryTest.php
@@ -1,0 +1,777 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Actions\ActionContext;
+use Fissible\Verdict\Actions\ActionEnvelope;
+use Fissible\Verdict\Actions\AuthorizedAction;
+use Fissible\Verdict\Approvals\ApprovalReceiptStatus;
+use Fissible\Verdict\Approvals\ApprovalStatusView;
+use Fissible\Verdict\Capabilities\Capability;
+use Fissible\Verdict\Capabilities\CapabilityRegistry;
+use Fissible\Verdict\Contracts\ApprovalStatusReader;
+use Fissible\Verdict\Contracts\CapabilityAuthorizer;
+use Fissible\Verdict\Decisions\Decision;
+use Fissible\Verdict\LaravelAi\VerdictApprovalMiddleware;
+use Fissible\Verdict\Targets\ExecutionTargetPolicy;
+use Fissible\Verdict\VerdictManager;
+use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
+use Fissible\VerdictConsole\Approvals\ApprovalNotificationKey;
+use Fissible\VerdictConsole\Approvals\ApprovalReconciliation;
+use Fissible\VerdictConsole\Approvals\ApprovalReconciliationStore;
+use Fissible\VerdictConsole\Approvals\ApprovalResolutionService;
+use Fissible\VerdictConsole\Approvals\CloseOutcome;
+use Fissible\VerdictConsole\Approvals\PendingApproval as StoredPendingApproval;
+use Fissible\VerdictConsole\Approvals\ResumeFailurePhase;
+use Fissible\VerdictConsole\Approvals\RetryOutcome;
+use Fissible\VerdictConsole\Contracts\ApprovalNotificationRecipients;
+use Fissible\VerdictConsole\Contracts\ApprovalScope;
+use Fissible\VerdictConsole\Contracts\ConversationParticipants;
+use Fissible\VerdictConsole\Contracts\ResumableAgents;
+use Fissible\VerdictConsole\Exceptions\ApprovalNotDrivable;
+use Fissible\VerdictConsole\Exceptions\ApprovalResumeFailed;
+use Fissible\VerdictConsole\Exceptions\NoContinuationToRetry;
+use Fissible\VerdictConsole\Notifications\ApprovalResumeOutcomeNotification;
+use Fissible\VerdictConsole\Tests\EndToEndTestCase;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\GenericUser;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Notification;
+use Laravel\Ai\Approvals\Decisions;
+use Laravel\Ai\Concerns\RemembersConversations as RemembersConversationsTrait;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasMiddleware;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Contracts\RemembersConversations as RemembersConversationsContract;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Responses\AgentResponse;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Tools\Request;
+
+/**
+ * VC-86: the durable-retry path for a decision Verdict accepted but Laravel AI could not resume.
+ *
+ * The decision is re-read live through the status read at retry time — never persisted in console
+ * state — and re-sent as the same tool-call-id-keyed continuation the original resolution would
+ * have driven. Fixtures are this file's own.
+ */
+const RETRY_TOOL_CALL_ID = 'call_retry';
+const RETRY_ORDER_ID = 8601;
+
+/** Counts executions across a whole test. At-most-once is the number this suite is really about. */
+final class RetryLedger
+{
+    public int $executions = 0;
+}
+
+final readonly class RetryOrder
+{
+    public function __construct(public int $id) {}
+}
+
+final readonly class RetryCustomer
+{
+    public function __construct(public int $id) {}
+}
+
+final class RetryNotificationRecipient
+{
+    use Notifiable;
+
+    public function __construct(private readonly string $key) {}
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+}
+
+/** Faithfully rebuilds the simple participant fixture by its host-owned opaque reference. */
+final class RetryParticipants implements ConversationParticipants
+{
+    public function referenceFor(object $participant): string
+    {
+        if (! $participant instanceof RetryCustomer) {
+            throw new LogicException('Unexpected retry participant.');
+        }
+
+        return 'customer:'.$participant->id;
+    }
+
+    public function resolve(string $reference): object
+    {
+        if (! preg_match('/^customer:(\d+)$/', $reference, $matches)) {
+            throw new LogicException('Unknown retry participant reference.');
+        }
+
+        return new RetryCustomer((int) $matches[1]);
+    }
+}
+
+/** Forces status views per read path, so the retry's routing and its derived decision are observable. */
+final class RetryForcedStatuses implements ApprovalStatusReader
+{
+    /** @var list<string> every read made through this reader, in order, as "method:key" */
+    public array $reads = [];
+
+    public function __construct(
+        private readonly ?ApprovalStatusView $byReceiptId = null,
+        private readonly ?ApprovalStatusView $byToolCall = null,
+    ) {}
+
+    public function statusFor(string $receiptId): ?ApprovalStatusView
+    {
+        $this->reads[] = 'statusFor:'.$receiptId;
+
+        return $this->byReceiptId;
+    }
+
+    public function statusForToolCall(string $toolCallId): ?ApprovalStatusView
+    {
+        $this->reads[] = 'statusForToolCall:'.$toolCallId;
+
+        return $this->byToolCall;
+    }
+
+    public function pendingWithin(array $scope): array
+    {
+        return [];
+    }
+}
+
+/** @param array<string, string|int>|null $context */
+function retryForcedView(
+    ApprovalReceiptStatus $status,
+    string $receiptId,
+    string $toolCallId = RETRY_TOOL_CALL_ID,
+): ApprovalStatusView {
+    return new ApprovalStatusView(
+        receiptId: $receiptId,
+        toolCallId: $toolCallId,
+        capability: 'retry.orders.cancel',
+        status: $status,
+        reason: null,
+        expiresAt: new DateTimeImmutable('2030-01-02T03:04:05+00:00'),
+        approvedBy: $status === ApprovalReceiptStatus::Approved ? 'operator-1' : null,
+        approvedAt: null,
+        rejectedBy: $status === ApprovalReceiptStatus::Rejected ? 'operator-1' : null,
+        rejectedAt: null,
+        consumedAt: null,
+        createdAt: new DateTimeImmutable('2026-08-30T09:00:00+00:00'),
+        approvalContext: null,
+    );
+}
+
+final class RetryCancelOrderTool implements Tool
+{
+    public function description(): Stringable|string
+    {
+        return 'Cancel an order by id.';
+    }
+
+    public function handle(Request $request): Stringable|string
+    {
+        return 'The Verdict-bound tool handles this.';
+    }
+
+    /** @return array<string, Type> */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}
+
+/** Builds the bound tool, registering the confirmation-gated capability once per container. */
+function retryBoundTool(): Tool
+{
+    $verdict = app(VerdictManager::class);
+
+    if (! app(CapabilityRegistry::class)->has('retry.orders.cancel')) {
+        $verdict->capability(
+            Capability::usingPolicy(
+                name: 'retry.orders.cancel',
+                ability: 'update',
+                resolveTarget: fn (ActionEnvelope $e): RetryOrder => new RetryOrder((int) $e->proposal->arguments['order_id']),
+            )
+                ->executionTarget(ExecutionTargetPolicy::acceptStaleSnapshot(
+                    name: 'retry-target',
+                    identityUsing: fn (ActionEnvelope $e, RetryOrder $t): array => ['id' => $t->id],
+                ))
+                ->requiresConfirmation(fn (ActionEnvelope $e, RetryOrder $t): array => ['order_id' => $t->id])
+                ->executeUsing(function (AuthorizedAction $a): string {
+                    app(RetryLedger::class)->executions++;
+
+                    return 'Order cancelled.';
+                }),
+        );
+    }
+
+    return $verdict->bound(new RetryCancelOrderTool, 'retry.orders.cancel', new ActionContext('retry-customer'));
+}
+
+final class RetryAgent implements Agent, HasMiddleware, HasTools, RemembersConversationsContract
+{
+    use Promptable;
+    use RemembersConversationsTrait;
+
+    public function instructions(): Stringable|string
+    {
+        return 'Cancel orders when asked.';
+    }
+
+    /** @return array<int, Tool> */
+    public function tools(): array
+    {
+        return [retryBoundTool()];
+    }
+
+    /** @return array<int, object> */
+    public function middleware(): array
+    {
+        return [app(VerdictApprovalMiddleware::class)];
+    }
+
+    public function provider(): string
+    {
+        return EndToEndTestCase::PROVIDER;
+    }
+
+    public function maxSteps(): int
+    {
+        return 3;
+    }
+}
+
+/** Records the continuation the retry constructs instead of executing it (service-boundary control). */
+final class RetryRecordingAgent implements Agent, HasMiddleware, HasTools, RemembersConversationsContract
+{
+    use Promptable;
+    use RemembersConversationsTrait;
+
+    /** @var array<int, array{conversationId: string, participant: ?object}> */
+    public array $continuations = [];
+
+    public ?Decisions $decisions = null;
+
+    #[Override]
+    public function continue(string $conversationId, ?object $as = null): static
+    {
+        $this->continuations[] = ['conversationId' => $conversationId, 'participant' => $as];
+
+        return $this;
+    }
+
+    #[Override]
+    public function continueLastConversation(object $as): static
+    {
+        throw new RuntimeException('A retry must resume an exact conversation id, never the participant\'s latest.');
+    }
+
+    #[Override]
+    public function prompt(
+        Decisions|string $prompt,
+        array $attachments = [],
+        Lab|array|string|null $provider = null,
+        ?string $model = null,
+        ?int $timeout = null): AgentResponse
+    {
+        if ($prompt instanceof Decisions) {
+            $this->decisions = $prompt;
+        }
+
+        return new AgentResponse('retry-recording-invocation', '', new Usage, new Meta);
+    }
+
+    public function instructions(): Stringable|string
+    {
+        return 'Records what it is asked to resume.';
+    }
+
+    /** @return array<int, Tool> */
+    public function tools(): array
+    {
+        return [retryBoundTool()];
+    }
+
+    /** @return array<int, object> */
+    public function middleware(): array
+    {
+        return [app(VerdictApprovalMiddleware::class)];
+    }
+
+    public function provider(): string
+    {
+        return EndToEndTestCase::PROVIDER;
+    }
+}
+
+/** Swap in a resolver whose factory fails, so a continuation dies definitely before any prompt. */
+function retryResolverBroken(): void
+{
+    $broken = new AgentResolverRegistry;
+    $broken->register(
+        'retry@v1',
+        fn (): object => throw new LogicException('host resolver offline'),
+        fn (Agent $agent): bool => $agent instanceof RetryAgent,
+    );
+    app()->instance(ResumableAgents::class, $broken);
+}
+
+/** Restore the working resolver the retry needs. */
+function retryResolverRestored(): void
+{
+    $working = new AgentResolverRegistry;
+    $working->register(
+        'retry@v1',
+        fn (): RetryAgent => new RetryAgent,
+        fn (Agent $agent): bool => $agent instanceof RetryAgent,
+    );
+    app()->instance(ResumableAgents::class, $working);
+}
+
+beforeEach(function (): void {
+    $this->migrateRoundTripTables();
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_approval_context_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_approval_notifications_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_approval_reconciliations_table.php.stub')->up();
+
+    $this->app->instance(RetryLedger::class, new RetryLedger);
+    $this->app->instance(ConversationParticipants::class, new RetryParticipants);
+
+    $this->app->instance(CapabilityAuthorizer::class, new class implements CapabilityAuthorizer
+    {
+        public function decide(Capability $capability, ActionEnvelope $envelope, mixed $target): Decision
+        {
+            return Decision::permit('retry test');
+        }
+    });
+
+    retryResolverRestored();
+});
+
+/** Pause the run and return the tool call id Verdict issued a receipt for. */
+function retryPause(RetryAgent $agent): string
+{
+    $paused = $agent->prompt('Please cancel order '.RETRY_ORDER_ID.'.');
+
+    expect($paused->hasPendingApprovals())->toBeTrue('Fixture: the confirmation-gated run must pause.')
+        ->and(app(RetryLedger::class)->executions)->toBe(0);
+
+    return $paused->pendingApprovals->first()->id;
+}
+
+/**
+ * A real pause whose decision Verdict recorded but whose continuation failed before any prompt:
+ * receipt approved (or rejected), nothing executed, one pre-execution reconciliation, one attempt.
+ */
+function decidedButUnresumed(bool $approve = true): StoredPendingApproval
+{
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push(test()->toolCallResponse(RETRY_TOOL_CALL_ID, 'RetryCancelOrderTool', ['order_id' => RETRY_ORDER_ID]))
+            ->push(test()->textResponse('Order cancelled.')),
+    ]);
+
+    retryPause((new RetryAgent)->forParticipant(new RetryCustomer(7)));
+    retryResolverBroken();
+    $row = StoredPendingApproval::query()->sole();
+    $service = app(ApprovalResolutionService::class);
+
+    try {
+        $approve
+            ? $service->approve($row, new GenericUser(['id' => 'operator-1']))
+            : $service->reject($row, new GenericUser(['id' => 'operator-1']));
+
+        throw new LogicException('Fixture: the continuation must fail.');
+    } catch (ApprovalResumeFailed) {
+    }
+
+    retryResolverRestored();
+
+    return $row->refresh();
+}
+
+it('retries an approved-but-unresumed continuation and the tool executes exactly once', function (): void {
+    $row = decidedButUnresumed();
+
+    // The stranded state the retry exists for: decision durable, nothing executed, failure durable.
+    expect(DB::table($this->approvalReceiptTable())->where('tool_call_id', RETRY_TOOL_CALL_ID)->value('status'))->toBe('approved')
+        ->and(app(RetryLedger::class)->executions)->toBe(0)
+        ->and(ApprovalReconciliation::query()->sole()->phase)->toBe(ResumeFailurePhase::DefinitelyPreExecution)
+        ->and($row->resume_attempts)->toBe(1);
+
+    $outcome = app(ApprovalResolutionService::class)->retry($row, new GenericUser(['id' => 'operator-2']));
+
+    expect($outcome)->toBe(RetryOutcome::ResumedApproval)
+        ->and(app(RetryLedger::class)->executions)->toBe(1, 'The approved tool executes exactly once.')
+        ->and(DB::table($this->approvalReceiptTable())->where('tool_call_id', RETRY_TOOL_CALL_ID)->first())
+        // The receipt shows the original decision untouched: a retry re-sends a continuation and
+        // performs no second Verdict transition — not even under a different operator.
+        ->toMatchArray(['status' => 'consumed', 'approved_by' => 'operator-1', 'rejected_by' => null])
+        ->and(StoredPendingApproval::query()->sole()->resume_attempts)->toBe(2, 'Retry attempts ride the existing counter.');
+
+    Http::assertSentCount(2);
+});
+
+it('refuses a second retry of a consumed receipt, keeping execution at most once', function (): void {
+    $row = decidedButUnresumed();
+    $service = app(ApprovalResolutionService::class);
+
+    expect($service->retry($row, new GenericUser(['id' => 'operator-1'])))->toBe(RetryOutcome::ResumedApproval);
+
+    Notification::fake();
+
+    expect($service->retry($row->refresh(), new GenericUser(['id' => 'operator-1'])))
+        ->toBe(RetryOutcome::ReceiptConsumed)
+        ->and(app(RetryLedger::class)->executions)->toBe(1)
+        // A refused retry attempts no resume, so it spends no attempt.
+        ->and(StoredPendingApproval::query()->sole()->resume_attempts)->toBe(2);
+
+    // A refusal is not an observation of anything new; it announces nothing.
+    Notification::assertNothingSent();
+});
+
+it('retries a rejected-but-unresumed continuation to a clean refusal without executing', function (): void {
+    $row = decidedButUnresumed(approve: false);
+
+    expect(DB::table($this->approvalReceiptTable())->where('tool_call_id', RETRY_TOOL_CALL_ID)->value('status'))->toBe('rejected');
+
+    $outcome = app(ApprovalResolutionService::class)->retry($row, new GenericUser(['id' => 'operator-2']));
+
+    expect($outcome)->toBe(RetryOutcome::ResumedRejection)
+        ->and(app(RetryLedger::class)->executions)->toBe(0)
+        ->and(StoredPendingApproval::query()->sole()->resume_attempts)->toBe(2, 'A resumed rejection spends a real attempt.')
+        ->and(DB::table($this->approvalReceiptTable())->where('tool_call_id', RETRY_TOOL_CALL_ID)->first())
+        ->toMatchArray(['status' => 'rejected', 'rejected_by' => 'operator-1']);
+
+    // The refusal genuinely reached Laravel AI: the turn is no longer resumable, which a close
+    // relays as the measured already-resolved answer rather than closing anything.
+    expect(app(ApprovalResolutionService::class)->close($row->refresh(), new GenericUser(['id' => 'operator-1'])))
+        ->toBe(CloseOutcome::AlreadyResolved);
+
+    // Measured on the reject round trip: a bare rejection ends the turn without another model call.
+    Http::assertSentCount(1);
+});
+
+/**
+ * The dangerous half of at-most-once: an indeterminate failure where the tool DID run before the
+ * continuation died. The receipt is consumed, and the retry must read that and refuse — never
+ * re-drive an execution because a failure report looked retryable.
+ */
+it('never re-executes after an indeterminate failure that already ran the tool', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    Http::fake([
+        '*/chat/completions' => Http::sequence()
+            ->push($this->toolCallResponse(RETRY_TOOL_CALL_ID, 'RetryCancelOrderTool', ['order_id' => RETRY_ORDER_ID]))
+            ->push($this->textResponse('Order cancelled.')),
+    ]);
+
+    retryPause((new RetryAgent)->forParticipant(new RetryCustomer(7)));
+    app()->instance(ConversationParticipants::class, new class implements ConversationParticipants
+    {
+        public function referenceFor(object $participant): string
+        {
+            return 'customer:7';
+        }
+
+        public function resolve(string $reference): object
+        {
+            return new RetryCustomer(8);
+        }
+    });
+    $row = StoredPendingApproval::query()->sole();
+
+    expect(fn () => app(ApprovalResolutionService::class)->approve($row, new GenericUser(['id' => 'operator-1'])))
+        ->toThrow(ApprovalResumeFailed::class);
+    expect(app(RetryLedger::class)->executions)->toBe(1)
+        ->and(ApprovalReconciliation::query()->sole()->phase)->toBe(ResumeFailurePhase::Indeterminate)
+        ->and(DB::table($this->approvalReceiptTable())->where('tool_call_id', RETRY_TOOL_CALL_ID)->value('status'))->toBe('consumed');
+
+    // The participant round-trips again; only the receipt's consumed status may stop this retry.
+    $this->app->instance(ConversationParticipants::class, new RetryParticipants);
+
+    expect(app(ApprovalResolutionService::class)->retry($row->refresh(), new GenericUser(['id' => 'operator-1'])))
+        ->toBe(RetryOutcome::ReceiptConsumed)
+        ->and(app(RetryLedger::class)->executions)->toBe(1, 'Retry after an executed indeterminate failure must not run the tool again.');
+});
+
+/**
+ * A rejected receipt whose turn was already closed: the receipt still reads Rejected, so the retry
+ * attempts the resume — and must relay Laravel AI's measured already-resolved answer rather than
+ * reporting a successful retry it did not perform.
+ */
+it('reports a turn Laravel AI already resolved instead of calling the retry successful', function (): void {
+    $row = decidedButUnresumed(approve: false);
+    $service = app(ApprovalResolutionService::class);
+
+    expect($service->close($row, new GenericUser(['id' => 'operator-1'])))->toBe(CloseOutcome::Closed);
+
+    expect($service->retry($row->refresh(), new GenericUser(['id' => 'operator-1'])))
+        ->toBe(RetryOutcome::AlreadyResumed)
+        ->and(app(RetryLedger::class)->executions)->toBe(0);
+});
+
+/**
+ * A close-path reconciliation leaves the receipt undecided. There is no decision to re-send, and
+ * inventing one would be the auto-reject ADR 0029 forbids: the retry refuses and the decide/close
+ * paths keep owning the row.
+ */
+it('does not retry a decision nobody made', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    Http::fake(['*/chat/completions' => Http::sequence()->push($this->toolCallResponse(RETRY_TOOL_CALL_ID, 'RetryCancelOrderTool', ['order_id' => RETRY_ORDER_ID]))]);
+
+    retryPause((new RetryAgent)->forParticipant(new RetryCustomer(7)));
+    DB::table($this->approvalReceiptTable())->where('tool_call_id', RETRY_TOOL_CALL_ID)->update(['expires_at' => now()->subMinute()]);
+    retryResolverBroken();
+    $row = StoredPendingApproval::query()->sole();
+
+    expect(fn () => app(ApprovalResolutionService::class)->close($row, new GenericUser(['id' => 'operator-1'])))
+        ->toThrow(ApprovalResumeFailed::class);
+
+    retryResolverRestored();
+    Notification::fake();
+
+    expect(app(ApprovalResolutionService::class)->retry($row->refresh(), new GenericUser(['id' => 'operator-1'])))
+        ->toBe(RetryOutcome::DecisionStillPending)
+        ->and(app(RetryLedger::class)->executions)->toBe(0)
+        ->and(DB::table($this->approvalReceiptTable())->where('tool_call_id', RETRY_TOOL_CALL_ID)->value('status'))->toBe('pending');
+
+    Notification::assertNothingSent();
+});
+
+it('says when the receipt vanished rather than guessing a decision', function (): void {
+    $row = decidedButUnresumed();
+    DB::table($this->approvalReceiptTable())->where('tool_call_id', RETRY_TOOL_CALL_ID)->delete();
+
+    expect(app(ApprovalResolutionService::class)->retry($row, new GenericUser(['id' => 'operator-1'])))
+        ->toBe(RetryOutcome::ReceiptUnavailable)
+        ->and(app(RetryLedger::class)->executions)->toBe(0)
+        ->and(StoredPendingApproval::query()->sole()->resume_attempts)->toBe(1);
+});
+
+/** Retry is the reconciliation path: without a recorded failed continuation there is nothing to retry. */
+it('throws when no failed continuation exists to retry', function (): void {
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    Http::fake(['*/chat/completions' => Http::sequence()->push($this->toolCallResponse(RETRY_TOOL_CALL_ID, 'RetryCancelOrderTool', ['order_id' => RETRY_ORDER_ID]))]);
+
+    retryPause((new RetryAgent)->forParticipant(new RetryCustomer(7)));
+    $row = StoredPendingApproval::query()->sole();
+
+    expect(fn () => app(ApprovalResolutionService::class)->retry($row, new GenericUser(['id' => 'operator-1'])))
+        ->toThrow(NoContinuationToRetry::class);
+    expect(app(RetryLedger::class)->executions)->toBe(0)
+        ->and(DB::table($this->approvalReceiptTable())->where('tool_call_id', RETRY_TOOL_CALL_ID)->value('status'))->toBe('pending');
+});
+
+it('refuses a retry the host Gate denies, resuming nothing', function (): void {
+    $row = decidedButUnresumed();
+    Gate::define('approve-verdict-action', fn (): bool => false);
+
+    expect(fn () => app(ApprovalResolutionService::class)->retry($row, new GenericUser(['id' => 'operator-2'])))
+        ->toThrow(AuthorizationException::class);
+    expect(app(RetryLedger::class)->executions)->toBe(0)
+        ->and(DB::table($this->approvalReceiptTable())->where('tool_call_id', RETRY_TOOL_CALL_ID)->value('status'))->toBe('approved')
+        ->and(StoredPendingApproval::query()->sole()->resume_attempts)->toBe(1);
+});
+
+/**
+ * Abandonment is an operator's closure note, not a lock: an explicit later retry supersedes it and
+ * leaves the note untouched, so the record still says when the strand was first written off.
+ */
+it('retries an abandoned reconciliation and leaves its abandonment record untouched', function (): void {
+    $row = decidedButUnresumed();
+    $store = app(ApprovalReconciliationStore::class);
+    $abandoned = $store->markAbandoned($store->find($row) ?? throw new LogicException('Fixture: reconciliation must exist.'));
+
+    expect(app(ApprovalResolutionService::class)->retry($row, new GenericUser(['id' => 'operator-1'])))
+        ->toBe(RetryOutcome::ResumedApproval)
+        ->and(app(RetryLedger::class)->executions)->toBe(1)
+        ->and(ApprovalReconciliation::query()->sole()->abandoned_at?->toIso8601String())
+        ->toBe($abandoned->abandoned_at?->toIso8601String());
+});
+
+/** A retry that fails the same way keeps one record, the first phase, and the row's abandonability. */
+it('re-detects nothing new when the retry fails the same way', function (): void {
+    $row = decidedButUnresumed();
+    retryResolverBroken();
+
+    expect(fn () => app(ApprovalResolutionService::class)->retry($row, new GenericUser(['id' => 'operator-1'])))
+        ->toThrow(ApprovalResumeFailed::class);
+    expect(ApprovalReconciliation::query()->count())->toBe(1)
+        ->and(ApprovalReconciliation::query()->sole()->phase)->toBe(ResumeFailurePhase::DefinitelyPreExecution)
+        ->and(StoredPendingApproval::query()->sole()->resume_attempts)->toBe(2)
+        ->and(app(RetryLedger::class)->executions)->toBe(0);
+
+    $store = app(ApprovalReconciliationStore::class);
+
+    expect($store->markAbandoned($store->find($row) ?? throw new LogicException('Fixture: reconciliation must exist.'))->abandoned_at)
+        ->not->toBeNull('A row whose retry failed stays abandonable.');
+});
+
+/** VC-12's rule holds for retry: a foreign-scoped row answers like a row that does not exist, before any read. */
+it('refuses a foreign-scoped row before reading or spending anything', function (): void {
+    $row = decidedButUnresumed();
+    $statuses = new RetryForcedStatuses;
+    app()->instance(ApprovalStatusReader::class, $statuses);
+    app()->instance(ApprovalScope::class, new class implements ApprovalScope
+    {
+        public function apply(Builder $query): Builder
+        {
+            return $query->whereRaw('1 = 0');
+        }
+    });
+
+    expect(fn () => app(ApprovalResolutionService::class)->retry($row, new GenericUser(['id' => 'operator-1'])))
+        ->toThrow(AuthorizationException::class);
+    expect($statuses->reads)->toBe([], 'A hidden row is never read from Verdict.')
+        ->and(app(RetryLedger::class)->executions)->toBe(0)
+        ->and(StoredPendingApproval::query()->sole()->resume_attempts)->toBe(1);
+});
+
+it('refuses an unresumable or context-stripped row without attempting a continuation', function (): void {
+    $row = decidedButUnresumed();
+    $row->forceFill(['resumability' => 'unresumable'])->save();
+
+    expect(fn () => app(ApprovalResolutionService::class)->retry($row->refresh(), new GenericUser(['id' => 'operator-1'])))
+        ->toThrow(ApprovalNotDrivable::class);
+
+    $row->forceFill(['resumability' => 'drivable'])->save();
+    $stripped = $row->refresh();
+    $stripped->resolver_key = null;
+
+    expect(fn () => app(ApprovalResolutionService::class)->retry($stripped, new GenericUser(['id' => 'operator-1'])))
+        ->toThrow(ApprovalNotDrivable::class, 'marked drivable but lacks its captured resume context');
+    expect(StoredPendingApproval::query()->sole()->resume_attempts)->toBe(1)
+        ->and(app(RetryLedger::class)->executions)->toBe(0);
+});
+
+/**
+ * The routing rule made falsifiable, and with it the source of the re-sent decision: the retry
+ * reads by the row's receipt id and re-sends what the READER reports — here a rejection, while the
+ * store still holds the approved receipt. An implementation reading the store, the challenge, or
+ * remembering the original verb would resume an approval.
+ */
+it('re-sends the decision the status read reports, read by the receipt id', function (): void {
+    $row = decidedButUnresumed();
+    $statuses = new RetryForcedStatuses(byReceiptId: retryForcedView(ApprovalReceiptStatus::Rejected, (string) $row->receipt_id));
+    app()->instance(ApprovalStatusReader::class, $statuses);
+    $recorder = new RetryRecordingAgent;
+
+    /** @var AgentResolverRegistry $resolvers */
+    $resolvers = app(ResumableAgents::class);
+    $resolvers->register('retry@v1', fn (): RetryRecordingAgent => $recorder, fn (Agent $agent): bool => $agent instanceof RetryAgent);
+
+    expect(app(ApprovalResolutionService::class)->retry($row, new GenericUser(['id' => 'operator-1'])))
+        ->toBe(RetryOutcome::ResumedRejection)
+        ->and($statuses->reads)->toBe(['statusFor:'.$row->receipt_id])
+        ->and($recorder->decisions?->get($row->tool_call_id)?->isApproved())->toBeFalse();
+});
+
+it('discards a status view that belongs to another tool call', function (): void {
+    $row = decidedButUnresumed();
+    app()->instance(ApprovalStatusReader::class, new RetryForcedStatuses(
+        byReceiptId: retryForcedView(ApprovalReceiptStatus::Approved, (string) $row->receipt_id, toolCallId: 'call_other'),
+    ));
+
+    expect(app(ApprovalResolutionService::class)->retry($row, new GenericUser(['id' => 'operator-1'])))
+        ->toBe(RetryOutcome::ReceiptUnavailable)
+        ->and(app(RetryLedger::class)->executions)->toBe(0)
+        ->and(StoredPendingApproval::query()->sole()->resume_attempts)->toBe(1);
+});
+
+/** A receiptless drivable row is publicly constructible; its read falls back to the tool call. */
+it('reads a receiptless row by its tool call before retrying', function (): void {
+    $row = decidedButUnresumed();
+    $row->forceFill(['receipt_id' => null])->save();
+    $statuses = new RetryForcedStatuses(byToolCall: retryForcedView(ApprovalReceiptStatus::Approved, 'receipt-forced'));
+    app()->instance(ApprovalStatusReader::class, $statuses);
+    $recorder = new RetryRecordingAgent;
+
+    /** @var AgentResolverRegistry $resolvers */
+    $resolvers = app(ResumableAgents::class);
+    $resolvers->register('retry@v1', fn (): RetryRecordingAgent => $recorder, fn (Agent $agent): bool => $agent instanceof RetryAgent);
+
+    expect(app(ApprovalResolutionService::class)->retry($row->refresh(), new GenericUser(['id' => 'operator-1'])))
+        ->toBe(RetryOutcome::ResumedApproval)
+        ->and($statuses->reads)->toBe(['statusForToolCall:'.RETRY_TOOL_CALL_ID]);
+});
+
+/**
+ * Only Laravel AI's measured already-resolved message may become AlreadyResumed. Every other
+ * mismatch — here a participant-scoped conversation miss — leaves the turn untouched and must
+ * surface as a failed continuation, not a false success.
+ */
+it('does not report a participant mismatch as already resumed', function (): void {
+    $row = decidedButUnresumed();
+    app()->instance(ConversationParticipants::class, new class implements ConversationParticipants
+    {
+        public function referenceFor(object $participant): string
+        {
+            return 'customer:7';
+        }
+
+        public function resolve(string $reference): object
+        {
+            return new RetryCustomer(8);
+        }
+    });
+
+    expect(fn () => app(ApprovalResolutionService::class)->retry($row, new GenericUser(['id' => 'operator-1'])))
+        ->toThrow(ApprovalResumeFailed::class);
+    expect(app(RetryLedger::class)->executions)->toBe(0)
+        ->and(ApprovalReconciliation::query()->count())->toBe(1)
+        ->and(DB::table($this->approvalReceiptTable())->where('tool_call_id', RETRY_TOOL_CALL_ID)->value('status'))->toBe('approved');
+});
+
+/** The retry drives the same exact continuation the original resolution would have: nothing widens. */
+it('resumes the retry with the exact captured decision map, conversation, and participant', function (): void {
+    $row = decidedButUnresumed();
+    $recorder = new RetryRecordingAgent;
+
+    /** @var AgentResolverRegistry $resolvers */
+    $resolvers = app(ResumableAgents::class);
+    $resolvers->register('retry@v1', fn (): RetryRecordingAgent => $recorder, fn (Agent $agent): bool => $agent instanceof RetryAgent);
+
+    expect(app(ApprovalResolutionService::class)->retry($row, new GenericUser(['id' => 'operator-1'])))
+        ->toBe(RetryOutcome::ResumedApproval);
+
+    expect($recorder->continuations)->toHaveCount(1)
+        ->and($recorder->continuations[0]['conversationId'])->toBe($row->conversation_id)
+        ->and($recorder->continuations[0]['participant'])->toBeInstanceOf(RetryCustomer::class)
+        ->and($recorder->decisions)->not->toBeNull()
+        ->and(array_keys($recorder->decisions->all()))->toBe([$row->tool_call_id])
+        ->and($recorder->decisions->get($row->tool_call_id)?->isApproved())->toBeTrue();
+});
+
+/** The host hears the continuation outcome through the existing observation, exactly once. */
+it('notifies the continuation outcome once when the retry succeeds', function (): void {
+    $recipient = new RetryNotificationRecipient('retry-outcome');
+    app()->instance(ApprovalNotificationRecipients::class, new class($recipient) implements ApprovalNotificationRecipients
+    {
+        public function __construct(private object $recipient) {}
+
+        public function forApproval(StoredPendingApproval $approval, ApprovalNotificationKey $key): iterable
+        {
+            return [$this->recipient];
+        }
+    });
+    Notification::fake();
+    $row = decidedButUnresumed();
+
+    expect(app(ApprovalResolutionService::class)->retry($row, new GenericUser(['id' => 'operator-1'])))
+        ->toBe(RetryOutcome::ResumedApproval);
+
+    Notification::assertSentToTimes($recipient, ApprovalResumeOutcomeNotification::class, 1);
+});

--- a/tests/Feature/DocumentationCorrectionsTest.php
+++ b/tests/Feature/DocumentationCorrectionsTest.php
@@ -186,3 +186,19 @@ it('records the adopted approval status read in the design and the unresumable-r
         ->toContain('ApprovalStatusReader')
         ->not->toContain('future Verdict status-read contract');
 });
+
+/**
+ * VC-86: reconciliation is no longer detect-and-abandon only. The design of record must carry the
+ * retry protocol — the decision is re-read live at retry time, never persisted for replay — and
+ * must stop saying retry is unbuilt and waiting.
+ */
+it('records the durable-retry protocol in the design of record', function (): void {
+    $design = documentation('docs/design/0001-verdict-console-design.md');
+
+    expect($design)
+        ->toContain('re-read live through `ApprovalStatusReader`')
+        ->toContain('never persists the decision it re-sends')
+        ->toContain('a consumed receipt refuses the retry')
+        ->not->toContain('it does not retry, and it names two phases')
+        ->not->toContain('retry waits on');
+});


### PR DESCRIPTION
Closes #86.

VC-10 deliberately shipped reconciliation as *detect and abandon*: retrying needed the decision back, no read for it existed, and persisting the decision for replay would have been a second copy of authorization state — the one thing design §5 forbids. #45's adoption of Verdict 0.13's `ApprovalStatusReader` opened the read; this builds the retry on it.

## What changed

- **`ApprovalResolutionService::retry(PendingApproval, ?Authenticatable): RetryOutcome`** — same visibility/Gate/drivability guards as the other verbs (a foreign-scoped row refuses before any Verdict read; refused retries spend no attempt), and it requires the recorded failed continuation (`NoContinuationToRetry` otherwise): retry is the reconciliation path, not a second resolve.
- **The decision is re-read live, never persisted.** At retry time the receipt's persisted status is read through `ApprovalStatusReader` (receipt-id first, tool-call fallback for receiptless rows, foreign views discarded — pinned with diverging-reader e2e tests): `Approved` → resume with the keyed `Decision::approve()`; `Rejected` → resume to a clean refusal (no model call — measured); `Pending` → refused, because no decision exists and inventing one is ADR 0029's forbidden auto-decision; `Consumed` → refused, because the tool already ran; null → refused. No `ApprovalManager` transition happens anywhere in retry — a cross-operator e2e pins that the original decider survives on the receipt.
- **At-most-once under both failure geometries, against the real gateway.** Pre-execution failure → retry executes exactly once and the receipt consumes; indeterminate failure that already ran the tool → the consumed status refuses the retry with nothing re-executed. The drifted-participant geometry is pinned to Laravel AI's measured order: the approved tool runs *before* participant identity is validated, so that retry executes once, consumes, throws — and the next retry is refused by the consumed status.
- **Honest outcomes.** Laravel AI's measured already-resolved message (and only that message) is relayed as `AlreadyResumed`; any other mismatch is a failed continuation. Retry attempts ride `resume_attempts`; a failed retry re-detects nothing (one reconciliation row, first phase preserved) and the row stays abandonable; an abandoned row still retries with its abandonment note untouched; refusals announce nothing, while a successful retry's continuation outcome flows through the existing `ToolApprovalResolved` notification path.
- **Docs**: design §6.2 now records the retry protocol (re-read live, never persisted, consumed refuses) and keeps the two-phase rule.

Suite: 409 passed (2233 assertions); phpstan clean, pint passed, type coverage 100%.
