### PR TITLE
Require Verdict ^0.15, the review-lane release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Require Verdict `^0.15` — the review-lane release.** The 0.15 compatibility pass: the bound
+  moves to the current minor per the standing prefer-lowest reasoning. What reaches this package:
+  the new `add_review_outcome` evidence stub joins both fixture guards (the column is additive and
+  `EvidenceRecord` does not expose it, so evidence surfaces are unchanged); the review-lane
+  substrate (#297, ADR 0035) shipped upstream, so the README now points its reviewer-queue surface
+  at #48 instead of calling the substrate planned. What does not: the #320/#436 decision-outcome
+  reordering — the resolution service re-reads live status before deciding and keys on no
+  refused-outcome string — and receipt retention pruning, whose pruned receipts read back as
+  absent, which the `receipt_unavailable` state already renders honestly.
 ## [0.8.0] - 2026-09-01
 
 - **Fingerprint pivot filters (#102).** `EvidenceFilter` grows six nullable pivot fields over the

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ AI's **`RemembersConversations`** concern with a real (non-fake) gateway. Non-`B
 are observable but not Verdict-drivable. See design §3.
 
 Verdict **`require_review` is a separate, gated review lane**: it has no receipt and does not resume
-an agent. Its durable review substrate and read API are planned in Verdict #297 and #298, so this
-package does not yet expose review items or treat decision evidence as an inbox.
+an agent. Its durable review substrate shipped in Verdict 0.15 (#297, ADR 0035) with a
+`ReviewStatusReader` read API; this package's reviewer-queue surface is tracked in #48, and until
+it lands review items are not exposed here and decision evidence is not an inbox.
 
 ## Package family
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "illuminate/routing": "^12.0||^13.0",
     "illuminate/support": "^12.0||^13.0",
     "illuminate/view": "^12.0||^13.0",
-    "fissible/verdict": "^0.14",
+    "fissible/verdict": "^0.15",
     "laravel/ai": "^0.11.0"
   },
   "require-dev": {

--- a/tests/Feature/DocumentationCorrectionsTest.php
+++ b/tests/Feature/DocumentationCorrectionsTest.php
@@ -160,10 +160,11 @@ it('cites the Verdict change that makes the evidence timestamp reading a UTC con
     expect(documentation('src/Evidence/DatabaseEvidenceQuery.php'))->toContain('fissible/verdict#335');
 });
 
-it('tells adopters that require_review awaits its gated Verdict substrate', function (): void {
+it('tells adopters the review-lane substrate shipped and where its surface is tracked', function (): void {
     expect(documentation('README.md'))
         ->toContain('`require_review` is a separate, gated review lane')
-        ->toContain('Verdict #297 and #298');
+        ->toContain('Verdict 0.15 (#297, ADR 0035)')
+        ->toContain('tracked in #48');
 });
 
 /**

--- a/tests/Feature/EvidencePageComponentTest.php
+++ b/tests/Feature/EvidencePageComponentTest.php
@@ -31,6 +31,7 @@ const AUDIT_EVIDENCE_STUBS = [
     'add_target_source_to_verdict_evidence_table.php.stub',
     'add_tool_description_fingerprints_to_verdict_evidence_table.php.stub',
     'add_record_identity_to_verdict_evidence_table.php.stub',
+    'add_review_outcome_to_verdict_evidence_table.php.stub',
     'add_intent_id_to_verdict_evidence_table.php.stub',
 ];
 

--- a/tests/Feature/EvidenceQueryTest.php
+++ b/tests/Feature/EvidenceQueryTest.php
@@ -33,6 +33,7 @@ const VERDICT_EVIDENCE_STUBS = [
     'add_target_source_to_verdict_evidence_table.php.stub',
     'add_tool_description_fingerprints_to_verdict_evidence_table.php.stub',
     'add_record_identity_to_verdict_evidence_table.php.stub',
+    'add_review_outcome_to_verdict_evidence_table.php.stub',
     'add_intent_id_to_verdict_evidence_table.php.stub',
 ];
 


### PR DESCRIPTION
The 0.15 compatibility pass, in the pattern of the ^0.14 one (#93): the bound moves to the current minor per the standing prefer-lowest reasoning.

**What reaches this package:** the new `add_review_outcome` evidence stub joins both fixture completeness guards (the column is additive and `EvidenceRecord` does not expose it, so evidence surfaces are unchanged); and the review-lane substrate (#297, ADR 0035) shipped upstream, so the README stops calling it planned and points the reviewer-queue surface at #48.

**What does not:** the #320/#436 decision-outcome reordering — the resolution service re-reads live status before deciding and keys on no refused-outcome string, and its receipt-store test doubles pass unchanged under the stricter undeclared-store path; receipt retention pruning, whose pruned receipts read back as absent, which `receipt_unavailable` already renders honestly; and #306's attested issuance, which is capability-configuration upstream of every console read.

Unblocks #46, #47, #48, and #96 for scheduling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)