### PR TITLE
Notify from Verdict's observed receipt transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Receipt-transition notifications (#46).** Decisions resolved through other clients and
+  model-consumed receipts now notify from Verdict's observed transition event. `Consumed` is a new
+  host-visible `ApprovalNotificationRecipients` routing key (`approval-consumed`).
+
 - **Require Verdict `^0.15` — the review-lane release.** The 0.15 compatibility pass: the bound
   moves to the current minor per the standing prefer-lowest reasoning. What reaches this package:
   the new `add_review_outcome` evidence stub joins both fixture guards (the column is additive and

--- a/docs/adr/0001-approval-surface-contract.md
+++ b/docs/adr/0001-approval-surface-contract.md
@@ -158,6 +158,12 @@ disposition is anything but a pending `RequireConfirmation` challenge is empty. 
 
 ### 3. The two actionable lanes differ in lifecycle, not just in latency
 
+**Amended 2026-09-01 — Verdict #299 shipped as one `ApprovalReceiptTransitioned` event.** Rather
+than four separate event classes for issued, approved, rejected, and consumed, the event carries the
+receipt and tool-call identities, resulting status, and occurrence time. The console observes only
+terminal transitions for an already-indexed matching pair; `Pending` remains solely the
+`ToolApprovalRequested` ingestion concern.
+
 | | Synchronous — `RequireConfirmation` | Asynchronous — `RequireReview` |
 | --- | --- | --- |
 | What is waiting | A paused Laravel AI run and a pending receipt | Nothing. The run already received a refusal and moved on |

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -287,10 +287,10 @@ tool-call id — never `approveAll()`** (Verdict deliberately ignores the wildca
 ### 6.5 Notifications
 Mail / database / Slack / broadcast. VC-11's notifications are limited to observations the console
 actually receives: a newly indexed pause, its own returned approval/rejection transition, and Laravel
-AI's `ToolApprovalResolved` continuation event. They never say an action completed or a receipt was
-consumed: the event carries post-resume tool results, not an execution-claim lifecycle, and a null
-challenge cannot distinguish consumption from expiry, rejection, ambiguity, or absence. Copy obeys
-the ADR 0028 ceiling by reporting the observation rather than inventing its unobservable consequence.
+AI's `ToolApprovalResolved` continuation event. Verdict #299's observed receipt-transition event also
+lets them say a receipt was consumed. They never say an action completed: the event carries a receipt
+lifecycle observation, not an execution-claim lifecycle or action outcome. Copy obeys the ADR 0028
+ceiling by reporting the observation rather than inventing its unobservable consequence.
 
 ### 6.6 Evidence read-models
 Over `DecisionEvidence`, honoring ADR 0008 (fingerprints, not raw), surfacing `claimType` +

--- a/src/Approvals/ApprovalNotificationDispatcher.php
+++ b/src/Approvals/ApprovalNotificationDispatcher.php
@@ -7,6 +7,7 @@ namespace Fissible\VerdictConsole\Approvals;
 use Fissible\VerdictConsole\Contracts\ApprovalNotificationRecipients;
 use Fissible\VerdictConsole\Notifications\ApprovalResumeOutcomeNotification;
 use Fissible\VerdictConsole\Notifications\ApprovedApprovalNotification;
+use Fissible\VerdictConsole\Notifications\ConsumedApprovalNotification;
 use Fissible\VerdictConsole\Notifications\PendingApprovalNotification;
 use Fissible\VerdictConsole\Notifications\RejectedApprovalNotification;
 use Illuminate\Contracts\Notifications\Dispatcher;
@@ -45,6 +46,12 @@ final readonly class ApprovalNotificationDispatcher
     public function rejected(PendingApproval $approval): void
     {
         $this->dispatch($approval, ApprovalNotificationKey::Rejected, new RejectedApprovalNotification($approval));
+    }
+
+    /** Announce Verdict's observed receipt consumption without inferring an action outcome. */
+    public function consumed(PendingApproval $approval): void
+    {
+        $this->dispatch($approval, ApprovalNotificationKey::Consumed, new ConsumedApprovalNotification($approval));
     }
 
     /** Announce Laravel AI's reported continuation result without inferring a completed action. */

--- a/src/Approvals/ApprovalNotificationKey.php
+++ b/src/Approvals/ApprovalNotificationKey.php
@@ -5,16 +5,18 @@ declare(strict_types=1);
 namespace Fissible\VerdictConsole\Approvals;
 
 /**
- * Names observations the console can notify without pretending to observe a receipt lifecycle.
+ * Names observations the console can notify without pretending to observe an action lifecycle.
  *
  * Hosts receive this value to choose different audiences for a new pause, a recorded decision, and
- * Laravel AI's continuation event. Keeping the set closed prevents a surface from routing a
- * fabricated "consumed" or "action completed" observation that the console cannot know.
+ * Laravel AI's continuation event. Verdict #299 now makes receipt consumption observable, so its
+ * transition has a key too. Keeping the set closed still prevents a surface from routing a
+ * fabricated action-completed observation that the console cannot know.
  */
 enum ApprovalNotificationKey: string
 {
     case Pending = 'approval-pending';
     case Approved = 'approval-approved';
     case Rejected = 'approval-rejected';
+    case Consumed = 'approval-consumed';
     case ResumeOutcome = 'approval-resume-outcome';
 }

--- a/src/Approvals/PendingApprovalStore.php
+++ b/src/Approvals/PendingApprovalStore.php
@@ -288,6 +288,20 @@ final class PendingApprovalStore
     }
 
     /**
+     * Find the indexed pause named by one observed Verdict receipt transition.
+     *
+     * Both identities are required. A tool-call id can be reused only by a malformed or stale
+     * delivery, and a receipt id alone must never attach an observation to a different pause.
+     */
+    public function findByTransition(string $toolCallId, string $receiptId): ?PendingApproval
+    {
+        return $this->correlationQuery()
+            ->where('tool_call_id', $toolCallId)
+            ->where('receipt_id', $receiptId)
+            ->first();
+    }
+
+    /**
      * Whether this approval remains inside the host's current query boundary.
      *
      * Actions accept a row because a surface just rendered it, but that row can outlive a tenant

--- a/src/Listeners/NotifyApprovalReceiptTransition.php
+++ b/src/Listeners/NotifyApprovalReceiptTransition.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Listeners;
+
+use Fissible\Verdict\Approvals\ApprovalReceiptStatus;
+use Fissible\Verdict\Approvals\Events\ApprovalReceiptTransitioned;
+use Fissible\VerdictConsole\Approvals\ApprovalNotificationDispatcher;
+use Fissible\VerdictConsole\Approvals\ApprovalNotificationKey;
+use Fissible\VerdictConsole\Approvals\ApprovalNotificationStore;
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
+use Throwable;
+
+/** Notifies only from Verdict's observed receipt transitions; pause ingestion remains Laravel AI-owned. */
+final readonly class NotifyApprovalReceiptTransition
+{
+    public function __construct(
+        private PendingApprovalStore $pendingApprovals,
+        private ApprovalNotificationStore $notificationStore,
+        private ApprovalNotificationDispatcher $notifications,
+    ) {}
+
+    public function handle(ApprovalReceiptTransitioned $event): void
+    {
+        if ($event->status === ApprovalReceiptStatus::Pending) {
+            return;
+        }
+
+        $approval = $this->pendingApprovals->findByTransition($event->toolCallId, $event->receiptId);
+
+        if ($approval === null) {
+            return;
+        }
+
+        if ($event->status === ApprovalReceiptStatus::Approved) {
+            if ($this->wasClaimed($approval, ApprovalNotificationKey::Approved)) {
+                return;
+            }
+
+            $this->notifications->approved($approval);
+
+            return;
+        }
+
+        if ($event->status === ApprovalReceiptStatus::Rejected) {
+            if ($this->wasClaimed($approval, ApprovalNotificationKey::Rejected)) {
+                return;
+            }
+
+            $this->notifications->rejected($approval);
+
+            return;
+        }
+
+        if ($this->wasClaimed($approval, ApprovalNotificationKey::Consumed)) {
+            return;
+        }
+
+        $this->notifications->consumed($approval);
+    }
+
+    /**
+     * Avoid re-entering host recipient policy after the durable dispatcher claim has won.
+     *
+     * This is only a redelivery shortcut, never a prerequisite: hosts can receive the package code
+     * before they migrate its notification table, and the dispatcher already degrades that state
+     * without interrupting Verdict's committed transition.
+     */
+    private function wasClaimed(PendingApproval $approval, ApprovalNotificationKey $key): bool
+    {
+        try {
+            return $this->notificationStore->find($approval, $key->value) !== null;
+        } catch (Throwable) {
+            return false;
+        }
+    }
+}

--- a/src/Notifications/ConsumedApprovalNotification.php
+++ b/src/Notifications/ConsumedApprovalNotification.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Notifications;
+
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+/** Announces Verdict's observed receipt consumption, not an action outcome. */
+final class ConsumedApprovalNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(private readonly PendingApproval $approval) {}
+
+    /** @return array<int, string> */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /** @return array{message: string, approval_id: string, tool_call_id: string} */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'message' => 'A tool approval receipt was consumed.',
+            'approval_id' => $this->approval->getKey(),
+            'tool_call_id' => $this->approval->tool_call_id,
+        ];
+    }
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Fissible\VerdictConsole;
 
