### PR TITLE
feat: report a chained evidence sink as chained, never a readable table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Chained-sink recording state (#104).** `EvidenceRecordingState::Chained`: an attest
+  configuration now answers "a chained sink is configured; decisions are not readable from this
+  table" — naming the fixed chain id or the resolver class configuration proves, and resolving
+  nothing to learn it — instead of "On" over a table holding only chain-gap markers, which read
+  as "nothing happened". The state claims configuration only: never that any append succeeded,
+  that the chain verifies, or that no gap exists — those claims belong to the integrity ADR
+  (#108).
+
 ## [0.7.0] - 2026-08-31
 
 - **Paged evidence read (#99).** `EvidenceQuery::searchPage()` now offers volume-bound evidence

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -298,6 +298,7 @@ Over `DecisionEvidence`, honoring ADR 0008 (fingerprints, not raw), surfacing `c
 - **Default recorder is `NullEvidenceRecorder`** — these surfaces are dark on a default install *by
   design*. The UI must detect it and say *"recording is off — blank by config,"* never render an
   empty table that reads as "nothing happened." [`config/verdict.php`]
+- **Attest recorder is a chained sink** — when configured, the UI says a chained sink is configured; decisions are not readable from this table, never rendering its chain-gap table as an empty decision history. This state claims configuration only: never that any append succeeded, that the chain verifies, or that no gap exists.
 - **`DecisionEvidence` has `invocationId` but no `conversationId`.**
   [`src/Evidence/DecisionEvidence.php`] "Filter evidence by conversation" is therefore **not native** —
   it depends on a console-owned correlation projection (invocationId ↔ conversationId), captured at

--- a/resources/views/components/evidence.blade.php
+++ b/resources/views/components/evidence.blade.php
@@ -1,6 +1,8 @@
 <section data-verdict-console="evidence" data-recording="{{ $result->recording->value }}" data-page="{{ $page }}" data-pages="{{ $pages }}"@if ($conversation !== null) data-conversation="{{ $result->conversation?->value ?? 'unknown' }}"@endif>
     @if ($result->recording->value === 'off')
         <p data-recording-off>recording is off — blank by config.</p>
+    @elseif ($result->recording->value === 'chained')
+        <p data-recording-chained>A chained sink{{ $result->recordedBy === null ? '' : " ({$result->recordedBy})" }} is configured; decisions are not readable from this table.</p>
     @elseif ($result->recording->value === 'elsewhere')
         <p data-recording-elsewhere>Evidence is recorded elsewhere by {{ $result->recordedBy }}.</p>
     @elseif ($conversation !== null && $result->conversation?->value === 'unknown')

--- a/src/Evidence/DatabaseEvidenceQuery.php
+++ b/src/Evidence/DatabaseEvidenceQuery.php
@@ -165,8 +165,9 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
     private function recording(): array
     {
         // Verdict's narrow writer takes precedence over the legacy mixed recorder. The table is a
-        // known sink only for the two shipped durable recorders; an unknown configured writer may
-        // retain evidence elsewhere, so calling it an empty table would lie to an operator.
+        // known sink only for the database recorder. Attest appends decisions to a chain and leaves
+        // only chain-gap markers in this table; an unknown configured writer may retain evidence
+        // elsewhere. Calling either an empty table would lie to an operator.
         $writer = $this->config->get('verdict.evidence.writer');
         $effectiveWriter = $writer ?? $this->config->get('verdict.evidence.recorder', self::NULL_RECORDER);
 
@@ -174,14 +175,34 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
             return ['state' => EvidenceRecordingState::Off, 'writer' => null];
         }
 
-        if (in_array($effectiveWriter, [self::DATABASE_RECORDER, self::ATTEST_RECORDER], true)) {
+        if ($effectiveWriter === self::DATABASE_RECORDER) {
             return ['state' => EvidenceRecordingState::On, 'writer' => null];
+        }
+
+        if ($effectiveWriter === self::ATTEST_RECORDER) {
+            return ['state' => EvidenceRecordingState::Chained, 'writer' => $this->chainIdentity()];
         }
 
         return [
             'state' => EvidenceRecordingState::Elsewhere,
             'writer' => is_string($effectiveWriter) ? $effectiveWriter : null,
         ];
+    }
+
+    private function chainIdentity(): ?string
+    {
+        $chain = $this->config->get('verdict.evidence.attest.chain');
+        $resolver = $this->config->get('verdict.evidence.attest.chain_resolver');
+
+        if (is_string($chain) && $chain !== '' && $resolver === null) {
+            return $chain;
+        }
+
+        if ($chain === null && is_string($resolver) && $resolver !== '') {
+            return $resolver;
+        }
+
+        return null;
     }
 
     private function nullableString(mixed $value): ?string

--- a/src/Evidence/EvidenceRecordingState.php
+++ b/src/Evidence/EvidenceRecordingState.php
@@ -9,5 +9,6 @@ enum EvidenceRecordingState: string
 {
     case Off = 'off';
     case On = 'on';
+    case Chained = 'chained';
     case Elsewhere = 'elsewhere';
 }

--- a/tests/Feature/DocumentationCorrectionsTest.php
+++ b/tests/Feature/DocumentationCorrectionsTest.php
@@ -216,3 +216,10 @@ it('records the recommended context scope and its subset guarantee in the design
         ->toContain('a subset of what Verdict would let them decide')
         ->toContain('typed-exact');
 });
+
+/** #104's honest state: the design must state the chained-sink rule in the surfaces' own words. */
+it('documents the chained-sink recording state in the design of record', function (): void {
+    expect(documentation('docs/design/0001-verdict-console-design.md'))
+        ->toContain('chained sink is configured; decisions are not readable from this table')
+        ->toContain('never that any append succeeded');
+});

--- a/tests/Feature/EvidencePageComponentTest.php
+++ b/tests/Feature/EvidencePageComponentTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Fissible\Verdict\Evidence\AttestEvidenceRecorder;
 use Fissible\Verdict\Evidence\DatabaseEvidenceRecorder;
 use Fissible\Verdict\Evidence\NullEvidenceRecorder;
 use Fissible\VerdictConsole\Contracts\EvidenceQuery;
@@ -479,4 +480,69 @@ it('publishes with the other views', function (): void {
     expect(File::exists($target.'/components/evidence.blade.php'))->toBeTrue();
 
     File::deleteDirectory($target);
+});
+
+/**
+ * The chained notice's own element, text-normalized, so its copy is judged exactly: the honest
+ * sentence and the identity, with no room for integrity overclaims beside them.
+ */
+function chainedNotice(string $html): string
+{
+    $document = new DOMDocument;
+    libxml_use_internal_errors(true);
+    $document->loadHTML('<?xml encoding="utf-8" ?>'.$html);
+    libxml_clear_errors();
+
+    foreach ((new DOMXPath($document))->query('//*[@data-recording-chained]') ?: [] as $node) {
+        return trim((string) preg_replace('/\s+/', ' ', $node->textContent));
+    }
+
+    throw new LogicException('No chained-sink notice was rendered.');
+}
+
+/**
+ * #104 on the surface: an attest-only configuration must never render an empty table implying no
+ * decisions. The notice's copy is pinned exactly: it claims configuration only — a chained sink is
+ * selected — never that any append succeeded or that the chain verifies; those claims belong to
+ * the integrity ADR (#108).
+ */
+it('says a chained sink is configured instead of rendering an empty table', function (): void {
+    config()->set('verdict.evidence.recorder', AttestEvidenceRecorder::class);
+    config()->set('verdict.evidence.attest.chain', 'main-ledger');
+    insertAuditEvidence(['id' => 'stray-decision', 'recorded_at' => '2026-08-30 10:00:00']);
+
+    $html = renderEvidence();
+
+    expect(rootAttribute($html, 'data-recording'))->toBe('chained')
+        ->and(chainedNotice($html))->toBe('A chained sink (main-ledger) is configured; decisions are not readable from this table.')
+        ->and($html)->not->toContain('<table')
+        ->and($html)->not->toContain('stray-decision')
+        ->and($html)->not->toContain('No decisions')
+        ->and($html)->not->toContain('recording is off')
+        ->and($html)->not->toContain('recorded elsewhere');
+});
+
+/**
+ * Attest selected through the narrow writer key reaches the same surface state, and with a tenant
+ * resolver the class chosen to mint chain ids is the identity config proves.
+ */
+it('names the chain resolver when the narrow writer selects attest without a fixed chain id', function (): void {
+    config()->set('verdict.evidence.writer', AttestEvidenceRecorder::class);
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+    config()->set('verdict.evidence.attest.chain_resolver', 'App\Support\UnresolvableTenantChainResolver');
+
+    $html = renderEvidence();
+
+    expect(rootAttribute($html, 'data-recording'))->toBe('chained')
+        ->and(chainedNotice($html))->toBe('A chained sink (App\Support\UnresolvableTenantChainResolver) is configured; decisions are not readable from this table.');
+});
+
+/** A misconfigured chained sink still is one; the sentence stands alone when no identity exists. */
+it('renders the chained notice without an identity when neither chain nor resolver is set', function (): void {
+    config()->set('verdict.evidence.recorder', AttestEvidenceRecorder::class);
+
+    $html = renderEvidence();
+
+    expect(rootAttribute($html, 'data-recording'))->toBe('chained')
+        ->and(chainedNotice($html))->toBe('A chained sink is configured; decisions are not readable from this table.');
 });

--- a/tests/Feature/EvidenceQueryTest.php
+++ b/tests/Feature/EvidenceQueryTest.php
@@ -105,7 +105,131 @@ it('uses Verdicts narrow writer before the legacy recorder and distinguishes an 
         ->and($elsewhere->recording)->toBe(EvidenceRecordingState::Elsewhere)
         ->and($elsewhere->recordedBy)->toBe('App\\Evidence\\ExternalWriter')
         ->and($elsewhere->records)->toBe([])
-        ->and($attestWriter->recording)->toBe(EvidenceRecordingState::On);
+        ->and($attestWriter->recording)->toBe(EvidenceRecordingState::Chained, 'The attest recorder appends to a chain; calling it a readable table is the #104 defect.')
+        ->and($attestWriter->recordedBy)->toBeNull();
+});
+
+/**
+ * #104: the attest recorder appends decisions to the attest chain; the SQL table receives only
+ * chain_gap markers. "On" over that table reads as "nothing happened" — the exact lie the Off and
+ * Elsewhere states exist to prevent. The chained state claims configuration only: a chained sink
+ * is selected — never that any append succeeded, that the chain verifies, or that no gap exists.
+ */
+it('calls a chained sink chained and keeps the unreadable tables rows out of the answer', function (): void {
+    config()->set('verdict.evidence.recorder', AttestEvidenceRecorder::class);
+    config()->set('verdict.evidence.attest.chain', 'main-ledger');
+
+    // What an attest-only host's table really holds: a gap marker. The decision row is seeded
+    // anyway — an implementation that returns it is reading a table it just disclaimed.
+    insertEvidence(['id' => 'gap-1', 'record_type' => 'chain_gap', 'stage' => 'decision', 'disposition' => 'gap', 'recorded_at' => '2026-08-25 10:00:00']);
+    insertEvidence(['id' => 'stray-decision', 'record_type' => 'decision', 'stage' => 'proposal', 'disposition' => 'permit', 'recorded_at' => '2026-08-25 10:01:00']);
+
+    // The disclaimed table is not merely filtered out — nothing is queried at all: on an
+    // attest-only host verdict.evidence.connection may point somewhere this console cannot read,
+    // so a query is itself a side effect. Every statement counts, not just ones naming the
+    // fixture's table — a regression reading the fallback table by another name must fail too.
+    $evidenceQueries = [];
+    DB::listen(function ($query) use (&$evidenceQueries): void {
+        $evidenceQueries[] = $query->sql;
+    });
+
+    $result = app(EvidenceQuery::class)->search(new EvidenceFilter);
+
+    expect($result->recording)->toBe(EvidenceRecordingState::Chained)
+        ->and($result->recording->value)->toBe('chained', 'Adapter surfaces key on the string value.')
+        ->and($result->records)->toBe([])
+        ->and($result->recordedBy)->toBe('main-ledger')
+        ->and($evidenceQueries)->toBe([]);
+});
+
+/**
+ * The identity is what configuration proves: the fixed chain id, or the class chosen to mint one —
+ * never a resolved value. The resolver class deliberately does not exist: an implementation that
+ * instantiates it to learn the chain id fails loudly here, exactly as the adapter's
+ * configuration-inspection-only rule requires.
+ */
+it('names the configured chain identity without resolving anything', function (): void {
+    config()->set('verdict.evidence.recorder', AttestEvidenceRecorder::class);
+    config()->set('verdict.evidence.attest.chain', null);
+    config()->set('verdict.evidence.attest.chain_resolver', 'App\\Support\\UnresolvableTenantChainResolver');
+
+    $resolver = app(EvidenceQuery::class)->search(new EvidenceFilter);
+
+    config()->set('verdict.evidence.attest.chain_resolver', null);
+
+    $unnamed = app(EvidenceQuery::class)->search(new EvidenceFilter);
+
+    // The narrow writer reaches the same state the legacy recorder key does.
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+    config()->set('verdict.evidence.writer', AttestEvidenceRecorder::class);
+    config()->set('verdict.evidence.attest.chain', 'tenant-42-ledger');
+
+    $narrowWriter = app(EvidenceQuery::class)->search(new EvidenceFilter);
+
+    // Verdict's recorder construction rejects both keys set together as mutually exclusive chain
+    // topologies — but only when the recorder is resolved, which a console read never does. The
+    // console reports the state honestly and picks no side of a topology Verdict itself rejects.
+    config()->set('verdict.evidence.attest.chain_resolver', 'App\\Support\\UnresolvableTenantChainResolver');
+
+    $both = app(EvidenceQuery::class)->search(new EvidenceFilter);
+
+    expect($resolver->recording)->toBe(EvidenceRecordingState::Chained)
+        ->and($resolver->recordedBy)->toBe('App\\Support\\UnresolvableTenantChainResolver')
+        ->and($unnamed->recording)->toBe(EvidenceRecordingState::Chained)
+        ->and($unnamed->recordedBy)->toBeNull('A misconfigured chained sink still is one; there is just no identity to name.')
+        ->and($narrowWriter->recording)->toBe(EvidenceRecordingState::Chained)
+        ->and($narrowWriter->recordedBy)->toBe('tenant-42-ledger')
+        ->and($both->recording)->toBe(EvidenceRecordingState::Chained)
+        ->and($both->recordedBy)->toBeNull('Both keys set is a topology Verdict rejects; the console names no identity rather than inventing a winner.');
+});
+
+/** The paged shape answers chained exactly as search() does — and no query touches the table. */
+it('answers the chained state in the paged shape without touching the table', function (): void {
+    (new ConversationInvocationStore)->record('invocation-1', 'conversation-a');
+    insertEvidence(['id' => 'gap-1', 'record_type' => 'chain_gap', 'stage' => 'decision', 'disposition' => 'gap', 'recorded_at' => '2026-08-25 10:00:00']);
+
+    config()->set('verdict.evidence.recorder', AttestEvidenceRecorder::class);
+    config()->set('verdict.evidence.attest.chain', 'main-ledger');
+
+    // Only the console-owned conversation-mapping reads are legitimate here. A statement is
+    // unexpected unless it is a pure mapping read: a single SELECT (no subqueries), naming the
+    // mapping table, no join, and no table whose name contains "evidence" — reaching the
+    // disclaimed sink through a join, an EXISTS, or a differently named fallback table is still
+    // a read of a sink this adapter just disclaimed.
+    $evidenceQueries = [];
+    DB::listen(function ($query) use (&$evidenceQueries): void {
+        $sql = strtolower((string) $query->sql);
+
+        if (! str_starts_with(ltrim($sql), 'select')
+            || substr_count($sql, 'select') !== 1
+            || ! str_contains($sql, 'verdict_console_conversation_invocations')
+            || str_contains($sql, 'evidence')
+            || str_contains($sql, 'join')) {
+            $evidenceQueries[] = $sql;
+        }
+    });
+
+    $page = app(EvidenceQuery::class)->searchPage(new EvidenceFilter, page: 1, perPage: 10);
+    $known = app(EvidenceQuery::class)->searchPage(new EvidenceFilter(conversationId: 'conversation-a'), page: 1, perPage: 10);
+    $unknown = app(EvidenceQuery::class)->searchPage(new EvidenceFilter(conversationId: 'conversation-never-seen'), page: 1, perPage: 10);
+
+    // The console-owned conversation mapping still answers: whether Verdict retained anything this
+    // adapter can read is a separate fact, exactly as the off and elsewhere states already pin.
+    expect($page->recording)->toBe(EvidenceRecordingState::Chained)
+        ->and($page->records)->toBe([])
+        ->and($page->total)->toBe(0)
+        ->and($page->recordedBy)->toBe('main-ledger')
+        ->and($known->recording)->toBe(EvidenceRecordingState::Chained)
+        ->and($known->conversation)->toBe(ConversationCorrelation::Known)
+        ->and($known->records)->toBe([])
+        ->and($known->total)->toBe(0)
+        ->and($known->recordedBy)->toBe('main-ledger')
+        ->and($unknown->recording)->toBe(EvidenceRecordingState::Chained)
+        ->and($unknown->conversation)->toBe(ConversationCorrelation::Unknown)
+        ->and($unknown->records)->toBe([])
+        ->and($unknown->total)->toBe(0)
+        ->and($unknown->recordedBy)->toBe('main-ledger')
+        ->and($evidenceQueries)->toBe([]);
 });
 
 it('treats Verdicts absent recorder configuration as recording off', function (): void {


### PR DESCRIPTION
Closes #104.

An attest-only configuration's decision writes append to the attest chain; the SQL evidence table receives only `chain_gap` markers. `DatabaseEvidenceQuery::recording()` mapped `AttestEvidenceRecorder` to `On` — a readable-table claim — so the browser answered "On" over a table with no decision rows, which reads as "nothing happened": the exact lie the Off/Elsewhere states exist to prevent.

**What this does**
- Fourth state, `EvidenceRecordingState::Chained` (`'chained'`), distinct from a widened `Elsewhere`: the posture (#105) and integrity-ADR (#108) threads hang off this state, so it must be distinguishable by its string value.
- `recordedBy` carries the identity configuration proves: the fixed `verdict.evidence.attest.chain` id, else the `chain_resolver` class-string, else null — resolving and instantiating nothing (a test uses a deliberately nonexistent resolver class so any resolution fails loudly). Both-keys-set is a topology Verdict itself rejects at recorder construction, so the console names no identity rather than inventing a winner; the state still reads `Chained` because that throw only fires when the recorder is resolved, which a console read never does.
- `Chained` joins the Off/Elsewhere read contract on both `search()` and `searchPage()`: no records, zero total, conversation correlation still answered from the console-owned mapping, and no SQL beyond pure mapping reads (pinned: single-SELECT, no join, nothing naming an evidence table — on an attest-only host `verdict.evidence.connection` may not be readable at all).
- The Blade surface renders the exact notice: *"A chained sink (identity) is configured; decisions are not readable from this table."* — parenthetical omitted when there is no identity. The copy claims configuration selection only: never that any append succeeded, that the chain verifies, or that no gap exists; those claims belong to #108. The design of record documents the constraint beside the blank-by-config rule.

**Deliberately out of scope**
- Empty-string writer/chain divergences — #105 owns that alignment decision.
- Adapter surfaces (livewire/filament) consume the new `'chained'` value as versioned follow-on slices in their own repositories, per the issue.

Acceptance holds: an attest-only configuration never renders an empty table implying no decisions; the existing Off/On/Elsewhere pins are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
