### PR TITLE
docs: record v0.5.0 as the current released version

### DIFF
--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -13,7 +13,7 @@ That convention **ended there** — the number space is shared with pull request
 after #48 (#51, #63, #67–#69) carry descriptive titles and no `VC-` prefix. Refer to them by issue
 number; do not mint new `VC-` numbers.
 
-Current version: `0.4.0` (released 2026-08-30; v0.1.0–v0.4.0 milestones closed). Release procedure: fissible standards in
+Current version: `0.5.0` (released 2026-08-30; v0.1.0–v0.5.0 milestones closed). Release procedure: fissible standards in
 [`fissible/.github`](https://github.com/fissible/.github).
 
 ## Core package `fissible/verdict-console`


### PR DESCRIPTION
Post-release bookkeeping for v0.5.0 (the post-0.13 adoption cluster: VC-45 reader adoption, VC-68 approval_context capture, VC-86 durable retry, VC-69 the recommended ApprovalContextScope). Milestones v0.1.0–v0.5.0 are closed; tag, GitHub Release, and Packagist verified.