+use Fissible\Verdict\Approvals\Events\ApprovalReceiptTransitioned;
 use Fissible\Verdict\Capabilities\Events\CapabilityConfigurationUnrecorded;
 use Fissible\Verdict\Evidence\Events\ChainWriteFailed;
 use Fissible\Verdict\Evidence\Events\ConsequentialActionUnrecorded;
@@ -35,6 +36,7 @@ use Fissible\VerdictConsole\Http\VerdictConsoleRoutes;
 use Fissible\VerdictConsole\Incidents\IncidentStore;
 use Fissible\VerdictConsole\Listeners\IngestToolApprovalRequests;
 use Fissible\VerdictConsole\Listeners\LogApprovalIngestionIncident;
+use Fissible\VerdictConsole\Listeners\NotifyApprovalReceiptTransition;
 use Fissible\VerdictConsole\Listeners\NotifyApprovalResumeOutcome;
 use Fissible\VerdictConsole\Listeners\RecordAnomalyIncident;
 use Fissible\VerdictConsole\Listeners\RecordConversationInvocation;
@@ -113,6 +115,7 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         // Listener registration belongs in boot, after every provider has registered its bindings.
         // It must precede the console-only guard: approvals are ingested on ordinary web requests.
         $events->listen(ToolApprovalRequested::class, IngestToolApprovalRequests::class);
