### PR TITLE
feat: one evidence-sink posture boundary for every sink-answering surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ All notable changes to Verdict Console will be documented in this file.
   reordering — the resolution service re-reads live status before deciding and keys on no
   refused-outcome string — and receipt retention pruning, whose pruned receipts read back as
   absent, which the `receipt_unavailable` state already renders honestly.
+
+- **Evidence-sink posture read boundary (#105).** One console-owned, host-replaceable contract —
+  `EvidenceSinkPosture::read(): SinkPosture` — now answers "what is the evidence sink and can this
+  console read it": the effective writer (matching Verdict's own `EvidenceWriter` resolution,
+  parity-tested), the honesty state including 0.8's chained sinks, the table and connection only
+  while the sink is a readable table, and whether an attest chain is configured. The evidence read
+  boundary consumes it instead of keeping a second config derivation. Named divergence, decided:
+  an empty-string `writer`/`recorder` reads as unset for the posture (Verdict itself throws at
+  first resolution rather than falling back — measured; the old reading named a nonexistent
+  writer). Configuration proves selection only — the posture never implies recording is verified
+  or complete.
+
 ## [0.8.0] - 2026-09-01
 
 - **Fingerprint pivot filters (#102).** `EvidenceFilter` grows six nullable pivot fields over the

--- a/src/Contracts/EvidenceSinkPosture.php
+++ b/src/Contracts/EvidenceSinkPosture.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Contracts;
+
+use Fissible\VerdictConsole\Evidence\SinkPosture;
+
+/**
+ * Console-owned, host-replaceable read boundary for the configured evidence sink.
+ *
+ * Configuration proves selection only and never implies verified or complete recording.
+ */
+interface EvidenceSinkPosture
+{
+    public function read(): SinkPosture;
+}

--- a/src/Evidence/ConfigurationSinkPosture.php
+++ b/src/Evidence/ConfigurationSinkPosture.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Evidence;
+
+use Fissible\VerdictConsole\Contracts\EvidenceSinkPosture;
+use Illuminate\Contracts\Config\Repository as Config;
+
+/**
+ * Configuration-only sink selection reader. It never resolves or instantiates a recorder.
+ */
+final readonly class ConfigurationSinkPosture implements EvidenceSinkPosture
+{
+    private const string NULL_RECORDER = 'Fissible\\Verdict\\Evidence\\NullEvidenceRecorder';
+
+    private const string DATABASE_RECORDER = 'Fissible\\Verdict\\Evidence\\DatabaseEvidenceRecorder';
+
+    private const string ATTEST_RECORDER = 'Fissible\\Verdict\\Evidence\\AttestEvidenceRecorder';
+
+    public function __construct(private Config $config) {}
+
+    public function read(): SinkPosture
+    {
+        $effectiveWriter = $this->effectiveWriter();
+        $chain = $this->config->get('verdict.evidence.attest.chain');
+        $resolver = $this->config->get('verdict.evidence.attest.chain_resolver');
+
+        if (! is_string($effectiveWriter)) {
+            return new SinkPosture(
+                state: EvidenceRecordingState::Elsewhere,
+                effectiveWriter: null,
+                recordedBy: null,
+                table: null,
+                connection: null,
+                chainConfigured: $this->chainConfigured($chain, $resolver),
+            );
+        }
+
+        if ($effectiveWriter === self::NULL_RECORDER) {
+            return $this->posture(EvidenceRecordingState::Off, $effectiveWriter, null, $chain, $resolver);
+        }
+
+        if ($effectiveWriter === self::DATABASE_RECORDER) {
+            return $this->posture(EvidenceRecordingState::On, $effectiveWriter, null, $chain, $resolver);
+        }
+
+        if ($effectiveWriter === self::ATTEST_RECORDER) {
+            return $this->posture(EvidenceRecordingState::Chained, $effectiveWriter, $this->chainIdentity($chain, $resolver), $chain, $resolver);
+        }
+
+        return $this->posture(EvidenceRecordingState::Elsewhere, $effectiveWriter, $effectiveWriter, $chain, $resolver);
+    }
+
+    private function effectiveWriter(): mixed
+    {
+        $writer = $this->config->get('verdict.evidence.writer');
+
+        if (is_string($writer) && $writer !== '') {
+            return $writer;
+        }
+
+        if ($writer !== null && ! is_string($writer)) {
+            return $writer;
+        }
+
+        $recorder = $this->config->get('verdict.evidence.recorder');
+
+        if (is_string($recorder)) {
+            return $recorder === '' ? self::NULL_RECORDER : $recorder;
+        }
+
+        return $recorder ?? self::NULL_RECORDER;
+    }
+
+    private function posture(EvidenceRecordingState $state, string $effectiveWriter, ?string $recordedBy, mixed $chain, mixed $resolver): SinkPosture
+    {
+        $table = $state === EvidenceRecordingState::On ? $this->config->get('verdict.evidence.table', 'verdict_evidence') : null;
+        $connection = $state === EvidenceRecordingState::On ? $this->config->get('verdict.evidence.connection') : null;
+
+        return new SinkPosture(
+            state: $state,
+            effectiveWriter: $effectiveWriter,
+            recordedBy: $recordedBy,
+            table: $state === EvidenceRecordingState::On ? (is_string($table) ? $table : 'verdict_evidence') : null,
+            connection: is_string($connection) ? $connection : null,
+            chainConfigured: $this->chainConfigured($chain, $resolver),
+        );
+    }
+
+    private function chainIdentity(mixed $chain, mixed $resolver): ?string
+    {
+        $chain = is_string($chain) && $chain !== '' ? $chain : null;
+        $resolver = is_string($resolver) && $resolver !== '' ? $resolver : null;
+
+        return $chain !== null && $resolver === null ? $chain : ($chain === null ? $resolver : null);
+    }
+
+    private function chainConfigured(mixed $chain, mixed $resolver): bool
+    {
+        return (is_string($chain) && $chain !== '') || (is_string($resolver) && $resolver !== '');
+    }
+}

--- a/src/Evidence/DatabaseEvidenceQuery.php
+++ b/src/Evidence/DatabaseEvidenceQuery.php
@@ -7,7 +7,8 @@ namespace Fissible\VerdictConsole\Evidence;
 use DateTimeImmutable;
 use DateTimeZone;
 use Fissible\VerdictConsole\Contracts\EvidenceQuery;
-use Illuminate\Contracts\Config\Repository as Config;
+use Fissible\VerdictConsole\Contracts\EvidenceSinkPosture;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Query\Builder;
 
@@ -19,24 +20,18 @@ use Illuminate\Database\Query\Builder;
  */
 final readonly class DatabaseEvidenceQuery implements EvidenceQuery
 {
-    private const string NULL_RECORDER = 'Fissible\\Verdict\\Evidence\\NullEvidenceRecorder';
-
-    private const string DATABASE_RECORDER = 'Fissible\\Verdict\\Evidence\\DatabaseEvidenceRecorder';
-
-    private const string ATTEST_RECORDER = 'Fissible\\Verdict\\Evidence\\AttestEvidenceRecorder';
-
     public function __construct(
         private DatabaseManager $database,
-        private Config $config,
         private ConversationInvocationStore $invocations,
+        private Container $app,
     ) {}
 
     public function search(EvidenceFilter $filter): EvidenceQueryResult
     {
-        [$invocationIds, $conversation, $recording] = $this->context($filter);
+        [$invocationIds, $conversation, $posture] = $this->context($filter);
 
-        if ($recording['state'] !== EvidenceRecordingState::On) {
-            return new EvidenceQueryResult($recording['state'], [], $recording['writer'], $conversation);
+        if ($posture->state !== EvidenceRecordingState::On) {
+            return new EvidenceQueryResult($posture->state, [], $posture->recordedBy, $conversation);
         }
 
         if ($conversation === ConversationCorrelation::Unknown) {
@@ -44,7 +39,7 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
         }
 
         $records = $this->records(
-            $this->filteredQuery($filter, $invocationIds, $conversation)->orderBy('recorded_at')->orderBy('id')->get(),
+            $this->filteredQuery($filter, $invocationIds, $conversation, $posture)->orderBy('recorded_at')->orderBy('id')->get(),
         );
 
         return new EvidenceQueryResult(EvidenceRecordingState::On, $records, null, $conversation);
@@ -54,17 +49,17 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
     {
         $page = max(1, $page);
         $perPage = max(1, $perPage);
-        [$invocationIds, $conversation, $recording] = $this->context($filter);
+        [$invocationIds, $conversation, $posture] = $this->context($filter);
 
-        if ($recording['state'] !== EvidenceRecordingState::On) {
-            return new EvidencePage($recording['state'], [], 0, $page, $perPage, $recording['writer'], $conversation);
+        if ($posture->state !== EvidenceRecordingState::On) {
+            return new EvidencePage($posture->state, [], 0, $page, $perPage, $posture->recordedBy, $conversation);
         }
 
         if ($conversation === ConversationCorrelation::Unknown) {
             return new EvidencePage(EvidenceRecordingState::On, [], 0, $page, $perPage, null, $conversation);
         }
 
-        $query = $this->filteredQuery($filter, $invocationIds, $conversation);
+        $query = $this->filteredQuery($filter, $invocationIds, $conversation, $posture);
         $total = (clone $query)->count();
         $records = $this->records(
             $query->orderByDesc('recorded_at')->orderByDesc('id')->forPage($page, $perPage)->get(),
@@ -73,7 +68,7 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
         return new EvidencePage(EvidenceRecordingState::On, $records, $total, $page, $perPage, null, $conversation);
     }
 
-    /** @return array{0: list<string>, 1: ?ConversationCorrelation, 2: array{state: EvidenceRecordingState, writer: ?string}} */
+    /** @return array{0: list<string>, 1: ?ConversationCorrelation, 2: SinkPosture} */
     private function context(EvidenceFilter $filter): array
     {
         $invocationIds = $filter->conversationId === null
@@ -85,17 +80,19 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
             ? null
             : ($invocationIds === [] ? ConversationCorrelation::Unknown : ConversationCorrelation::Known);
 
-        return [$invocationIds, $conversation, $this->recording()];
+        return [$invocationIds, $conversation, $this->app->make(EvidenceSinkPosture::class)->read()];
     }
 
     /** @param list<string> $invocationIds */
-    private function filteredQuery(EvidenceFilter $filter, array $invocationIds, ?ConversationCorrelation $conversation): Builder
+    private function filteredQuery(EvidenceFilter $filter, array $invocationIds, ?ConversationCorrelation $conversation, SinkPosture $posture): Builder
     {
-        $connection = $this->config->get('verdict.evidence.connection');
-        $table = $this->config->get('verdict.evidence.table', 'verdict_evidence');
+        if ($posture->table === null) {
+            throw new \LogicException('A readable evidence posture must name a table.');
+        }
+
         $query = $this->database
-            ->connection(is_string($connection) ? $connection : null)
-            ->table(is_string($table) ? $table : 'verdict_evidence')
+            ->connection($posture->connection)
+            ->table($posture->table)
             ->where('record_type', 'decision');
 
         if ($filter->disposition !== null) {
@@ -183,50 +180,6 @@ final readonly class DatabaseEvidenceQuery implements EvidenceQuery
         }
 
         return $records;
-    }
-
-    /** @return array{state: EvidenceRecordingState, writer: ?string} */
-    private function recording(): array
-    {
-        // Verdict's narrow writer takes precedence over the legacy mixed recorder. The table is a
-        // known sink only for the database recorder. Attest appends decisions to a chain and leaves
-        // only chain-gap markers in this table; an unknown configured writer may retain evidence
-        // elsewhere. Calling either an empty table would lie to an operator.
-        $writer = $this->config->get('verdict.evidence.writer');
-        $effectiveWriter = $writer ?? $this->config->get('verdict.evidence.recorder', self::NULL_RECORDER);
-
-        if ($effectiveWriter === self::NULL_RECORDER) {
-            return ['state' => EvidenceRecordingState::Off, 'writer' => null];
-        }
-
-        if ($effectiveWriter === self::DATABASE_RECORDER) {
-            return ['state' => EvidenceRecordingState::On, 'writer' => null];
-        }
-
-        if ($effectiveWriter === self::ATTEST_RECORDER) {
-            return ['state' => EvidenceRecordingState::Chained, 'writer' => $this->chainIdentity()];
-        }
-
-        return [
-            'state' => EvidenceRecordingState::Elsewhere,
-            'writer' => is_string($effectiveWriter) ? $effectiveWriter : null,
-        ];
-    }
-
-    private function chainIdentity(): ?string
-    {
-        $chain = $this->config->get('verdict.evidence.attest.chain');
-        $resolver = $this->config->get('verdict.evidence.attest.chain_resolver');
-
-        if (is_string($chain) && $chain !== '' && $resolver === null) {
-            return $chain;
-        }
-
-        if ($chain === null && is_string($resolver) && $resolver !== '') {
-            return $resolver;
-        }
-
-        return null;
     }
 
     private function nullableString(mixed $value): ?string

--- a/src/Evidence/SinkPosture.php
+++ b/src/Evidence/SinkPosture.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Evidence;
+
+final readonly class SinkPosture
+{
+    public function __construct(
+        public EvidenceRecordingState $state,
+        public ?string $effectiveWriter,
+        public ?string $recordedBy,
+        public ?string $table,
+        public ?string $connection,
+        public bool $chainConfigured,
+    ) {}
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -25,10 +25,12 @@ use Fissible\VerdictConsole\Contracts\ChatEntry;
 use Fissible\VerdictConsole\Contracts\ConfigurationInspection;
 use Fissible\VerdictConsole\Contracts\ConversationParticipants;
 use Fissible\VerdictConsole\Contracts\EvidenceQuery;
+use Fissible\VerdictConsole\Contracts\EvidenceSinkPosture;
 use Fissible\VerdictConsole\Contracts\ExecutionClaimAuthority;
 use Fissible\VerdictConsole\Contracts\ResumableAgents;
 use Fissible\VerdictConsole\Events\ApprovalDecisionRefused;
 use Fissible\VerdictConsole\Events\ApprovalIngestionIncident;
+use Fissible\VerdictConsole\Evidence\ConfigurationSinkPosture;
 use Fissible\VerdictConsole\Evidence\DatabaseEvidenceQuery;
 use Fissible\VerdictConsole\ExecutionClaims\GateExecutionClaimAuthority;
 use Fissible\VerdictConsole\Http\VerdictConsoleRoutes;
@@ -92,6 +94,8 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         $this->app->singleton(ApprovalNotificationRecipients::class, UnconfiguredApprovalNotificationRecipients::class);
 
         $this->app->singleton(EvidenceQuery::class, DatabaseEvidenceQuery::class);
+
+        $this->app->singleton(EvidenceSinkPosture::class, ConfigurationSinkPosture::class);
 
         $this->app->singleton(ConfigurationInspection::class, VerdictConfigurationInspection::class);
 

--- a/tests/Feature/EvidenceSinkPostureTest.php
+++ b/tests/Feature/EvidenceSinkPostureTest.php
@@ -2,11 +2,6 @@
 
 declare(strict_types=1);
 
-use Fissible\Verdict\Contracts\EvidenceWriter;
-use Fissible\Verdict\Evidence\ContextReleaseEvidence;
-use Fissible\Verdict\Evidence\DecisionEvidence;
-use Fissible\Verdict\Evidence\ProvenanceDerivation;
-use Fissible\Verdict\Evidence\ProvenanceEntry;
 use Fissible\VerdictConsole\Contracts\EvidenceQuery;
 use Fissible\VerdictConsole\Contracts\EvidenceSinkPosture;
 use Fissible\VerdictConsole\Evidence\ConfigurationSinkPosture;
@@ -32,18 +27,6 @@ const POSTURE_ATTEST_RECORDER = 'Fissible\\Verdict\\Evidence\\AttestEvidenceReco
 function posture(): SinkPosture
 {
     return app(EvidenceSinkPosture::class)->read();
-}
-
-/** An instantiable host writer for the parity check: narrow contract, records nothing. */
-final class PostureParityWriter implements EvidenceWriter
-{
-    public function record(DecisionEvidence $evidence): void {}
-
-    public function recordRelease(ContextReleaseEvidence $evidence): void {}
-
-    public function recordProvenance(ProvenanceEntry $entry): void {}
-
-    public function recordDerivation(ProvenanceDerivation $derivation): void {}
 }
 
 it('binds the shipped configuration reader to a contract a host may replace', function (): void {
@@ -427,34 +410,6 @@ it('imports no Verdict types and states the selection-only ceiling', function ()
 
     expect((string) file_get_contents(dirname(__DIR__, 2).'/src/Contracts/EvidenceSinkPosture.php'))
         ->toContain('never implies verified or complete');
-});
-
-/**
- * The precedence is measured, not hand-written lore: for every supported non-empty selection the
- * posture's effectiveWriter must equal the class Verdict's own EvidenceWriter binding resolves.
- * (Tests may import Verdict types; only the shipped reader may not.) The empty-writer divergence
- * stays deliberately outside this parity — Verdict throws there, and its alignment is decided in
- * the empty-writer test above.
- */
-it('matches Verdicts own writer resolution for every supported non-empty selection', function (): void {
-    $verdictResolves = function (): string {
-        // The EvidenceWriter binding is scoped and holds what it resolved; re-read config fresh.
-        app()->forgetScopedInstances();
-
-        return app(EvidenceWriter::class)::class;
-    };
-
-    config()->set('verdict.evidence.recorder', POSTURE_NULL_RECORDER);
-
-    expect(posture()->effectiveWriter)->toBe($verdictResolves())->toBe(POSTURE_NULL_RECORDER);
-
-    config()->set('verdict.evidence.recorder', POSTURE_DATABASE_RECORDER);
-
-    expect(posture()->effectiveWriter)->toBe($verdictResolves())->toBe(POSTURE_DATABASE_RECORDER);
-
-    config()->set('verdict.evidence.writer', PostureParityWriter::class);
-
-    expect(posture()->effectiveWriter)->toBe($verdictResolves())->toBe(PostureParityWriter::class, 'The narrow writer key must win over the legacy recorder, exactly as Verdict resolves it.');
 });
 
 /** The contract is one read; the value is immutable. A wider API or a mutable answer fails here. */

--- a/tests/Feature/EvidenceSinkPostureTest.php
+++ b/tests/Feature/EvidenceSinkPostureTest.php
@@ -1,0 +1,469 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Contracts\EvidenceWriter;
+use Fissible\Verdict\Evidence\ContextReleaseEvidence;
+use Fissible\Verdict\Evidence\DecisionEvidence;
+use Fissible\Verdict\Evidence\ProvenanceDerivation;
+use Fissible\Verdict\Evidence\ProvenanceEntry;
+use Fissible\VerdictConsole\Contracts\EvidenceQuery;
+use Fissible\VerdictConsole\Contracts\EvidenceSinkPosture;
+use Fissible\VerdictConsole\Evidence\ConfigurationSinkPosture;
+use Fissible\VerdictConsole\Evidence\EvidenceFilter;
+use Fissible\VerdictConsole\Evidence\EvidenceRecordingState;
+use Fissible\VerdictConsole\Evidence\SinkPosture;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * #105: one console-owned, host-replaceable answer to "what is the evidence sink and can this
+ * console read it" — the posture every sink-answering surface consumes instead of re-deriving
+ * config on its own. Configuration proves selection only: nothing here claims a write succeeded,
+ * a chain verifies, or a table is complete.
+ *
+ * The shipped reader works by configuration inspection alone. These class names are deliberately
+ * strings: the reader must never import or resolve Verdict recorder types.
+ */
+const POSTURE_NULL_RECORDER = 'Fissible\\Verdict\\Evidence\\NullEvidenceRecorder';
+const POSTURE_DATABASE_RECORDER = 'Fissible\\Verdict\\Evidence\\DatabaseEvidenceRecorder';
+const POSTURE_ATTEST_RECORDER = 'Fissible\\Verdict\\Evidence\\AttestEvidenceRecorder';
+
+function posture(): SinkPosture
+{
+    return app(EvidenceSinkPosture::class)->read();
+}
+
+/** An instantiable host writer for the parity check: narrow contract, records nothing. */
+final class PostureParityWriter implements EvidenceWriter
+{
+    public function record(DecisionEvidence $evidence): void {}
+
+    public function recordRelease(ContextReleaseEvidence $evidence): void {}
+
+    public function recordProvenance(ProvenanceEntry $entry): void {}
+
+    public function recordDerivation(ProvenanceDerivation $derivation): void {}
+}
+
+it('binds the shipped configuration reader to a contract a host may replace', function (): void {
+    expect(app(EvidenceSinkPosture::class))->toBeInstanceOf(ConfigurationSinkPosture::class);
+
+    $replacement = new class implements EvidenceSinkPosture
+    {
+        public function read(): SinkPosture
+        {
+            return new SinkPosture(
+                state: EvidenceRecordingState::Elsewhere,
+                effectiveWriter: null,
+                recordedBy: 'Host\\Replacement\\Answered',
+                table: null,
+                connection: null,
+                chainConfigured: false,
+            );
+        }
+    };
+
+    app()->instance(EvidenceSinkPosture::class, $replacement);
+
+    expect(posture()->recordedBy)->toBe('Host\\Replacement\\Answered');
+});
+
+/** The honesty states through the one boundary, matching the answers the surfaces already give. */
+it('reports off, on, elsewhere, and chained from configuration alone', function (): void {
+    config()->set('verdict.evidence.recorder', POSTURE_NULL_RECORDER);
+
+    $off = posture();
+
+    config()->set('verdict.evidence.recorder', POSTURE_DATABASE_RECORDER);
+
+    $on = posture();
+
+    config()->set('verdict.evidence.writer', 'App\\Evidence\\ExternalWriter');
+
+    $elsewhere = posture();
+
+    config()->set('verdict.evidence.writer', null);
+    config()->set('verdict.evidence.recorder', POSTURE_ATTEST_RECORDER);
+    config()->set('verdict.evidence.attest.chain', 'main-ledger');
+
+    $chained = posture();
+
+    expect($off->state)->toBe(EvidenceRecordingState::Off)
+        ->and($off->effectiveWriter)->toBe(POSTURE_NULL_RECORDER)
+        ->and($off->recordedBy)->toBeNull()
+        ->and($on->state)->toBe(EvidenceRecordingState::On)
+        ->and($on->effectiveWriter)->toBe(POSTURE_DATABASE_RECORDER)
+        ->and($on->recordedBy)->toBeNull()
+        ->and($elsewhere->state)->toBe(EvidenceRecordingState::Elsewhere)
+        ->and($elsewhere->effectiveWriter)->toBe('App\\Evidence\\ExternalWriter', 'The narrow writer key takes precedence over the legacy recorder — Verdict resolves EvidenceWriter from it first.')
+        ->and($elsewhere->recordedBy)->toBe('App\\Evidence\\ExternalWriter')
+        ->and($chained->state)->toBe(EvidenceRecordingState::Chained)
+        ->and($chained->effectiveWriter)->toBe(POSTURE_ATTEST_RECORDER)
+        ->and($chained->recordedBy)->toBe('main-ledger');
+});
+
+it('treats an absent recorder key as recording off, exactly as the read surfaces do', function (): void {
+    $evidence = config('verdict.evidence');
+    unset($evidence['recorder']);
+    config()->set('verdict.evidence', $evidence);
+
+    expect(posture()->state)->toBe(EvidenceRecordingState::Off)
+        ->and(posture()->effectiveWriter)->toBe(POSTURE_NULL_RECORDER);
+});
+
+/** The table facts belong to the posture only while the sink IS a readable table. */
+it('names the table and connection only for a tabular sink', function (): void {
+    config()->set('verdict.evidence.recorder', POSTURE_DATABASE_RECORDER);
+    config()->set('verdict.evidence.table', 'host_evidence');
+    config()->set('verdict.evidence.connection', 'audit');
+
+    $tabular = posture();
+
+    config()->set('verdict.evidence.table', null);
+    config()->set('verdict.evidence.connection', null);
+
+    $defaults = posture();
+
+    config()->set('verdict.evidence.recorder', POSTURE_ATTEST_RECORDER);
+    config()->set('verdict.evidence.attest.chain', 'main-ledger');
+
+    $chained = posture();
+
+    config()->set('verdict.evidence.recorder', POSTURE_NULL_RECORDER);
+
+    $off = posture();
+
+    // An external writer's posture must not leak the tabular config beside it: the table facts
+    // describe the sink selected, not whatever keys happen to be set.
+    config()->set('verdict.evidence.writer', 'App\\Evidence\\ExternalWriter');
+    config()->set('verdict.evidence.table', 'host_evidence');
+    config()->set('verdict.evidence.connection', 'audit');
+
+    $elsewhere = posture();
+
+    expect($tabular->table)->toBe('host_evidence')
+        ->and($tabular->connection)->toBe('audit')
+        ->and($defaults->table)->toBe('verdict_evidence', "Verdict's published default table name.")
+        ->and($defaults->connection)->toBeNull()
+        ->and($chained->table)->toBeNull('A chained sink is not a readable table; naming one would invite reading it.')
+        ->and($chained->connection)->toBeNull()
+        ->and($off->table)->toBeNull()
+        ->and($off->connection)->toBeNull()
+        ->and($elsewhere->state)->toBe(EvidenceRecordingState::Elsewhere)
+        ->and($elsewhere->table)->toBeNull('An unreadable sink has no table to name, whatever config sets.')
+        ->and($elsewhere->connection)->toBeNull();
+});
+
+/**
+ * The chain identity follows #104's rules exactly: the fixed chain id, else the resolver class,
+ * and no identity at all for a topology Verdict itself rejects — while chainConfigured answers the
+ * raw configuration fact #108's ADR needs, independent of which sink is selected.
+ */
+it('reports the chain identity by #104s rules and the chain-configured fact independently', function (): void {
+    config()->set('verdict.evidence.recorder', POSTURE_ATTEST_RECORDER);
+    config()->set('verdict.evidence.attest.chain', null);
+    config()->set('verdict.evidence.attest.chain_resolver', 'App\\Support\\UnresolvableTenantChainResolver');
+
+    $resolver = posture();
+
+    config()->set('verdict.evidence.attest.chain', 'main-ledger');
+
+    $both = posture();
+
+    config()->set('verdict.evidence.attest.chain_resolver', null);
+    config()->set('verdict.evidence.attest.chain', null);
+
+    $neither = posture();
+
+    // A database recorder beside leftover attest config: the selected sink is the table, but the
+    // chain-configured fact still answers truthfully.
+    config()->set('verdict.evidence.recorder', POSTURE_DATABASE_RECORDER);
+    config()->set('verdict.evidence.attest.chain', 'main-ledger');
+
+    $tabularWithChain = posture();
+
+    expect($resolver->state)->toBe(EvidenceRecordingState::Chained)
+        ->and($resolver->recordedBy)->toBe('App\\Support\\UnresolvableTenantChainResolver')
+        ->and($resolver->chainConfigured)->toBeTrue()
+        ->and($both->recordedBy)->toBeNull('Both keys set is a topology Verdict rejects; the posture names no identity.')
+        ->and($both->chainConfigured)->toBeTrue()
+        ->and($neither->state)->toBe(EvidenceRecordingState::Chained)
+        ->and($neither->recordedBy)->toBeNull()
+        ->and($neither->chainConfigured)->toBeFalse()
+        ->and($tabularWithChain->state)->toBe(EvidenceRecordingState::On)
+        ->and($tabularWithChain->chainConfigured)->toBeTrue();
+
+    // Configured means a non-empty value, exactly as the identity rules read them: empty strings
+    // are unset, and an empty fixed id beside a valid resolver leaves the resolver in charge.
+    config()->set('verdict.evidence.recorder', POSTURE_ATTEST_RECORDER);
+    config()->set('verdict.evidence.attest.chain', '');
+    config()->set('verdict.evidence.attest.chain_resolver', null);
+
+    $emptyChain = posture();
+
+    config()->set('verdict.evidence.attest.chain_resolver', '');
+
+    $bothEmpty = posture();
+
+    config()->set('verdict.evidence.attest.chain_resolver', 'App\\Support\\UnresolvableTenantChainResolver');
+
+    $emptyChainRealResolver = posture();
+
+    expect($emptyChain->chainConfigured)->toBeFalse()
+        ->and($emptyChain->recordedBy)->toBeNull()
+        ->and($bothEmpty->chainConfigured)->toBeFalse()
+        ->and($emptyChainRealResolver->chainConfigured)->toBeTrue()
+        ->and($emptyChainRealResolver->recordedBy)->toBe('App\\Support\\UnresolvableTenantChainResolver');
+});
+
+/**
+ * The named divergence this issue decides. Measured against Verdict v0.14 (VerdictServiceProvider,
+ * EvidenceWriter binding): only `null` falls back to the legacy recorder; an empty string passes
+ * the null check and dies inside `$app->make('')` the first time the writer resolves. No honesty
+ * state can say "resolution will throw", and the console's old reading — "recorded elsewhere by
+ * ''" — named a writer that does not exist. Decision: for the posture read, empty means unset
+ * (the recorder key answers), because an empty env var is the dominant real cause and every other
+ * mapping states a falsehood. The raw divergence from Verdict's throw is a doctor finding to file
+ * with the sink-review work, not a state.
+ */
+it('reads an empty writer as unset rather than an unnameable elsewhere', function (): void {
+    config()->set('verdict.evidence.writer', '');
+    config()->set('verdict.evidence.recorder', POSTURE_DATABASE_RECORDER);
+
+    $emptyOverDatabase = posture();
+
+    config()->set('verdict.evidence.recorder', POSTURE_NULL_RECORDER);
+
+    $emptyOverNull = posture();
+
+    config()->set('verdict.evidence.recorder', POSTURE_ATTEST_RECORDER);
+    config()->set('verdict.evidence.attest.chain', 'main-ledger');
+
+    $emptyOverChained = posture();
+
+    // And the same hygiene for the recorder key itself: '' is unset, so the shipped default — the
+    // null recorder — answers.
+    config()->set('verdict.evidence.writer', null);
+    config()->set('verdict.evidence.recorder', '');
+
+    $emptyRecorder = posture();
+
+    expect($emptyOverDatabase->state)->toBe(EvidenceRecordingState::On)
+        ->and($emptyOverDatabase->effectiveWriter)->toBe(POSTURE_DATABASE_RECORDER)
+        ->and($emptyOverDatabase->recordedBy)->toBeNull()
+        ->and($emptyOverNull->state)->toBe(EvidenceRecordingState::Off)
+        ->and($emptyOverChained->state)->toBe(EvidenceRecordingState::Chained)
+        ->and($emptyOverChained->recordedBy)->toBe('main-ledger')
+        ->and($emptyRecorder->state)->toBe(EvidenceRecordingState::Off)
+        ->and($emptyRecorder->effectiveWriter)->toBe(POSTURE_NULL_RECORDER);
+});
+
+/** A non-string writer or recorder value can select nothing nameable: elsewhere, unnamed. */
+it('reports a non-string sink selection as an unnameable elsewhere', function (): void {
+    config()->set('verdict.evidence.recorder', ['not', 'a', 'class']);
+
+    expect(posture()->state)->toBe(EvidenceRecordingState::Elsewhere)
+        ->and(posture()->effectiveWriter)->toBeNull()
+        ->and(posture()->recordedBy)->toBeNull();
+});
+
+/**
+ * The evidence read surface consumes THIS boundary rather than keeping a second derivation: bound
+ * to an answer configuration cannot produce, the query must repeat the contract's answer. No
+ * evidence table exists in this test — a query that still read one would fail loudly here.
+ */
+it('drives the evidence read surfaces recording answer through the posture boundary', function (): void {
+    config()->set('verdict.evidence.recorder', POSTURE_DATABASE_RECORDER);
+
+    app()->instance(EvidenceSinkPosture::class, new class implements EvidenceSinkPosture
+    {
+        public function read(): SinkPosture
+        {
+            return new SinkPosture(
+                state: EvidenceRecordingState::Chained,
+                effectiveWriter: null,
+                recordedBy: 'fake-chain-not-derivable-from-config',
+                table: null,
+                connection: null,
+                chainConfigured: true,
+            );
+        }
+    });
+
+    $complete = app(EvidenceQuery::class)->search(new EvidenceFilter);
+    $page = app(EvidenceQuery::class)->searchPage(new EvidenceFilter, page: 1, perPage: 10);
+
+    expect($complete->recording)->toBe(EvidenceRecordingState::Chained)
+        ->and($complete->recordedBy)->toBe('fake-chain-not-derivable-from-config')
+        ->and($complete->records)->toBe([])
+        ->and($page->recording)->toBe(EvidenceRecordingState::Chained)
+        ->and($page->recordedBy)->toBe('fake-chain-not-derivable-from-config')
+        ->and($page->total)->toBe(0);
+
+    // And the same for a replacement declaring the sink unreadable outright: an implementation
+    // that special-cased chained but re-derived elsewhere from config would read the
+    // config-derived table — which does not exist — and die here.
+    app()->instance(EvidenceSinkPosture::class, new class implements EvidenceSinkPosture
+    {
+        public function read(): SinkPosture
+        {
+            return new SinkPosture(
+                state: EvidenceRecordingState::Elsewhere,
+                effectiveWriter: 'Host\\Fake\\Writer',
+                recordedBy: 'Host\\Fake\\Writer',
+                table: null,
+                connection: null,
+                chainConfigured: false,
+            );
+        }
+    });
+
+    $elsewhereComplete = app(EvidenceQuery::class)->search(new EvidenceFilter);
+    $elsewherePage = app(EvidenceQuery::class)->searchPage(new EvidenceFilter, page: 1, perPage: 10);
+
+    expect($elsewhereComplete->recording)->toBe(EvidenceRecordingState::Elsewhere)
+        ->and($elsewhereComplete->recordedBy)->toBe('Host\\Fake\\Writer')
+        ->and($elsewhereComplete->records)->toBe([])
+        ->and($elsewherePage->recording)->toBe(EvidenceRecordingState::Elsewhere)
+        ->and($elsewherePage->recordedBy)->toBe('Host\\Fake\\Writer')
+        ->and($elsewherePage->total)->toBe(0);
+});
+
+/**
+ * And the tabular half of the same delegation: the table AND connection the query reads are the
+ * ones the POSTURE names. The real table lives only on a second connection; config names a
+ * missing table on the default connection — an implementation keeping its own table or connection
+ * derivation dies loudly on either.
+ */
+it('reads the table and connection the posture boundary names, never the ones config names', function (): void {
+    config()->set('database.connections.posture_audit', ['driver' => 'sqlite', 'database' => ':memory:', 'prefix' => '']);
+    config()->set('verdict.evidence.recorder', POSTURE_DATABASE_RECORDER);
+    config()->set('verdict.evidence.table', 'config_names_a_missing_table');
+    config()->set('verdict.evidence.connection', null);
+
+    Schema::connection('posture_audit')->create('posture_named_table', function ($table): void {
+        $table->string('id')->primary();
+        $table->string('record_type');
+        $table->string('capability')->nullable();
+        $table->string('stage');
+        $table->string('disposition');
+        $table->text('reason')->nullable();
+        $table->string('claim_type')->nullable();
+        $table->string('record_digest')->nullable();
+        $table->string('argument_fingerprint')->nullable();
+        $table->string('idempotency_key_fingerprint')->nullable();
+        $table->string('approval_receipt_fingerprint')->nullable();
+        $table->string('configuration_fingerprint')->nullable();
+        $table->string('actor_fingerprint')->nullable();
+        $table->string('subject_fingerprint')->nullable();
+        $table->string('proposal_target_identity_fingerprint')->nullable();
+        $table->string('execution_target_identity_fingerprint')->nullable();
+        $table->string('rate_limit_key_fingerprint')->nullable();
+        $table->string('execution_claim_fingerprint')->nullable();
+        $table->string('execution_claim_binding_fingerprint')->nullable();
+        $table->string('invocation_id')->nullable();
+        $table->timestamp('rate_limit_reset_at')->nullable();
+        $table->timestamp('recorded_at');
+    });
+
+    DB::connection('posture_audit')->table('posture_named_table')->insert([
+        'id' => 'in-the-postures-table',
+        'record_type' => 'decision',
+        'stage' => 'proposal',
+        'disposition' => 'permit',
+        'recorded_at' => '2026-09-01 10:00:00',
+    ]);
+
+    app()->instance(EvidenceSinkPosture::class, new class implements EvidenceSinkPosture
+    {
+        public function read(): SinkPosture
+        {
+            return new SinkPosture(
+                state: EvidenceRecordingState::On,
+                effectiveWriter: POSTURE_DATABASE_RECORDER,
+                recordedBy: null,
+                table: 'posture_named_table',
+                connection: 'posture_audit',
+                chainConfigured: false,
+            );
+        }
+    });
+
+    $complete = app(EvidenceQuery::class)->search(new EvidenceFilter);
+    $page = app(EvidenceQuery::class)->searchPage(new EvidenceFilter, page: 1, perPage: 10);
+
+    expect(array_map(fn ($record) => $record->id, $complete->records))->toBe(['in-the-postures-table'])
+        ->and(array_map(fn ($record) => $record->id, $page->records))->toBe(['in-the-postures-table'])
+        ->and($page->total)->toBe(1);
+
+    Schema::connection('posture_audit')->dropIfExists('posture_named_table');
+});
+
+/**
+ * The reader answers by configuration inspection only: no Verdict recorder type is imported by the
+ * posture files, and the contract states the ceiling — configuration proves selection, never that
+ * recording is verified or complete.
+ */
+it('imports no Verdict types and states the selection-only ceiling', function (): void {
+    $sources = [
+        'src/Contracts/EvidenceSinkPosture.php',
+        'src/Evidence/SinkPosture.php',
+        'src/Evidence/ConfigurationSinkPosture.php',
+    ];
+
+    foreach ($sources as $source) {
+        $code = (string) file_get_contents(dirname(__DIR__, 2).'/'.$source);
+
+        // The only permitted spelling of a Verdict name is an escaped string constant
+        // ('Fissible\\Verdict\\...'): strip that form, and any remaining single-backslash
+        // occurrence — a use statement, an FQCN reference, ::class, an unescaped string — fails.
+        // (toContain takes no message parameter; the path in the failure comes from per-file
+        // assertion.)
+        $withoutEscapedStrings = str_replace('Fissible\\\\Verdict\\\\', '', $code);
+
+        expect($withoutEscapedStrings)->not->toContain('Fissible\\Verdict\\');
+    }
+
+    expect((string) file_get_contents(dirname(__DIR__, 2).'/src/Contracts/EvidenceSinkPosture.php'))
+        ->toContain('never implies verified or complete');
+});
+
+/**
+ * The precedence is measured, not hand-written lore: for every supported non-empty selection the
+ * posture's effectiveWriter must equal the class Verdict's own EvidenceWriter binding resolves.
+ * (Tests may import Verdict types; only the shipped reader may not.) The empty-writer divergence
+ * stays deliberately outside this parity — Verdict throws there, and its alignment is decided in
+ * the empty-writer test above.
+ */
+it('matches Verdicts own writer resolution for every supported non-empty selection', function (): void {
+    $verdictResolves = function (): string {
+        // The EvidenceWriter binding is scoped and holds what it resolved; re-read config fresh.
+        app()->forgetScopedInstances();
+
+        return app(EvidenceWriter::class)::class;
+    };
+
+    config()->set('verdict.evidence.recorder', POSTURE_NULL_RECORDER);
+
+    expect(posture()->effectiveWriter)->toBe($verdictResolves())->toBe(POSTURE_NULL_RECORDER);
+
+    config()->set('verdict.evidence.recorder', POSTURE_DATABASE_RECORDER);
+
+    expect(posture()->effectiveWriter)->toBe($verdictResolves())->toBe(POSTURE_DATABASE_RECORDER);
+
+    config()->set('verdict.evidence.writer', PostureParityWriter::class);
+
+    expect(posture()->effectiveWriter)->toBe($verdictResolves())->toBe(PostureParityWriter::class, 'The narrow writer key must win over the legacy recorder, exactly as Verdict resolves it.');
+});
+
+/** The contract is one read; the value is immutable. A wider API or a mutable answer fails here. */
+it('keeps the contract to a single read of an immutable value', function (): void {
+    $contract = new ReflectionClass(EvidenceSinkPosture::class);
+    $methods = array_map(fn (ReflectionMethod $method): string => $method->getName(), $contract->getMethods());
+    sort($methods);
+
+    expect($contract->isInterface())->toBeTrue()
+        ->and($methods)->toBe(['read'])
+        ->and((new ReflectionClass(SinkPosture::class))->isReadOnly())->toBeTrue();
+});

--- a/tests/Feature/VerdictReadBoundaryTest.php
+++ b/tests/Feature/VerdictReadBoundaryTest.php
@@ -60,7 +60,9 @@ it('confines direct Verdict table reads to the documented evidence seam', functi
         static fn (string $source): bool => preg_match('/verdict_(?!console_)/', $source) === 1,
     ));
 
-    expect($offenders)->toBe(['Evidence/DatabaseEvidenceQuery.php']);
+    // #105 widened the documented seam by one file: the posture reader owns naming Verdict's
+    // published table (its default name included); the query reads whatever the posture names.
+    expect($offenders)->toBe(['Evidence/ConfigurationSinkPosture.php', 'Evidence/DatabaseEvidenceQuery.php']);
 });
 
 it('routes approval status reads through the verdict#298 contract', function (): void {

--- a/tests/Integration/EvidenceSinkPostureParityTest.php
+++ b/tests/Integration/EvidenceSinkPostureParityTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Contracts\EvidenceWriter;
+use Fissible\Verdict\Evidence\ContextReleaseEvidence;
+use Fissible\Verdict\Evidence\DecisionEvidence;
+use Fissible\Verdict\Evidence\ProvenanceDerivation;
+use Fissible\Verdict\Evidence\ProvenanceEntry;
+use Fissible\VerdictConsole\Contracts\EvidenceSinkPosture;
+
+const PARITY_NULL_RECORDER = 'Fissible\\Verdict\\Evidence\\NullEvidenceRecorder';
+const PARITY_DATABASE_RECORDER = 'Fissible\\Verdict\\Evidence\\DatabaseEvidenceRecorder';
+
+/** An instantiable host writer for the parity check: narrow contract, records nothing. */
+final class PostureParityWriter implements EvidenceWriter
+{
+    public function record(DecisionEvidence $evidence): void {}
+
+    public function recordRelease(ContextReleaseEvidence $evidence): void {}
+
+    public function recordProvenance(ProvenanceEntry $entry): void {}
+
+    public function recordDerivation(ProvenanceDerivation $derivation): void {}
+}
+
+/**
+ * #105: the precedence is measured, not hand-written lore — for every supported non-empty
+ * selection the posture's effectiveWriter must equal the class Verdict's own EvidenceWriter
+ * binding resolves. This lives in the Integration suite because it needs Verdict's real container
+ * bindings; the shipped reader itself never touches them. The empty-writer divergence stays
+ * deliberately outside this parity — Verdict throws there, and its alignment is decided in the
+ * Feature posture suite.
+ */
+it('matches Verdicts own writer resolution for every supported non-empty selection', function (): void {
+    $verdictResolves = function (): string {
+        // The EvidenceWriter binding is scoped and holds what it resolved; re-read config fresh.
+        app()->forgetScopedInstances();
+
+        return app(EvidenceWriter::class)::class;
+    };
+
+    $posture = fn (): ?string => app(EvidenceSinkPosture::class)->read()->effectiveWriter;
+
+    config()->set('verdict.evidence.writer', null);
+    config()->set('verdict.evidence.recorder', PARITY_NULL_RECORDER);
+
+    expect($posture())->toBe($verdictResolves())->toBe(PARITY_NULL_RECORDER);
+
+    config()->set('verdict.evidence.recorder', PARITY_DATABASE_RECORDER);
+
+    expect($posture())->toBe($verdictResolves())->toBe(PARITY_DATABASE_RECORDER);
+
+    config()->set('verdict.evidence.writer', PostureParityWriter::class);
+
+    expect($posture())->toBe($verdictResolves())->toBe(PostureParityWriter::class, 'The narrow writer key must win over the legacy recorder, exactly as Verdict resolves it.');
+});

--- a/tests/Integration/EvidenceSinkPostureParityTest.php
+++ b/tests/Integration/EvidenceSinkPostureParityTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Fissible\Verdict\Contracts\EvidenceRecorder;
 use Fissible\Verdict\Contracts\EvidenceWriter;
+use Fissible\Verdict\Evidence\ApprovalOperationEvidence;
 use Fissible\Verdict\Evidence\ContextReleaseEvidence;
 use Fissible\Verdict\Evidence\DecisionEvidence;
 use Fissible\Verdict\Evidence\ProvenanceDerivation;
@@ -23,6 +24,8 @@ final class PostureParityWriter implements EvidenceWriter
     public function recordProvenance(ProvenanceEntry $entry): void {}
 
     public function recordDerivation(ProvenanceDerivation $derivation): void {}
+
+    public function recordApprovalOperation(ApprovalOperationEvidence $evidence): void {}
 }
 
 /**

--- a/tests/Integration/EvidenceSinkPostureParityTest.php
+++ b/tests/Integration/EvidenceSinkPostureParityTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Fissible\Verdict\Contracts\EvidenceRecorder;
 use Fissible\Verdict\Contracts\EvidenceWriter;
 use Fissible\Verdict\Evidence\ContextReleaseEvidence;
 use Fissible\Verdict\Evidence\DecisionEvidence;
@@ -34,7 +35,9 @@ final class PostureParityWriter implements EvidenceWriter
  */
 it('matches Verdicts own writer resolution for every supported non-empty selection', function (): void {
     $verdictResolves = function (): string {
-        // The EvidenceWriter binding is scoped and holds what it resolved; re-read config fresh.
+        // The EvidenceWriter binding is scoped and the legacy EvidenceRecorder it falls back to is
+        // a singleton; both hold what they resolved, so both are forgotten to re-read config fresh.
+        app()->forgetInstance(EvidenceRecorder::class);
         app()->forgetScopedInstances();
 
         return app(EvidenceWriter::class)::class;


### PR DESCRIPTION
Closes #105.

The surfaces answering "what is the evidence sink and can this console read it" each re-derived posture from config independently. Now one console-owned, host-replaceable contract answers it.

**What this does**
- `Contracts\EvidenceSinkPosture::read(): SinkPosture` — a single read of an immutable value (both reflection-pinned): the honesty state (Off/On/Elsewhere/Chained), the **effective writer**, `recordedBy` (external writer name or #104's chain identity), the **table and connection only while the sink is a readable table**, and `chainConfigured` — the raw configuration fact #108's ADR needs, independent of which sink is selected.
- The shipped `ConfigurationSinkPosture` works by configuration inspection alone: no Verdict imports (source-scanned — the only permitted spelling is an escaped string constant), nothing resolved or instantiated to answer.
- **Precedence is measured, not lore**: an Integration-suite parity test resolves Verdict's own `EvidenceWriter` binding per configuration and pins `effectiveWriter` equal to it (clearing both the scoped writer and the singleton recorder it falls back to between configs).
- `DatabaseEvidenceQuery` consumes the contract for its recording answer **and** for the table+connection it queries — pinned by replacement fixtures where any config-derived read dies loudly (missing config table; real table existing only on a posture-named second connection), for Chained and Elsewhere replacements on both read shapes.
- The standing seam-guard allowlist grows by exactly `Evidence/ConfigurationSinkPosture.php`: the posture reader now owns naming Verdict's table.

**The named divergence, decided:** the issue hypothesized Verdict treats `writer: ''` as no-override. Measured against v0.14's `VerdictServiceProvider`: it does not — only `null` falls back; `''` passes the null check and dies inside `$app->make('')` at first resolution. Since no honesty state can say "resolution will throw" and the old mapping answered *"recorded elsewhere by ''"* (a writer that does not exist), the posture reads empty as unset for both keys — the recorder key (or its null-recorder default) answers. The raw `''`-vs-`null` hygiene divergence is doctor-finding material for the sink-review work, not a state.

**Acceptance held:** every existing surface pin reproduces through the boundary (full suite green); "On" never implies verified or complete (docblock-pinned: configuration proves selection only); replacements swap in the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
