### PR TITLE
Paged evidence read on the query boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Paged evidence read (#99).** `EvidenceQuery::searchPage()` now offers volume-bound evidence
+  surfaces a newest-first page and matching filtered total, while `search()` remains the complete
+  projection used by the existing audit component.
+
 ## [0.6.0] - 2026-08-31
 
 - **Require Verdict `^0.14` (#93).** The 0.14 compatibility pass: the bound moves to the current

--- a/src/Contracts/EvidenceQuery.php
+++ b/src/Contracts/EvidenceQuery.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fissible\VerdictConsole\Contracts;
 
 use Fissible\VerdictConsole\Evidence\EvidenceFilter;
+use Fissible\VerdictConsole\Evidence\EvidencePage;
 use Fissible\VerdictConsole\Evidence\EvidenceQueryResult;
 
 /**
@@ -17,4 +18,6 @@ use Fissible\VerdictConsole\Evidence\EvidenceQueryResult;
 interface EvidenceQuery
 {
     public function search(EvidenceFilter $filter): EvidenceQueryResult;
+
+    public function searchPage(EvidenceFilter $filter, int $page, int $perPage): EvidencePage;
 }

--- a/src/Evidence/DatabaseEvidenceQuery.php
+++ b/src/Evidence/DatabaseEvidenceQuery.php
@@ -125,7 +125,10 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
         return $query;
     }
 
-    /** @param iterable<object> $rows @return list<EvidenceRecord> */
+    /**
+     * @param  iterable<\stdClass>  $rows
+     * @return list<EvidenceRecord>
+     */
     private function records(iterable $rows): array
     {
         $records = [];

--- a/src/Evidence/DatabaseEvidenceQuery.php
+++ b/src/Evidence/DatabaseEvidenceQuery.php
@@ -9,6 +9,7 @@ use DateTimeZone;
 use Fissible\VerdictConsole\Contracts\EvidenceQuery;
 use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\Query\Builder;
 
 /**
  * Reads Verdict's published `verdict_evidence` decision-row schema without depending on its writer.
@@ -32,15 +33,7 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
 
     public function search(EvidenceFilter $filter): EvidenceQueryResult
     {
-        $invocationIds = $filter->conversationId === null
-            ? []
-            : $this->invocations->invocationIdsFor($filter->conversationId);
-        // Materialize console-owned ids before querying evidence: verdict.evidence.connection may be
-        // a different connection, across which a SQL subquery cannot be composed.
-        $conversation = $filter->conversationId === null
-            ? null
-            : ($invocationIds === [] ? ConversationCorrelation::Unknown : ConversationCorrelation::Known);
-        $recording = $this->recording();
+        [$invocationIds, $conversation, $recording] = $this->context($filter);
 
         if ($recording['state'] !== EvidenceRecordingState::On) {
             return new EvidenceQueryResult($recording['state'], [], $recording['writer'], $conversation);
@@ -50,6 +43,54 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
             return new EvidenceQueryResult(EvidenceRecordingState::On, [], null, $conversation);
         }
 
+        $records = $this->records(
+            $this->filteredQuery($filter, $invocationIds, $conversation)->orderBy('recorded_at')->orderBy('id')->get(),
+        );
+
+        return new EvidenceQueryResult(EvidenceRecordingState::On, $records, null, $conversation);
+    }
+
+    public function searchPage(EvidenceFilter $filter, int $page, int $perPage): EvidencePage
+    {
+        $page = max(1, $page);
+        $perPage = max(1, $perPage);
+        [$invocationIds, $conversation, $recording] = $this->context($filter);
+
+        if ($recording['state'] !== EvidenceRecordingState::On) {
+            return new EvidencePage($recording['state'], [], 0, $page, $perPage, $recording['writer'], $conversation);
+        }
+
+        if ($conversation === ConversationCorrelation::Unknown) {
+            return new EvidencePage(EvidenceRecordingState::On, [], 0, $page, $perPage, null, $conversation);
+        }
+
+        $query = $this->filteredQuery($filter, $invocationIds, $conversation);
+        $total = (clone $query)->count();
+        $records = $this->records(
+            $query->orderByDesc('recorded_at')->orderByDesc('id')->forPage($page, $perPage)->get(),
+        );
+
+        return new EvidencePage(EvidenceRecordingState::On, $records, $total, $page, $perPage, null, $conversation);
+    }
+
+    /** @return array{0: list<string>, 1: ?ConversationCorrelation, 2: array{state: EvidenceRecordingState, writer: ?string}} */
+    private function context(EvidenceFilter $filter): array
+    {
+        $invocationIds = $filter->conversationId === null
+            ? []
+            : $this->invocations->invocationIdsFor($filter->conversationId);
+        // Materialize console-owned ids before querying evidence: verdict.evidence.connection may be
+        // a different connection, across which a SQL subquery cannot be composed.
+        $conversation = $filter->conversationId === null
+            ? null
+            : ($invocationIds === [] ? ConversationCorrelation::Unknown : ConversationCorrelation::Known);
+
+        return [$invocationIds, $conversation, $this->recording()];
+    }
+
+    /** @param list<string> $invocationIds */
+    private function filteredQuery(EvidenceFilter $filter, array $invocationIds, ?ConversationCorrelation $conversation): Builder
+    {
         $connection = $this->config->get('verdict.evidence.connection');
         $table = $this->config->get('verdict.evidence.table', 'verdict_evidence');
         $query = $this->database
@@ -81,9 +122,15 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
             $query->where('invocation_id', $filter->invocationId);
         }
 
+        return $query;
+    }
+
+    /** @param iterable<object> $rows @return list<EvidenceRecord> */
+    private function records(iterable $rows): array
+    {
         $records = [];
 
-        foreach ($query->orderBy('recorded_at')->orderBy('id')->get() as $row) {
+        foreach ($rows as $row) {
             $records[] = new EvidenceRecord(
                 id: (string) $row->id,
                 capability: $this->nullableString($row->capability),
@@ -108,7 +155,7 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
             );
         }
 
-        return new EvidenceQueryResult(EvidenceRecordingState::On, $records, null, $conversation);
+        return $records;
     }
 
     /** @return array{state: EvidenceRecordingState, writer: ?string} */

--- a/src/Evidence/EvidencePage.php
+++ b/src/Evidence/EvidencePage.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Evidence;
+
+/** @param list<EvidenceRecord> $records */
+final readonly class EvidencePage
+{
+    /** @param list<EvidenceRecord> $records */
+    public function __construct(
+        public EvidenceRecordingState $recording,
+        public array $records,
+        public int $total,
+        public int $page,
+        public int $perPage,
+        /** The configured writer when evidence is retained somewhere this table adapter cannot read. */
+        public ?string $recordedBy = null,
+        /** Null means no conversation filter was requested. */
+        public ?ConversationCorrelation $conversation = null,
+    ) {}
+}

--- a/src/View/Components/Evidence.php
+++ b/src/View/Components/Evidence.php
@@ -14,9 +14,10 @@ use Illuminate\View\Component;
 /**
  * Server-rendered audit table over the VC-13 evidence read boundary.
  *
- * Pagination deliberately happens in memory: VC-13 specifies one complete filtered projection and
- * has no limit/offset contract. A host with a table too large for that projection replaces
- * EvidenceQuery with a boundary suited to its own storage and audience rules.
+ * Pagination deliberately happens in memory: this component keeps VC-13's complete filtered
+ * projection even though EvidenceQuery also offers searchPage() for volume-bound surfaces. A host
+ * with a table too large for that projection replaces EvidenceQuery with a boundary suited to its
+ * own storage and audience rules.
  */
 final class Evidence extends Component
 {

--- a/tests/Feature/EvidencePageComponentTest.php
+++ b/tests/Feature/EvidencePageComponentTest.php
@@ -7,6 +7,7 @@ use Fissible\Verdict\Evidence\NullEvidenceRecorder;
 use Fissible\VerdictConsole\Contracts\EvidenceQuery;
 use Fissible\VerdictConsole\Evidence\ConversationInvocationStore;
 use Fissible\VerdictConsole\Evidence\EvidenceFilter;
+use Fissible\VerdictConsole\Evidence\EvidencePage;
 use Fissible\VerdictConsole\Evidence\EvidenceQueryResult;
 use Fissible\VerdictConsole\Evidence\EvidenceRecord;
 use Fissible\VerdictConsole\Evidence\EvidenceRecordingState;
@@ -174,6 +175,13 @@ final class RecordingEvidenceQuery implements EvidenceQuery
         $this->filter = $filter;
 
         return $this->result;
+    }
+
+    public function searchPage(EvidenceFilter $filter, int $page, int $perPage): EvidencePage
+    {
+        // The core Blade surface stays on the complete projection; reaching for the paged read
+        // here would silently change which boundary the audit page's honesty rests on.
+        throw new LogicException('The evidence Blade component reads the complete projection.');
     }
 }
 

--- a/tests/Feature/EvidenceQueryTest.php
+++ b/tests/Feature/EvidenceQueryTest.php
@@ -10,6 +10,7 @@ use Fissible\VerdictConsole\Evidence\ConversationCorrelation;
 use Fissible\VerdictConsole\Evidence\ConversationInvocationStore;
 use Fissible\VerdictConsole\Evidence\DatabaseEvidenceQuery;
 use Fissible\VerdictConsole\Evidence\EvidenceFilter;
+use Fissible\VerdictConsole\Evidence\EvidencePage;
 use Fissible\VerdictConsole\Evidence\EvidenceQueryResult;
 use Fissible\VerdictConsole\Evidence\EvidenceRecordingState;
 use Illuminate\Support\Facades\DB;
@@ -323,11 +324,163 @@ it('binds the shipped table adapter to a contract a host may replace', function 
         {
             return new EvidenceQueryResult(EvidenceRecordingState::On, []);
         }
+
+        public function searchPage(EvidenceFilter $filter, int $page, int $perPage): EvidencePage
+        {
+            return new EvidencePage(EvidenceRecordingState::On, [], total: 0, page: $page, perPage: $perPage);
+        }
     };
 
     app()->instance(EvidenceQuery::class, $replacement);
 
     expect(app(EvidenceQuery::class))->toBe($replacement);
+});
+
+// --- paged read -----------------------------------------------------------------------------------
+
+/**
+ * The paged read shape (#99): the same boundary, answering one page newest-first with the filtered
+ * total, so a surface whose evidence volume outgrows the complete projection can stop
+ * materializing it. search() and its complete-projection contract are unchanged.
+ */
+it('answers one page of decision evidence newest first with the filtered total', function (): void {
+    foreach (range(1, 5) as $i) {
+        insertEvidence(['id' => 'row-'.$i, 'record_type' => 'decision', 'stage' => 'proposal', 'disposition' => 'permit', 'recorded_at' => '2026-08-25 10:0'.$i.':00']);
+    }
+    insertEvidence(['id' => 'provenance-1', 'record_type' => 'provenance', 'stage' => 'input', 'disposition' => 'recorded', 'recorded_at' => '2026-08-25 11:00:00']);
+
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+
+    $page = app(EvidenceQuery::class)->searchPage(new EvidenceFilter, page: 2, perPage: 2);
+
+    expect($page->recording)->toBe(EvidenceRecordingState::On)
+        ->and(array_map(fn ($record) => $record->id, $page->records))->toBe(['row-3', 'row-2'])
+        ->and($page->total)->toBe(5)
+        ->and($page->page)->toBe(2)
+        ->and($page->perPage)->toBe(2);
+});
+
+it('orders same-instant evidence by id descending so pages cannot overlap between requests', function (): void {
+    insertEvidence(['id' => 'tie-a', 'record_type' => 'decision', 'stage' => 'proposal', 'disposition' => 'permit', 'recorded_at' => '2026-08-25 10:00:00']);
+    insertEvidence(['id' => 'tie-b', 'record_type' => 'decision', 'stage' => 'proposal', 'disposition' => 'permit', 'recorded_at' => '2026-08-25 10:00:00']);
+    insertEvidence(['id' => 'tie-c', 'record_type' => 'decision', 'stage' => 'proposal', 'disposition' => 'permit', 'recorded_at' => '2026-08-25 10:00:00']);
+
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+
+    $first = app(EvidenceQuery::class)->searchPage(new EvidenceFilter, page: 1, perPage: 2);
+    $second = app(EvidenceQuery::class)->searchPage(new EvidenceFilter, page: 2, perPage: 2);
+
+    expect(array_map(fn ($record) => $record->id, $first->records))->toBe(['tie-c', 'tie-b'])
+        ->and(array_map(fn ($record) => $record->id, $second->records))->toBe(['tie-a']);
+});
+
+it('applies every filter to the page and its total together', function (): void {
+    insertEvidence(['id' => 'permit', 'record_type' => 'decision', 'capability' => 'orders.refund', 'stage' => 'proposal', 'disposition' => 'permit', 'recorded_at' => '2026-08-25 10:00:00']);
+    insertEvidence(['id' => 'deny-early', 'record_type' => 'decision', 'capability' => 'orders.refund', 'stage' => 'proposal', 'disposition' => 'deny', 'invocation_id' => 'invocation-1', 'recorded_at' => '2026-08-25 09:00:00']);
+    insertEvidence(['id' => 'deny-1', 'record_type' => 'decision', 'capability' => 'orders.refund', 'stage' => 'proposal', 'disposition' => 'deny', 'invocation_id' => 'invocation-1', 'recorded_at' => '2026-08-25 11:00:00']);
+    insertEvidence(['id' => 'deny-2', 'record_type' => 'decision', 'capability' => 'orders.refund', 'stage' => 'proposal', 'disposition' => 'deny', 'invocation_id' => 'invocation-2', 'recorded_at' => '2026-08-25 12:00:00']);
+    insertEvidence(['id' => 'deny-late', 'record_type' => 'decision', 'capability' => 'orders.refund', 'stage' => 'proposal', 'disposition' => 'deny', 'invocation_id' => 'invocation-1', 'recorded_at' => '2026-08-25 14:00:00']);
+    insertEvidence(['id' => 'deny-other', 'record_type' => 'decision', 'capability' => 'billing.refund', 'stage' => 'proposal', 'disposition' => 'deny', 'recorded_at' => '2026-08-25 13:00:00']);
+
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+
+    // The slice honors every filter and the total counts the whole filtered set, not the table —
+    // the recorded-at bounds and the invocation filter must cut the count exactly as they cut the page.
+    $bounded = app(EvidenceQuery::class)->searchPage(
+        new EvidenceFilter(
+            disposition: 'deny',
+            capability: 'orders.refund',
+            recordedFrom: new DateTimeImmutable('2026-08-25 10:00:00 UTC'),
+            recordedUntil: new DateTimeImmutable('2026-08-25 13:00:00 UTC'),
+        ),
+        page: 1,
+        perPage: 1,
+    );
+
+    expect(array_map(fn ($record) => $record->id, $bounded->records))->toBe(['deny-2'])
+        ->and($bounded->total)->toBe(2);
+
+    $invocation = app(EvidenceQuery::class)->searchPage(new EvidenceFilter(invocationId: 'invocation-1'), page: 1, perPage: 2);
+
+    expect(array_map(fn ($record) => $record->id, $invocation->records))->toBe(['deny-late', 'deny-1'])
+        ->and($invocation->total)->toBe(3);
+});
+
+it('spans a conversations invocations in the paged read and degrades unknown ones identically', function (): void {
+    $correlations = new ConversationInvocationStore;
+    $correlations->record('invocation-pause', 'conversation-a');
+    $correlations->record('invocation-resume', 'conversation-a');
+
+    insertEvidence(['id' => 'pause', 'record_type' => 'decision', 'stage' => 'proposal', 'disposition' => 'require_confirmation', 'invocation_id' => 'invocation-pause', 'recorded_at' => '2026-08-25 10:00:00']);
+    insertEvidence(['id' => 'resume', 'record_type' => 'decision', 'stage' => 'execution', 'disposition' => 'permit', 'invocation_id' => 'invocation-resume', 'recorded_at' => '2026-08-25 10:05:00']);
+    insertEvidence(['id' => 'unrelated', 'record_type' => 'decision', 'stage' => 'proposal', 'disposition' => 'permit', 'recorded_at' => '2026-08-25 10:06:00']);
+
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+
+    $known = app(EvidenceQuery::class)->searchPage(new EvidenceFilter(conversationId: 'conversation-a'), page: 1, perPage: 10);
+    $unknown = app(EvidenceQuery::class)->searchPage(new EvidenceFilter(conversationId: 'conversation-never-seen'), page: 1, perPage: 10);
+
+    expect($known->conversation)->toBe(ConversationCorrelation::Known)
+        ->and(array_map(fn ($record) => $record->id, $known->records))->toBe(['resume', 'pause'])
+        ->and($known->total)->toBe(2)
+        ->and($unknown->conversation)->toBe(ConversationCorrelation::Unknown)
+        ->and($unknown->records)->toBe([])
+        ->and($unknown->total)->toBe(0);
+});
+
+it('answers off and elsewhere recording states in the paged shape without touching the table', function (): void {
+    (new ConversationInvocationStore)->record('invocation-1', 'conversation-a');
+    insertEvidence(['id' => 'retained', 'record_type' => 'decision', 'stage' => 'proposal', 'disposition' => 'permit', 'recorded_at' => '2026-08-25 10:00:00']);
+
+    $evidenceQueries = [];
+    DB::listen(function ($query) use (&$evidenceQueries): void {
+        if (str_contains($query->sql, 'console_test_evidence')) {
+            $evidenceQueries[] = $query->sql;
+        }
+    });
+
+    $off = app(EvidenceQuery::class)->searchPage(new EvidenceFilter, page: 1, perPage: 10);
+    $offKnown = app(EvidenceQuery::class)->searchPage(new EvidenceFilter(conversationId: 'conversation-a'), page: 1, perPage: 10);
+
+    config()->set('verdict.evidence.writer', 'App\\Evidence\\ExternalWriter');
+
+    $elsewhere = app(EvidenceQuery::class)->searchPage(new EvidenceFilter, page: 1, perPage: 10);
+    $elsewhereUnknown = app(EvidenceQuery::class)->searchPage(new EvidenceFilter(conversationId: 'conversation-never-seen'), page: 1, perPage: 10);
+
+    // Rows the configuration says this adapter may not vouch for stay out of the page AND the
+    // total — a nonzero total over an unreadable page would invent evidence — while the
+    // console-owned conversation mapping still answers, exactly as search() does. And the claim in
+    // this test's name is measured: no query touches the evidence table in any of these calls.
+    expect($off->recording)->toBe(EvidenceRecordingState::Off)
+        ->and($off->records)->toBe([])
+        ->and($off->total)->toBe(0)
+        ->and($offKnown->conversation)->toBe(ConversationCorrelation::Known)
+        ->and($offKnown->records)->toBe([])
+        ->and($offKnown->total)->toBe(0)
+        ->and($elsewhere->recording)->toBe(EvidenceRecordingState::Elsewhere)
+        ->and($elsewhere->recordedBy)->toBe('App\\Evidence\\ExternalWriter')
+        ->and($elsewhere->records)->toBe([])
+        ->and($elsewhere->total)->toBe(0)
+        ->and($elsewhereUnknown->conversation)->toBe(ConversationCorrelation::Unknown)
+        ->and($elsewhereUnknown->total)->toBe(0)
+        ->and($evidenceQueries)->toBe([]);
+});
+
+it('returns an empty page with the real total beyond the last page and clamps degenerate inputs', function (): void {
+    insertEvidence(['id' => 'only', 'record_type' => 'decision', 'stage' => 'proposal', 'disposition' => 'permit', 'recorded_at' => '2026-08-25 10:00:00']);
+
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+
+    $beyond = app(EvidenceQuery::class)->searchPage(new EvidenceFilter, page: 9, perPage: 10);
+    $clamped = app(EvidenceQuery::class)->searchPage(new EvidenceFilter, page: 0, perPage: 0);
+
+    // An audit page fed page=0 by a UI must not throw or lie; it answers the first page, one row.
+    expect($beyond->records)->toBe([])
+        ->and($beyond->total)->toBe(1)
+        ->and($beyond->page)->toBe(9)
+        ->and($clamped->page)->toBe(1)
+        ->and($clamped->perPage)->toBe(1)
+        ->and(array_map(fn ($record) => $record->id, $clamped->records))->toBe(['only']);
 });
 
 /** @param array<string, mixed> $attributes */


### PR DESCRIPTION
Closes #99; unblocks verdict-console-filament#8.

`EvidenceQuery` gains `searchPage(EvidenceFilter, int $page, int $perPage): EvidencePage` — a newest-first page (id-descending tie-break, so same-instant rows cannot straddle or duplicate across pages) carrying the filtered total, echoed page/perPage, and the same recording/conversation vocabulary as the complete projection. Every filter cuts the slice and the total together; `Off`/`Elsewhere`/unknown-conversation answer an empty page with a zero total without touching the evidence table (a nonzero total over an unreadable page would invent evidence — and the no-read claim is pinned by a SQL listener); page/perPage below 1 clamp rather than throw, so a UI passing 0 cannot 500 an audit page.

`search()` is unchanged, and the core Blade audit component deliberately stays on the complete projection — its test double now throws on `searchPage` to keep that decision executable.

**Breaking for boundary implementors:** any host or adapter class implementing `EvidenceQuery` must add the method. The adapters' test doubles pick it up with their next console pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)