+        $events->listen(ApprovalReceiptTransitioned::class, NotifyApprovalReceiptTransition::class);
         $events->listen(ToolApprovalResolved::class, NotifyApprovalResumeOutcome::class);
         // Laravel's dispatcher matches an event's class and interfaces, not its parent classes, so
         // AgentStreamed must be explicit despite extending AgentPrompted.

--- a/tests/Feature/ApprovalNotificationDispatchTest.php
+++ b/tests/Feature/ApprovalNotificationDispatchTest.php
@@ -57,6 +57,11 @@ it('claims one pending observation before notifying every host recipient', funct
     expect(ApprovalNotification::query()->count())->toBe(1, 'A claim belongs to the approval observation, not to each recipient.');
 });
 
+/**
+ * VC-46 amended this pin: consumption became observable through verdict#299's transition event, so
+ * the consumed notice may name that observation — the ban it keeps is on inventing an executed
+ * action. Every other notice still must not claim consumption it did not observe.
+ */
 it('never presents a notification as a consumed receipt or a finished action', function (): void {
     $approval = app(PendingApprovalStore::class)->ingest('call_notification_copy');
     $recipient = new ApprovalNotificationRecipient('copy');

--- a/tests/Feature/ReceiptTransitionListenerTest.php
+++ b/tests/Feature/ReceiptTransitionListenerTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Approvals\ApprovalReceiptStatus;
+use Fissible\Verdict\Approvals\Events\ApprovalReceiptTransitioned;
+use Fissible\Verdict\Testing\AllowAllApprovalAuthorizer;
+use Fissible\VerdictConsole\Approvals\ApprovalNotification;
+use Fissible\VerdictConsole\Approvals\ApprovalNotificationDispatcher;
+use Fissible\VerdictConsole\Approvals\ApprovalNotificationKey;
+use Fissible\VerdictConsole\Approvals\PendingApproval;
+use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
+use Fissible\VerdictConsole\Contracts\ApprovalNotificationRecipients;
+use Fissible\VerdictConsole\Notifications\ApprovedApprovalNotification;
+use Fissible\VerdictConsole\Notifications\ConsumedApprovalNotification;
+use Fissible\VerdictConsole\Notifications\RejectedApprovalNotification;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Notification;
+
+/**
+ * VC-46: verdict#299's receipt-transition event, adopted. One store-dispatched event —
+ * ApprovalReceiptTransitioned, carrying identity, resulting status, and time under ADR 0008 —
+ * lets the console observe decisions made through some other client and receipts the model
+ * consumed, which were invisible until the next live read. The observation lands through the
+ * existing claim-idempotent notification dispatcher; ingestion stays on Laravel AI's
+ * ToolApprovalRequested, and no listener invents the expiry transition Verdict does not have.
+ */
+final class TransitionRecipient
+{
+    use Notifiable;
+
+    public function __construct(private readonly string $key) {}
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+}
+
+function transitionRow(string $toolCallId, string $receiptId): PendingApproval
+{
+    $approval = app(PendingApprovalStore::class)->ingest(
+        $toolCallId,
+        conversationId: 'conversation-1',
+        receiptId: $receiptId,
+    );
+
+    DB::table('verdict_approval_receipts')->insert([
+        'id' => $receiptId,
+        'tool_call_id' => $toolCallId,
+        'capability' => 'orders.cancel',
+        'binding_fingerprint' => str_repeat('a', 64),
+        'status' => 'pending',
+        'reason' => 'Cancelling an order needs confirmation.',
+        'expires_at' => now()->addHour(),
+        'created_at' => now()->subMinutes(5),
+        'updated_at' => now()->subMinutes(5),
+    ]);
+
+    return $approval;
+}
+
+function transitioned(string $receiptId, string $toolCallId, ApprovalReceiptStatus $status): ApprovalReceiptTransitioned
+{
+    return new ApprovalReceiptTransitioned(
+        receiptId: $receiptId,
+        toolCallId: $toolCallId,
+        capability: 'orders.cancel',
+        status: $status,
+        occurredAt: new DateTimeImmutable('now'),
+    );
+}
+
+beforeEach(function (): void {
+    config()->set('verdict.approvals.authorizer', AllowAllApprovalAuthorizer::class);
+
+    $console = dirname(__DIR__, 2).'/database/migrations';
+    (require $console.'/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require $console.'/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require $console.'/add_approval_context_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require $console.'/create_verdict_console_approval_notifications_table.php.stub')->up();
+
+    $verdict = dirname(__DIR__, 2).'/vendor/fissible/verdict/database/migrations';
+
+    foreach ([
+        'create_verdict_approval_receipts_table.php.stub',
+        'add_proposal_provenance_to_verdict_approval_receipts_table.php.stub',
+        'add_approval_context_to_verdict_approval_receipts_table.php.stub',
+        'add_approver_summary_to_verdict_approval_receipts_table.php.stub',
+        'add_pending_enumeration_index_to_verdict_approval_receipts_table.php.stub',
+    ] as $stub) {
+        (require $verdict.'/'.$stub)->up();
+    }
+
+    $this->recipient = new TransitionRecipient('observer');
+    $recipient = $this->recipient;
+    app()->instance(ApprovalNotificationRecipients::class, new class($recipient) implements ApprovalNotificationRecipients
+    {
+        /** @var list<ApprovalNotificationKey> */
+        public array $requested = [];
+
+        /** @var list<PendingApproval> */
+        public array $approvals = [];
+
+        public function __construct(private readonly TransitionRecipient $recipient) {}
+
+        public function forApproval(PendingApproval $approval, ApprovalNotificationKey $key): iterable
+        {
+            $this->requested[] = $key;
+            $this->approvals[] = $approval;
+
+            return [$this->recipient];
+        }
+    });
+    Notification::fake();
+});
+
+it('notifies an approval decided through another client, exactly once under redelivery', function (): void {
+    $row = transitionRow('call_elsewhere', 'receipt-elsewhere');
+
+    // The console's resolution service never runs; the committed transition's event is the only
+    // thing the console hears — delivered twice, as a queue retry or second worker would.
+    // (The Integration tier proves the same event arriving from Verdict's real manager and store;
+    // this tier deliberately boots no Verdict provider.)
+    event(transitioned('receipt-elsewhere', 'call_elsewhere', ApprovalReceiptStatus::Approved));
+    event(transitioned('receipt-elsewhere', 'call_elsewhere', ApprovalReceiptStatus::Approved));
+
+    Notification::assertSentToTimes($this->recipient, ApprovedApprovalNotification::class, 1);
+
+    // The observation must carry the indexed row itself — a listener fabricating a sufficient
+    // model from the event payload would notify while orphaning the claim from the queue's row.
+    $given = app(ApprovalNotificationRecipients::class)->approvals;
+
+    expect($given)->toHaveCount(1)
+        ->and($given[0]->getKey())->toBe($row->getKey())
+        ->and($given[0]->tool_call_id)->toBe('call_elsewhere')
+        ->and($given[0]->receipt_id)->toBe('receipt-elsewhere');
+});
+
+it('treats a terminal event whose binding does not match the indexed row as a quiet no-op', function (): void {
+    $row = transitionRow('call_bound', 'receipt-bound');
+
+    // A known tool call under a different receipt, and a known receipt under a different tool
+    // call: neither names the indexed pause, so neither may notify, claim, or touch the row.
+    event(transitioned('receipt-other', 'call_bound', ApprovalReceiptStatus::Approved));
+    event(transitioned('receipt-bound', 'call_other', ApprovalReceiptStatus::Approved));
+
+    Notification::assertNothingSent();
+
+    $kept = $row->fresh();
+
+    expect(ApprovalNotification::query()->count())->toBe(0)
+        ->and(PendingApproval::query()->count())->toBe(1)
+        ->and($kept->getKey())->toBe($row->getKey())
+        ->and($kept->tool_call_id)->toBe('call_bound')
+        ->and($kept->receipt_id)->toBe('receipt-bound');
+});
+
+it('notifies a rejection observed from the transition event', function (): void {
+    transitionRow('call_rejected_elsewhere', 'receipt-rejected-elsewhere');
+
+    event(transitioned('receipt-rejected-elsewhere', 'call_rejected_elsewhere', ApprovalReceiptStatus::Rejected));
+
+    Notification::assertSentToTimes($this->recipient, RejectedApprovalNotification::class, 1);
+});
+
+it('ships the consumed notice VC-11 could not build, reporting the observation within its ceiling', function (): void {
+    $row = transitionRow('call_consumed', 'receipt-consumed');
+
+    event(transitioned('receipt-consumed', 'call_consumed', ApprovalReceiptStatus::Consumed));
+    event(transitioned('receipt-consumed', 'call_consumed', ApprovalReceiptStatus::Consumed));
+
+    Notification::assertSentToTimes($this->recipient, ConsumedApprovalNotification::class, 1);
+
+    // ADR 0028 ceiling: report Verdict's observation — the receipt was consumed — never the
+    // unobservable consequence a reader would infer from "completed" or "finished".
+    $message = (new ConsumedApprovalNotification($row))->toArray($this->recipient)['message'];
+
+    expect($message)->toContain('consumed')
+        ->not->toContain('completed')
+        ->not->toContain('finished');
+
+    $keys = app(ApprovalNotificationRecipients::class)->requested;
+
+    expect($keys)->toContain(ApprovalNotificationKey::Consumed);
+});
+
+it('notifies once when the console decided and the transition event arrives for its own decision', function (): void {
+    $row = transitionRow('call_own_decision', 'receipt-own-decision');
+
+    // The resolution service notifies at decision time; the store's event then reports the same
+    // committed transition back. One observation, one claim, one notification.
+    app(ApprovalNotificationDispatcher::class)->approved($row);
+    event(transitioned('receipt-own-decision', 'call_own_decision', ApprovalReceiptStatus::Approved));
+
+    Notification::assertSentToTimes($this->recipient, ApprovedApprovalNotification::class, 1);
+});
+
+it('ingests nothing from an issuance transition: the pause pipeline stays on ToolApprovalRequested', function (): void {
+    event(transitioned('receipt-issued', 'call_never_ingested', ApprovalReceiptStatus::Pending));
+
+    // The issuance event carries no conversation or participant correlation; treating it as a
+    // second ingestion path would mint rows the resume pipeline cannot drive.
+    expect(PendingApproval::query()->count())->toBe(0);
+    Notification::assertNothingSent();
+});
+
+it('treats a transition for a pause this console never indexed as a quiet no-op', function (): void {
+    event(transitioned('receipt-foreign', 'call_foreign', ApprovalReceiptStatus::Approved));
+
+    Notification::assertNothingSent();
+
+    expect(PendingApproval::query()->count())->toBe(0);
+});
+
+/**
+ * ADR 0001 §3: expiry has no transition moment — a TTL passes silently, observed only at
+ * validate/consume time — so no listener may exist for an expiry-shaped event. Verdict's status
+ * vocabulary is where one would have to appear first; this pins the console to deciding what an
+ * expired transition means BEFORE handling one, instead of silently routing it.
+ */
+it('confirms verdict ships no expiry transition for the console to listen for', function (): void {
+    expect(array_map(fn (ApprovalReceiptStatus $status) => $status->value, ApprovalReceiptStatus::cases()))
+        ->toEqualCanonicalizing(['pending', 'approved', 'rejected', 'consumed']);
+});

--- a/tests/Integration/ReceiptTransitionIntegrationTest.php
+++ b/tests/Integration/ReceiptTransitionIntegrationTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Approvals\ApprovalManager;
+use Fissible\Verdict\Testing\AllowAllApprovalAuthorizer;
+use Fissible\VerdictConsole\Approvals\PendingApprovalStore;
+use Fissible\VerdictConsole\Contracts\ApprovalNotificationRecipients;
+use Fissible\VerdictConsole\Notifications\ApprovedApprovalNotification;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Notification;
+
+/**
+ * VC-46's wiring, proven against the real substrate: Verdict's manager decides, its store commits
+ * and dispatches ApprovalReceiptTransitioned, and the console's listener — registered by the
+ * provider, not by this test — lands the observation. The Feature tier pins the listener's whole
+ * behavior matrix over hand-built events; this proves those events are the ones Verdict sends.
+ */
+final class TransitionChainRecipient
+{
+    use Notifiable;
+
+    public function __construct(private readonly string $key) {}
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+}
+
+it('lands the approved notice when verdicts own manager decides, with no console decision path involved', function (): void {
+    config()->set('verdict.approvals.authorizer', AllowAllApprovalAuthorizer::class);
+
+    $console = dirname(__DIR__, 2).'/database/migrations';
+    (require $console.'/create_verdict_console_pending_approvals_table.php.stub')->up();
+    (require $console.'/add_operational_state_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require $console.'/add_approval_context_to_verdict_console_pending_approvals_table.php.stub')->up();
+    (require $console.'/create_verdict_console_approval_notifications_table.php.stub')->up();
+
+    $verdict = dirname(__DIR__, 2).'/vendor/fissible/verdict/database/migrations';
+
+    foreach ([
+        'create_verdict_approval_receipts_table.php.stub',
+        'add_proposal_provenance_to_verdict_approval_receipts_table.php.stub',
+        'add_approval_context_to_verdict_approval_receipts_table.php.stub',
+        'add_approver_summary_to_verdict_approval_receipts_table.php.stub',
+        'add_pending_enumeration_index_to_verdict_approval_receipts_table.php.stub',
+    ] as $stub) {
+        (require $verdict.'/'.$stub)->up();
+    }
+
+    app(PendingApprovalStore::class)->ingest(
+        'call_real_chain',
+        conversationId: 'conversation-1',
+        receiptId: 'receipt-real-chain',
+    );
+    DB::table('verdict_approval_receipts')->insert([
+        'id' => 'receipt-real-chain',
+        'tool_call_id' => 'call_real_chain',
+        'capability' => 'orders.cancel',
+        'binding_fingerprint' => str_repeat('a', 64),
+        'status' => 'pending',
+        'reason' => 'Cancelling an order needs confirmation.',
+        'expires_at' => now()->addHour(),
+        'created_at' => now()->subMinutes(5),
+        'updated_at' => now()->subMinutes(5),
+    ]);
+
+    $recipient = new TransitionChainRecipient('integration-observer');
+    app()->instance(ApprovalNotificationRecipients::class, new class($recipient) implements ApprovalNotificationRecipients
+    {
+        public function __construct(private readonly TransitionChainRecipient $recipient) {}
+
+        public function forApproval($approval, $key): iterable
+        {
+            return [$this->recipient];
+        }
+    });
+    Notification::fake();
+
+    $transition = app(ApprovalManager::class)->approve('receipt-real-chain', 'call_real_chain', 'other-operator');
+
+    expect($transition->succeeded())->toBeTrue()
+        ->and(DB::table('verdict_approval_receipts')->where('id', 'receipt-real-chain')->value('status'))->toBe('approved');
+
+    Notification::assertSentToTimes($recipient, ApprovedApprovalNotification::class, 1);
+});


### PR DESCRIPTION
Closes #46.

Decisions resolved through some other client (a host's own endpoint) and receipts consumed by the model were invisible to the console until its next live read. verdict 0.15 ships #299 as one store-dispatched `ApprovalReceiptTransitioned` event — identity, resulting status, and time (ADR 0008 payload) — rather than the four event classes the issue predicted; this adoption follows the shipped shape, and ADR 0001 §3 carries a dated amendment recording it.

The new listener observes terminal transitions only, for an indexed pause matching **both** the tool-call and receipt identities: approved/rejected land the existing notices, and the `consumed` notice VC-11 recorded as impossible now ships (its copy reports the observation and never claims a completed action — the ADR 0028 ceiling). Everything routes through the claim-idempotent dispatcher, so redelivery and console-decided-then-event both notify exactly once. Issuance transitions are ignored — ingestion stays on Laravel AI's `ToolApprovalRequested`, which holds the conversation correlation — and unknown or mismatched bindings are quiet no-ops that touch nothing. A fixture guard pins Verdict's four-status vocabulary, so an expiry transition appearing upstream forces a decision here instead of being silently routed.

`Consumed` (`approval-consumed`) is a new host-visible `ApprovalNotificationRecipients` routing key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)