### PR TITLE
feat: recommended ApprovalContextScope keyed on the captured approval_context (VC-69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Recommended approval-context scope (VC-69).** `ApprovalContextScope` implements the existing
+  `ApprovalScope` contract keyed on the captured `approval_context`, with the same typed-exact
+  containment as Verdict's ADR 0031 §3 — matching in PHP, mirroring verdict#327's portability
+  decision, so no database backend's number/string coercion can widen it. Rows whose context is
+  null or empty are never in scope, an empty scope is refused at construction, and every scoped
+  read (`visible()`, `findVisible()`, `isVisible()`) honors the same rule — keeping what the
+  console shows a person a subset of what Verdict's `pendingWithin()` would let them decide,
+  proven against the real reader. Additive and host-opt-in: the contract is unchanged, arbitrary
+  host scopes keep working, and the package default remains unscoped.
+
 - **Durable retry for approved-but-unresumed reconciliations (VC-86).**
   `ApprovalResolutionService::retry()` re-drives a continuation whose decision Verdict already
   holds: the decision is re-read live through `ApprovalStatusReader` at retry time — never

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -340,7 +340,10 @@ rate limits, and approval rules; it deliberately has no write path.
   gates rendered verbs and a direct resolve/close call, so a model retained across a tenant switch
   is neither visible nor actionable. **It does not scope console correlation work:** ingest
   read-backs, resume locks, and Laravel AI event joins must survive a worker with no current tenant,
-  because visibility is an operator boundary rather than a condition for recording a pause.
+  because visibility is an operator boundary rather than a condition for recording a pause. Hosts
+  that capture Verdict approval context should bind the recommended `ApprovalContextScope`: it
+  applies the same identifiers with typed-exact containment, so operator visibility is a subset of what Verdict would let them decide; this is additive host opt-in, and the package default remains
+  unscoped.
   [`src/Contracts/ApprovalScope.php`]
 - **Real-time transport degrades:** polling default (no infra); broadcast (Reverb/Pusher) opt-in.
 

--- a/src/Approvals/ApprovalContextScope.php
+++ b/src/Approvals/ApprovalContextScope.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Approvals;
+
+use Fissible\VerdictConsole\Contracts\ApprovalScope;
+use Illuminate\Database\Eloquent\Builder;
+use InvalidArgumentException;
+
+/**
+ * Constrains operator visibility to a captured, host-owned approval context.
+ *
+ * Matching happens in PHP after Eloquent has read the cast context: no backend JSON containment
+ * operator, nor any backend's number/string coercion, can preserve ADR 0031 §3's typed-exact
+ * rule across every supported database (the portability decision from Verdict #327). Context is
+ * stable enough to constrain by the resulting ids because it is immutable after issue and console
+ * capture is first-write-wins. Consequently, on the same identifiers and with the same rule, this
+ * scope exposes a subset of what Verdict would let them decide.
+ */
+final readonly class ApprovalContextScope implements ApprovalScope
+{
+    /** @var non-empty-array<string, string|int> */
+    private array $scope;
+
+    /**
+     * @param  array<string, string|int>  $scope
+     */
+    public function __construct(array $scope)
+    {
+        if ($scope === []) {
+            throw new InvalidArgumentException(
+                'ApprovalContextScope requires a non-empty approval-context scope; unscoped global visibility is deliberately not expressible (ADR 0031).'
+            );
+        }
+
+        $this->scope = $scope;
+    }
+
+    public function apply(Builder $query): Builder
+    {
+        $model = $query->getModel();
+        $keyName = $model->getKeyName();
+        $ids = [];
+
+        // This deliberately starts from the incoming model rather than cloning or changing the
+        // operator query: candidate discovery must be unscoped, while the returned query retains
+        // every constraint the host already added.
+        $candidates = $model->newQueryWithoutScopes()
+            ->whereNotNull('approval_context')
+            ->where('approval_context', '!=', '[]')
+            ->get([$keyName, 'approval_context']);
+
+        foreach ($candidates as $candidate) {
+            $context = $candidate->getAttribute('approval_context');
+
+            if (! is_array($context)) {
+                continue;
+            }
+
+            foreach ($this->scope as $key => $value) {
+                if (! array_key_exists($key, $context) || $context[$key] !== $value) {
+                    continue 2;
+                }
+            }
+
+            $ids[] = $candidate->getKey();
+        }
+
+        return $query->whereIn($keyName, $ids);
+    }
+}

--- a/tests/Feature/ApprovalContextScopeTest.php
+++ b/tests/Feature/ApprovalContextScopeTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Approvals\ApprovalScopeMatch;
+use Fissible\VerdictConsole\Approvals\ApprovalContextScope;
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
+use Fissible\VerdictConsole\Contracts\ApprovalScope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * VC-69: the recommended scope, keyed on the captured `approval_context` with the same typed-exact
+ * containment as Verdict's ADR 0031 §3 — so what the console shows a person stays a subset of what
+ * Verdict would let them decide. The published ApprovalScope contract is untouched: this is one
+ * more implementation of it, not a narrowing.
+ */
+final readonly class ContextHostScope implements ApprovalScope
+{
+    public function __construct(private string $conversationId) {}
+
+    public function apply(Builder $query): Builder
+    {
+        return $query->where('conversation_id', $this->conversationId);
+    }
+}
+
+/** @param array<string, string|int>|null $context */
+function contextRow(PendingApprovalStore $store, string $toolCallId, ?array $context): PendingApproval
+{
+    return $store->ingest(
+        toolCallId: $toolCallId,
+        conversationId: 'conv-'.$toolCallId,
+        receiptId: 'receipt-'.$toolCallId,
+        approvalContext: $context,
+    );
+}
+
+/** @return list<string> the visible rows' tool call ids under the currently bound scope */
+function visibleToolCalls(): array
+{
+    return array_values(array_map(
+        static fn (PendingApproval $row): string => $row->tool_call_id,
+        app(PendingApprovalStore::class)->visible(),
+    ));
+}
+
+beforeEach(function (): void {
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_approval_context_to_verdict_console_pending_approvals_table.php.stub')->up();
+
+    $this->store = new PendingApprovalStore;
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists('verdict_console_pending_approvals');
+});
+
+/** ADR 0031 §3's mechanical rejection, mirrored: an unscoped global visibility is not expressible here either. */
+it('refuses an empty scope at construction', function (): void {
+    expect(fn (): ApprovalContextScope => new ApprovalContextScope([]))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+/** No coercion in either direction: integer 7 and string '7' are different identifiers. */
+it('matches typed-exactly in both directions', function (): void {
+    contextRow($this->store, 'call_int', ['workspace' => 7]);
+    contextRow($this->store, 'call_string', ['workspace' => '7']);
+
+    app()->instance(ApprovalScope::class, new ApprovalContextScope(['workspace' => 7]));
+
+    expect(visibleToolCalls())->toBe(['call_int']);
+
+    app()->instance(ApprovalScope::class, new ApprovalContextScope(['workspace' => '7']));
+
+    expect(visibleToolCalls())->toBe(['call_string']);
+});
+
+it('requires every scope pair and ignores extra row keys', function (): void {
+    $full = contextRow($this->store, 'call_full', ['tenant' => 'acme', 'workspace' => 7, 'extra' => 'noise']);
+    contextRow($this->store, 'call_partial', ['tenant' => 'acme']);
+    contextRow($this->store, 'call_other', ['tenant' => 'beta', 'workspace' => 7]);
+
+    app()->instance(ApprovalScope::class, new ApprovalContextScope(['tenant' => 'acme', 'workspace' => 7]));
+
+    expect(visibleToolCalls())->toBe(['call_full'])
+        ->and(app(PendingApprovalStore::class)->isVisible($full))->toBeTrue();
+});
+
+/** A null or empty captured context is never in scope: no identifiers, no visibility through this scope. */
+it('never scopes in a row whose context is null or empty', function (): void {
+    contextRow($this->store, 'call_null', null);
+    contextRow($this->store, 'call_empty', []);
+    $matching = contextRow($this->store, 'call_match', ['tenant' => 'acme']);
+    $nullRow = PendingApproval::query()->where('tool_call_id', 'call_null')->sole();
+
+    $foreign = contextRow($this->store, 'call_foreign', ['tenant' => 'beta']);
+    $mistyped = contextRow($this->store, 'call_mistyped', ['tenant' => 'acme', 'workspace' => '7']);
+
+    app()->instance(ApprovalScope::class, new ApprovalContextScope(['tenant' => 'acme', 'workspace' => 7]));
+    $mismatch = contextRow($this->store, 'call_ws', ['tenant' => 'acme', 'workspace' => 7]);
+
+    // Every scoped read refuses the same rows: a scope that filtered the list but leaked a
+    // wrong-tenant or coerced row through the single-row reads would be an authorization gap.
+    expect(app(PendingApprovalStore::class)->findVisible((string) $nullRow->getKey()))->toBeNull()
+        ->and(app(PendingApprovalStore::class)->isVisible($nullRow))->toBeFalse()
+        ->and(app(PendingApprovalStore::class)->findVisible((string) $foreign->getKey()))->toBeNull()
+        ->and(app(PendingApprovalStore::class)->isVisible($foreign))->toBeFalse()
+        ->and(app(PendingApprovalStore::class)->findVisible((string) $mistyped->getKey()))->toBeNull()
+        ->and(app(PendingApprovalStore::class)->isVisible($mistyped))->toBeFalse()
+        ->and(app(PendingApprovalStore::class)->findVisible((string) $mismatch->getKey()))->not->toBeNull()
+        ->and(app(PendingApprovalStore::class)->isVisible($mismatch))->toBeTrue();
+
+    app()->instance(ApprovalScope::class, new ApprovalContextScope(['tenant' => 'acme']));
+
+    expect(visibleToolCalls())->toEqualCanonicalizing(['call_match', 'call_mistyped', 'call_ws'])
+        ->and(app(PendingApprovalStore::class)->findVisible((string) $matching->getKey()))->not->toBeNull();
+});
+
+/** A scope that matches nothing shows nothing — never everything. */
+it('shows an empty list when no row carries the scoped identifiers', function (): void {
+    contextRow($this->store, 'call_a', ['tenant' => 'acme']);
+    contextRow($this->store, 'call_b', ['tenant' => 'beta']);
+    contextRow($this->store, 'call_c', null);
+
+    app()->instance(ApprovalScope::class, new ApprovalContextScope(['tenant' => 'gamma']));
+
+    expect(visibleToolCalls())->toBe([]);
+});
+
+/**
+ * The published contract is not narrowed: an arbitrary host scope keyed on anything else keeps
+ * working unchanged beside the recommended one — receiving the query, returning it constrained.
+ */
+it('leaves an arbitrary host scope working unmodified', function (): void {
+    contextRow($this->store, 'call_a', ['tenant' => 'acme']);
+    contextRow($this->store, 'call_b', ['tenant' => 'acme']);
+
+    app()->instance(ApprovalScope::class, new ContextHostScope('conv-call_b'));
+
+    expect(visibleToolCalls())->toBe(['call_b']);
+});
+
+/**
+ * The subset guarantee is only as good as rule parity, so the console's matching is pinned case
+ * for case against Verdict's own `ApprovalScopeMatch` — the premise (Verdict's answer) and the
+ * behavior (what the bound scope makes visible) must both equal the expectation, or the two sides
+ * have drifted.
+ */
+it('agrees with Verdict containment case for case', function (?array $context, array $scope, bool $expected): void {
+    expect(ApprovalScopeMatch::matches($context, $scope))->toBe($expected, 'Premise: this is Verdict\'s own answer.');
+
+    $row = contextRow($this->store, 'call_case', $context);
+    app()->instance(ApprovalScope::class, new ApprovalContextScope($scope));
+
+    expect(app(PendingApprovalStore::class)->isVisible($row))->toBe($expected);
+})->with([
+    'exact single pair' => [['t' => 'a'], ['t' => 'a'], true],
+    'scope is a subset of the row' => [['t' => 'a', 'w' => 7], ['t' => 'a'], true],
+    'integer row, string scope' => [['w' => 7], ['w' => '7'], false],
+    'string row, integer scope' => [['w' => '7'], ['w' => 7], false],
+    'missing scope key on the row' => [['t' => 'a'], ['t' => 'a', 'w' => 7], false],
+    'null context' => [null, ['t' => 'a'], false],
+    'empty context' => [[], ['t' => 'a'], false],
+    'integer zero exact' => [['n' => 0], ['n' => 0], true],
+    'string zero against integer zero' => [['n' => '0'], ['n' => 0], false],
+    'empty-string value exact' => [['t' => ''], ['t' => ''], true],
+]);

--- a/tests/Feature/DocumentationCorrectionsTest.php
+++ b/tests/Feature/DocumentationCorrectionsTest.php
@@ -202,3 +202,17 @@ it('records the durable-retry protocol in the design of record', function (): vo
         ->not->toContain('it does not retry, and it names two phases')
         ->not->toContain('retry waits on');
 });
+
+/**
+ * VC-69: the recommended scope and its reason travel in the design of record — the subset
+ * guarantee only means something if the rule it relies on (typed-exact, ADR 0031 §3) is named
+ * beside the recommendation.
+ */
+it('records the recommended context scope and its subset guarantee in the design of record', function (): void {
+    $design = documentation('docs/design/0001-verdict-console-design.md');
+
+    expect($design)
+        ->toContain('`ApprovalContextScope`')
+        ->toContain('a subset of what Verdict would let them decide')
+        ->toContain('typed-exact');
+});

--- a/tests/Integration/ApprovalContextSubsetTest.php
+++ b/tests/Integration/ApprovalContextSubsetTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Approvals\ApprovalReceipt;
+use Fissible\Verdict\Approvals\ApprovalReceiptStatus;
+use Fissible\Verdict\Approvals\ApprovalStatusView;
+use Fissible\Verdict\Contracts\ApprovalReceiptStore;
+use Fissible\Verdict\Contracts\ApprovalStatusReader;
+use Fissible\VerdictConsole\Approvals\ApprovalContextScope;
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
+use Fissible\VerdictConsole\Contracts\ApprovalScope;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * VC-69's stated point, measured against the real reader: with the console scoped by
+ * `ApprovalContextScope` on the same identifiers, the pending rows the console shows are exactly
+ * the receipts Verdict's `pendingWithin()` would enumerate for that scope. Lifecycle stays the
+ * state machinery's job — the console deliberately still shows a context-matching row whose
+ * receipt was already decided — so the equality is asserted on the pending slice, which is the
+ * slice where a person can act.
+ */
+beforeEach(function (): void {
+    $verdict = dirname(__DIR__, 2).'/vendor/fissible/verdict/database/migrations';
+    (require $verdict.'/create_verdict_approval_receipts_table.php.stub')->up();
+    (require $verdict.'/add_proposal_provenance_to_verdict_approval_receipts_table.php.stub')->up();
+    (require $verdict.'/add_approval_context_to_verdict_approval_receipts_table.php.stub')->up();
+
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/database/migrations/add_approval_context_to_verdict_console_pending_approvals_table.php.stub')->up();
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists('verdict_console_pending_approvals');
+    Schema::dropIfExists('verdict_approval_receipts');
+});
+
+/** @param array<string, string|int>|null $context */
+function subsetReceipt(string $toolCallId, ?array $context): ApprovalReceipt
+{
+    $now = new DateTimeImmutable('2026-08-30T12:00:00+00:00');
+
+    $receipt = new ApprovalReceipt(
+        id: 'receipt-'.$toolCallId,
+        toolCallId: $toolCallId,
+        capability: 'orders.cancel',
+        bindingFingerprint: hash('sha256', $toolCallId.'-binding'),
+        provenance: null,
+        approvalContext: $context,
+        status: ApprovalReceiptStatus::Pending,
+        reason: null,
+        expiresAt: $now->modify('+15 minutes'),
+        approvedBy: null,
+        approvedAt: null,
+        rejectedBy: null,
+        rejectedAt: null,
+        consumedAt: null,
+        createdAt: $now,
+        updatedAt: $now,
+    );
+
+    app(ApprovalReceiptStore::class)->issue($receipt);
+
+    return $receipt;
+}
+
+it('shows exactly the pending rows Verdict would enumerate for the same scope', function (): void {
+    $store = new PendingApprovalStore;
+    $pairs = [
+        'call_acme' => ['tenant' => 'acme'],
+        'call_acme_ws' => ['tenant' => 'acme', 'workspace' => 7],
+        'call_beta' => ['tenant' => 'beta'],
+        'call_uncaptured' => null,
+        'call_decided' => ['tenant' => 'acme'],
+    ];
+
+    foreach ($pairs as $toolCallId => $context) {
+        subsetReceipt($toolCallId, $context);
+        $store->ingest(
+            toolCallId: $toolCallId,
+            conversationId: 'conv-'.$toolCallId,
+            receiptId: 'receipt-'.$toolCallId,
+            approvalContext: $context,
+        );
+    }
+
+    // Decided outside the console after capture: still context-visible, no longer pending.
+    app(ApprovalReceiptStore::class)->reject('receipt-call_decided', 'call_decided', 'someone-else', new DateTimeImmutable('2026-08-30T12:01:00+00:00'));
+
+    app()->instance(ApprovalScope::class, new ApprovalContextScope(['tenant' => 'acme']));
+
+    $visible = app(PendingApprovalStore::class)->visible();
+    $visibleToolCalls = array_map(static fn (PendingApproval $row): string => $row->tool_call_id, $visible);
+
+    // The scope dimension: every visible row carries the scope's identifiers; beta and the
+    // uncaptured row are outside it. The decided row remains visible — the inbox renders it as
+    // already decided — because lifecycle is not this boundary's job.
+    expect($visibleToolCalls)->toEqualCanonicalizing(['call_acme', 'call_acme_ws', 'call_decided']);
+
+    $enumerated = array_map(
+        static fn (ApprovalStatusView $view): string => $view->toolCallId,
+        app(ApprovalStatusReader::class)->pendingWithin(['tenant' => 'acme']),
+    );
+    $reader = app(ApprovalStatusReader::class);
+    $visiblePending = array_values(array_filter(
+        $visibleToolCalls,
+        static fn (string $toolCallId): bool => $reader->statusForToolCall($toolCallId)?->status === ApprovalReceiptStatus::Pending,
+    ));
+
+    // The subset guarantee, both directions on the actionable slice: what the console shows a
+    // person and still lets them decide is exactly what Verdict would enumerate for the scope.
+    expect($visiblePending)->toEqualCanonicalizing($enumerated)
+        ->and($enumerated)->toEqualCanonicalizing(['call_acme', 'call_acme_ws']);
+});


### PR DESCRIPTION
Closes #69 — the last item of v0.5.0.

ADR 0001 §4 (as amended) calls for a shipped `ApprovalScope` implementation keyed on the captured `approval_context` (#68's column). Its point: Verdict's `pendingWithin()` enumerates on `approval_context` with typed-exact containment (verdict ADR 0031 §3) — a console scope keyed on the **same** identifiers with the **same** rule is what makes *what the console shows a person a subset of what Verdict would let them decide*. Any other scope leaves those two answers free to diverge.

## What changed

- **`ApprovalContextScope`** — one new class implementing the existing `ApprovalScope` contract (not narrowed; arbitrary host scopes keep working unchanged, pinned). Constructor takes a non-empty `array<string, string|int>`; an empty scope is refused the way ADR 0031 refuses it: unscoped global visibility is deliberately not expressible.
- **Typed-exact, in PHP.** `apply()` discovers candidate rows (non-null, non-empty contexts) from the incoming model, applies ADR 0031 §3's containment in PHP — `array_key_exists` + strict `!==`, no backend JSON operator, none of any backend's number/string coercion (the same portability decision as verdict#327's reader) — and constrains the operator query by the matching keys. Safe to key by ids because the context is immutable after issue and console capture is first-write-wins.
- **Parity pinned, not assumed.** A ten-case dataset asserts Verdict's own `ApprovalScopeMatch` answer *and* the bound scope's visibility answer against the same expectation — drift on either side fails. Coercion is refused in both directions (`7`≠`'7'`, `0`≠`'0'`), null/`[]` contexts never match, every scoped read (`visible()`/`findVisible()`/`isVisible()`) refuses the same rows, and a zero-match scope shows nothing rather than everything.
- **The subset property, measured.** An integration test against the real `DatabaseApprovalStatusReader`: with the scope bound on `tenant=acme`, the pending slice of what the console shows equals `pendingWithin(['tenant' => 'acme'])` in both directions — while a context-matching row whose receipt was decided elsewhere stays visible, because lifecycle is the state machinery's job, not this boundary's.
- **Docs**: design §7's tenancy bullet now carries the recommendation and its reason; the package default remains `UnscopedApprovalScope` — binding the recommended scope is the host's opt-in.

Suite: 427 passed (2276 assertions); phpstan clean, pint passed, type coverage 100%.
