### PR TITLE
Run every release guard before any file mutation

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -151,6 +151,36 @@ esac
 new_version="${major}.${minor}.${patch}"
 new_tag="v${new_version}"
 
+# --- remaining guards: nothing past the Proceed prompt may refuse ---
+#
+# Every check that can die runs before the changelog preparer touches a file. A refusal after
+# mutation leaves a dirty tree, and the retry then dies on "Working tree is dirty" with no hint
+# that the script itself dirtied it — verdict-console-filament's first release hit exactly that.
+#
+# Composer's caret pins the leftmost non-zero component, so on a 0.x line ^0.5
+# means >=0.5.0 <0.6.0. A minor bump therefore leaves a README that still says
+# ^0.4 documenting a range that excludes the release it ships with — readers
+# following it install the previous minor and silently miss every fix in this
+# one. Derive the constraint here rather than hand-editing it each release.
+
+package=""
+constraint=""
+if [[ -f README.md && -f composer.json ]]; then
+    package=$(php -r 'echo json_decode(file_get_contents("composer.json"), true)["name"] ?? "";')
+    [[ -n "$package" ]] || die "composer.json has no package name — cannot update the README constraint"
+
+    if (( major == 0 )); then
+        constraint="^0.${minor}"      # pre-1.0: the minor is the compatibility boundary
+    else
+        constraint="^${major}.0"      # post-1.0: the major is
+    fi
+
+    # A silent no-op here would reintroduce exactly the drift this guards against,
+    # so a README that no longer carries the line stops the release.
+    grep -q "composer require ${package}:" README.md \
+        || die "no 'composer require ${package}:' line in README.md — refusing to release with an unverifiable install constraint"
+fi
+
 printf '\nNew version: %s → %s\n\n' "$current" "$new_version"
 confirm "Proceed?" || { printf 'Aborted.\n'; exit 0; }
 
@@ -178,28 +208,8 @@ if [[ -f package.json ]]; then
 fi
 
 # --- update the documented install constraint ---
-#
-# Composer's caret pins the leftmost non-zero component, so on a 0.x line ^0.5
-# means >=0.5.0 <0.6.0. A minor bump therefore leaves a README that still says
-# ^0.4 documenting a range that excludes the release it ships with — readers
-# following it install the previous minor and silently miss every fix in this
-# one. Derive the constraint here rather than hand-editing it each release.
 
-if [[ -f README.md && -f composer.json ]]; then
-    package=$(php -r 'echo json_decode(file_get_contents("composer.json"), true)["name"] ?? "";')
-    [[ -n "$package" ]] || die "composer.json has no package name — cannot update the README constraint"
-
-    if (( major == 0 )); then
-        constraint="^0.${minor}"      # pre-1.0: the minor is the compatibility boundary
-    else
-        constraint="^${major}.0"      # post-1.0: the major is
-    fi
-
-    # A silent no-op here would reintroduce exactly the drift this guards against,
-    # so a README that no longer carries the line stops the release.
-    grep -q "composer require ${package}:" README.md \
-        || die "no 'composer require ${package}:' line in README.md — refusing to release with an unverifiable install constraint"
-
+if [[ -n "$package" ]]; then
     replace_in_file README.md "s|composer require ${package}:[^[:space:]]*|composer require ${package}:${constraint}|g"
     printf 'README install constraint: %s\n' "$constraint"
 fi

--- a/tests/Unit/ReleaseScriptFirstReleaseTest.php
+++ b/tests/Unit/ReleaseScriptFirstReleaseTest.php
@@ -130,3 +130,38 @@ it('still requires a bump once a previous tag exists', function (): void {
         removeFirstReleaseRepository($work);
     }
 })->skipOnWindows();
+
+it('leaves the tree exactly as it found it when a guard refuses after confirmation', function (): void {
+    [$work] = scaffoldFirstReleaseRepository();
+
+    try {
+        // The filament v0.1.0 incident: a README without the install-constraint line. The refusal
+        // must come before any file is rewritten — a mutated CHANGELOG makes the retry die on
+        // "Working tree is dirty" with no hint that the script itself dirtied it.
+        file_put_contents($work.'/README.md', "# Example\n\nNo install line yet.\n");
+
+        $env = [
+            'GIT_AUTHOR_NAME' => 'Test', 'GIT_AUTHOR_EMAIL' => 'test@example.com',
+            'GIT_COMMITTER_NAME' => 'Test', 'GIT_COMMITTER_EMAIL' => 'test@example.com',
+        ];
+        (new Process(['git', 'commit', '--quiet', '-am', 'docs: drop the install line'], $work, $env))->mustRun();
+        (new Process(['git', 'push', '--quiet'], $work, $env))->mustRun();
+
+        $before = (string) file_get_contents($work.'/CHANGELOG.md');
+
+        // first release as-is? → y · Proceed? → y (the refusal must arrive before either matters)
+        $process = runReleaseScript($work, ['y', 'y']);
+
+        $status = (new Process(['git', 'status', '--porcelain'], $work))->mustRun()->getOutput();
+        $tags = (new Process(['git', 'tag', '--list'], $work))->mustRun()->getOutput();
+
+        expect($process->isSuccessful())->toBeFalse()
+            ->and($process->getErrorOutput())->toContain("no 'composer require fissible/example:' line in README.md")
+            ->and(trim($status))->toBe('')
+            ->and((string) file_get_contents($work.'/CHANGELOG.md'))->toBe($before)
+            ->and(trim((string) file_get_contents($work.'/VERSION')))->toBe('0.1.0')
+            ->and(trim($tags))->toBe('');
+    } finally {
+        removeFirstReleaseRepository($work);
+    }
+})->skipOnWindows();


### PR DESCRIPTION
Closes #98.

A guard that refused after the changelog preparer had already rolled `[Unreleased]` left the tree dirty, and the retry then died on `Working tree is dirty` with no hint that the script itself dirtied it — the filament v0.1.0 first release hit exactly that. The package-name check, install-constraint derivation, and README install-line guard now run before the Proceed prompt; the mutation phase can no longer refuse. Pinned by a hermetic run of the real `release.sh`: a refused release must leave the working tree, CHANGELOG, VERSION, and tag list exactly as it found them.

Sibling repos carry copies of this script — propagate after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)