### PR TITLE
build: require Verdict ^0.14, the approvals-design-milestone release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Require Verdict `^0.14` (#93).** The 0.14 compatibility pass: the bound moves to the current
+  minor (the standing prefer-lowest reasoning — a disjunction would pin the lowest-dependency cell
+  to a superseded floor). Nothing in 0.14 reaches this package's behaviour: `Decision::edit()` now
+  throws `UnsupportedApprovalDecision` upstream, but the console only ever resumes with tool-call-id-keyed
+  approve/reject and offers no widened decision shape; the new `verdict:validate` session-timezone
+  audit is host-side tooling; verdict#306 (challenge contents) did not land, so the approval item
+  read-model is untouched.
+
 ## [0.5.0] - 2026-08-30
 
 - **Recommended approval-context scope (VC-69).** `ApprovalContextScope` implements the existing

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ the shipped authority **fails closed** until you do.
 - PHP 8.3+
 - Laravel 12 or 13
 - `laravel/ai` ^0.11
-- `fissible/verdict` ^0.13
+- `fissible/verdict` ^0.14
 
 ## Development
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "illuminate/routing": "^12.0||^13.0",
     "illuminate/support": "^12.0||^13.0",
     "illuminate/view": "^12.0||^13.0",
-    "fissible/verdict": "^0.13",
+    "fissible/verdict": "^0.14",
     "laravel/ai": "^0.11.0"
   },
   "require-dev": {
@@ -85,7 +85,7 @@
   "extra": {
     "verdict-console": {
       "dependency_constraints": {
-        "fissible/verdict": "^0.13 only: 0.13 is the first release carrying ApprovalStatusReader (ADR 0031), and ^0.x disjunctions make prefer-lowest skip the supported current minor."
+        "fissible/verdict": "^0.14 only: the console tracks the current Verdict minor (0.14, the approvals design milestone), and ^0.x disjunctions make prefer-lowest skip the supported current minor."
       }
     },
     "laravel": {


### PR DESCRIPTION
Closes #93 — the standing per-minor compatibility pass, same shape as #74/PR #75. The full 0.14 analysis is in the issue; this PR records the outcome.

## Outcome

- **The bump forces nothing.** Full suite against verdict `v0.14.0`: **427 passed (2276 assertions)**, phpstan clean, pint passed, type coverage 100% — zero code changes required. Every migration stub name the test harness requires is unchanged in 0.14.
- **`^0.14` alone** (the standing prefer-lowest reasoning from #63/#74: a disjunction would pin the lowest-dependency cell to a superseded floor); `composer.json`'s constraint annotation and the README requirement updated to match.
- **verdict#396** (`Decision::edit()` → `UnsupportedApprovalDecision`): unreachable from console paths — resolution, close, and retry send only tool-call-id-keyed approve/reject, and no surface offers a widened decision shape (ADR 0001 §5). No console doc claimed the old silent-drop behavior, so nothing to correct.
- **verdict#309** (session-timezone audit in `verdict:validate`): host-side tooling; noted in the issue that the console's own `timestamp()` columns share the reinterpretation pattern the audit guards — pointing hosts at the audit from console docs is a possible follow-up, deliberately not smuggled into a build pass.
- **verdict#306 did not land** (still OPEN): no challenge-contents change, so the approval item read-model is untouched. Recorded in #93 so the next pass knows to look for it.