### PR TITLE
feat: observed-configuration drift view over the decision trail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to Verdict Console will be documented in this file.
   model-consumed receipts now notify from Verdict's observed transition event. `Consumed` is a new
   host-visible `ApprovalNotificationRecipients` routing key (`approval-consumed`).
 
+- **Observed-configuration drift view (#106).** `ConfigurationDriftQuery::observed()` — a
+  host-replaceable aggregate over the decision trail: per (capability, configuration fingerprint),
+  first and last observation and the decision count, newest-last-observation first with a
+  deterministic tie-break, consuming the #105 sink posture for state, table, and connection. The
+  `<x-verdict-console::configuration-drift />` rendering lists observed fingerprints per
+  capability and marks the one matching that capability's current declared fingerprint from the
+  `ConfigurationInspection` boundary — never cross-capability, never filtered to current
+  declarations, and stated plainly on the page: observed history, not a write log — a
+  configuration change that never decided anything leaves no row.
+
 - **Require Verdict `^0.15` — the review-lane release.** The 0.15 compatibility pass: the bound
   moves to the current minor per the standing prefer-lowest reasoning. What reaches this package:
   the new `add_review_outcome` evidence stub joins both fixture guards (the column is additive and

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -366,6 +366,10 @@ free.
   §6.6 says "recording is off — blank by config," it stays blank rather than implying no decisions.
   Its evidence-display audience is host-governed: the host embeds it behind its own authorization;
   the page adds no gate of its own.
+  `<x-verdict-console::configuration-drift />` presents observed configuration history through the
+  host-replaceable `ConfigurationDriftQuery`: per capability it marks an observed fingerprint only
+  when it is the current declared fingerprint. It is observed history, not a write log: a
+  configuration change that never decided anything leaves no row.
   Chat surfaces start and continue conversations through the host's `ChatEntry` contract
   (participant plus resumable-agent key, `verdict-console.chat.entry_key`), check ownership
   against Laravel AI's recorded participant, and read the thread through the host's

--- a/resources/views/components/configuration-drift.blade.php
+++ b/resources/views/components/configuration-drift.blade.php
@@ -1,0 +1,25 @@
+<section data-verdict-console="configuration-drift" data-recording="{{ $result->recording->value }}">
+    @if ($result->recording->value === 'off')
+        <p data-recording-off>recording is off — blank by config.</p>
+    @elseif ($result->recording->value === 'chained')
+        <p data-recording-chained>A chained sink{{ $result->recordedBy === null ? '' : ' ('.$result->recordedBy.')' }} is configured; decisions are not readable from this table.</p>
+    @elseif ($result->recording->value === 'elsewhere')
+        <p data-recording-elsewhere>Evidence is recorded elsewhere by {{ $result->recordedBy }}.</p>
+    @elseif ($result->observations === [])
+        <p data-empty>No configuration observations have been recorded.</p>
+    @else
+        <table data-configuration-drift>
+            <tbody>
+                @foreach ($result->observations as $observation)
+                    <tr data-observation data-capability="{{ $observation->capability }}" data-fingerprint="{{ $observation->configurationFingerprint }}" data-current="{{ ($currentFingerprints[$observation->capability] ?? null) === $observation->configurationFingerprint ? 'true' : 'false' }}">
+                        <td data-field="first_observed"><time datetime="{{ $observation->firstObservedAt->format(DATE_ATOM) }}">{{ $observation->firstObservedAt->format(DATE_ATOM) }}</time></td>
+                        <td data-field="last_observed"><time datetime="{{ $observation->lastObservedAt->format(DATE_ATOM) }}">{{ $observation->lastObservedAt->format(DATE_ATOM) }}</time></td>
+                        <td data-field="decisions">{{ $observation->decisionCount }}</td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    @endif
+
+    <p>Observed history, not a write log: a configuration change that never decided anything leaves no row here.</p>
+</section>

--- a/src/Contracts/ConfigurationDriftQuery.php
+++ b/src/Contracts/ConfigurationDriftQuery.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Contracts;
+
+use Fissible\VerdictConsole\Evidence\ConfigurationDriftResult;
+
+/**
+ * Console-owned, host-replaceable read boundary for observed configuration history.
+ */
+interface ConfigurationDriftQuery
+{
+    public function observed(): ConfigurationDriftResult;
+}

--- a/src/Evidence/ConfigurationDriftResult.php
+++ b/src/Evidence/ConfigurationDriftResult.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Evidence;
+
+/** @param list<ObservedConfiguration> $observations */
+final readonly class ConfigurationDriftResult
+{
+    /** @param list<ObservedConfiguration> $observations */
+    public function __construct(
+        public EvidenceRecordingState $recording,
+        public array $observations,
+        public ?string $recordedBy = null,
+    ) {}
+}

--- a/src/Evidence/DatabaseConfigurationDriftQuery.php
+++ b/src/Evidence/DatabaseConfigurationDriftQuery.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Evidence;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Fissible\VerdictConsole\Contracts\ConfigurationDriftQuery;
+use Fissible\VerdictConsole\Contracts\EvidenceSinkPosture;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Database\DatabaseManager;
+
+/**
+ * Aggregates observed configuration fingerprints from Verdict's published decision evidence.
+ *
+ * This is observed history, not a write log: configurations that never decided anything have no
+ * row to aggregate.
+ */
+final readonly class DatabaseConfigurationDriftQuery implements ConfigurationDriftQuery
+{
+    public function __construct(
+        private DatabaseManager $database,
+        private Container $app,
+    ) {}
+
+    public function observed(): ConfigurationDriftResult
+    {
+        $posture = $this->app->make(EvidenceSinkPosture::class)->read();
+
+        if ($posture->state !== EvidenceRecordingState::On) {
+            return new ConfigurationDriftResult($posture->state, [], $posture->recordedBy);
+        }
+
+        if ($posture->table === null) {
+            throw new \LogicException('A readable evidence posture must name a table.');
+        }
+
+        $rows = $this->database
+            ->connection($posture->connection)
+            ->table($posture->table)
+            ->selectRaw('capability, configuration_fingerprint, MIN(recorded_at) as first_observed_at, MAX(recorded_at) as last_observed_at, COUNT(*) as decision_count')
+            ->where('record_type', 'decision')
+            ->whereNotNull('capability')
+            ->whereNotNull('configuration_fingerprint')
+            ->groupBy('capability', 'configuration_fingerprint')
+            ->orderBy('capability')
+            ->orderByDesc('last_observed_at')
+            ->orderBy('configuration_fingerprint')
+            ->get();
+
+        $observations = [];
+
+        foreach ($rows as $row) {
+            $observations[] = new ObservedConfiguration(
+                capability: (string) $row->capability,
+                configurationFingerprint: (string) $row->configuration_fingerprint,
+                firstObservedAt: $this->date((string) $row->first_observed_at),
+                lastObservedAt: $this->date((string) $row->last_observed_at),
+                decisionCount: (int) $row->decision_count,
+            );
+        }
+
+        return new ConfigurationDriftResult(EvidenceRecordingState::On, $observations);
+    }
+
+    private function date(string $value): DateTimeImmutable
+    {
+        return new DateTimeImmutable($value, new DateTimeZone('UTC'));
+    }
+}

--- a/src/Evidence/ObservedConfiguration.php
+++ b/src/Evidence/ObservedConfiguration.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Evidence;
+
+use DateTimeImmutable;
+
+final readonly class ObservedConfiguration
+{
+    public function __construct(
+        public string $capability,
+        public string $configurationFingerprint,
+        public DateTimeImmutable $firstObservedAt,
+        public DateTimeImmutable $lastObservedAt,
+        public int $decisionCount,
+    ) {}
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -23,6 +23,7 @@ use Fissible\VerdictConsole\Contracts\ApprovalPresenter;
 use Fissible\VerdictConsole\Contracts\ApprovalScope;
 use Fissible\VerdictConsole\Contracts\ApproverAuthority;
 use Fissible\VerdictConsole\Contracts\ChatEntry;
+use Fissible\VerdictConsole\Contracts\ConfigurationDriftQuery;
 use Fissible\VerdictConsole\Contracts\ConfigurationInspection;
 use Fissible\VerdictConsole\Contracts\ConversationParticipants;
 use Fissible\VerdictConsole\Contracts\EvidenceQuery;
@@ -32,6 +33,7 @@ use Fissible\VerdictConsole\Contracts\ResumableAgents;
 use Fissible\VerdictConsole\Events\ApprovalDecisionRefused;
 use Fissible\VerdictConsole\Events\ApprovalIngestionIncident;
 use Fissible\VerdictConsole\Evidence\ConfigurationSinkPosture;
+use Fissible\VerdictConsole\Evidence\DatabaseConfigurationDriftQuery;
 use Fissible\VerdictConsole\Evidence\DatabaseEvidenceQuery;
 use Fissible\VerdictConsole\ExecutionClaims\GateExecutionClaimAuthority;
 use Fissible\VerdictConsole\Http\VerdictConsoleRoutes;
@@ -96,6 +98,8 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         $this->app->singleton(ApprovalNotificationRecipients::class, UnconfiguredApprovalNotificationRecipients::class);
 
         $this->app->singleton(EvidenceQuery::class, DatabaseEvidenceQuery::class);
+
+        $this->app->singleton(ConfigurationDriftQuery::class, DatabaseConfigurationDriftQuery::class);
 
         $this->app->singleton(EvidenceSinkPosture::class, ConfigurationSinkPosture::class);
 

--- a/src/View/Components/ConfigurationDrift.php
+++ b/src/View/Components/ConfigurationDrift.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\View\Components;
+
+use Fissible\VerdictConsole\Contracts\ConfigurationDriftQuery;
+use Fissible\VerdictConsole\Contracts\ConfigurationInspection;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+final class ConfigurationDrift extends Component
+{
+    public function __construct(
+        private ConfigurationDriftQuery $drift,
+        private ConfigurationInspection $inspection,
+    ) {}
+
+    public function render(): View
+    {
+        $result = $this->drift->observed();
+        $currentFingerprints = [];
+
+        foreach ($this->inspection->capabilities() as $capability) {
+            $currentFingerprints[$capability->name] = $capability->configurationFingerprint;
+        }
+
+        return view('verdict-console::components.configuration-drift', [
+            'result' => $result,
+            'currentFingerprints' => $currentFingerprints,
+        ]);
+    }
+}

--- a/tests/Feature/ConfigurationDriftPageTest.php
+++ b/tests/Feature/ConfigurationDriftPageTest.php
@@ -1,0 +1,344 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\VerdictConsole\Configuration\ApprovalRules;
+use Fissible\VerdictConsole\Configuration\CapabilityInspection;
+use Fissible\VerdictConsole\Contracts\ConfigurationDriftQuery;
+use Fissible\VerdictConsole\Contracts\ConfigurationInspection;
+use Fissible\VerdictConsole\Evidence\ConfigurationDriftResult;
+use Fissible\VerdictConsole\Evidence\EvidenceRecordingState;
+use Fissible\VerdictConsole\Evidence\ObservedConfiguration;
+
+/**
+ * #106's rendering: `<x-verdict-console::configuration-drift />` lists observed fingerprints per
+ * capability, marks the one matching the capability's CURRENT declared fingerprint — from the
+ * ConfigurationInspection boundary, never from config — and states plainly that this is observed
+ * history, not a write log. The page is a pure function of its two contracts; no database exists
+ * in this file.
+ */
+function driftObservation(string $capability, string $fingerprint, string $first, string $last, int $count): ObservedConfiguration
+{
+    return new ObservedConfiguration(
+        capability: $capability,
+        configurationFingerprint: $fingerprint,
+        firstObservedAt: new DateTimeImmutable($first),
+        lastObservedAt: new DateTimeImmutable($last),
+        decisionCount: $count,
+    );
+}
+
+/** @param list<ObservedConfiguration> $observations */
+function bindDriftResult(EvidenceRecordingState $recording, array $observations = [], ?string $recordedBy = null): void
+{
+    $result = new ConfigurationDriftResult(recording: $recording, observations: $observations, recordedBy: $recordedBy);
+
+    app()->instance(ConfigurationDriftQuery::class, new class($result) implements ConfigurationDriftQuery
+    {
+        public function __construct(private readonly ConfigurationDriftResult $result) {}
+
+        public function observed(): ConfigurationDriftResult
+        {
+            return $this->result;
+        }
+    });
+}
+
+/** @param array<string, string> $declared capability name => current declared fingerprint */
+function bindDriftInspection(array $declared): void
+{
+    $capabilities = [];
+
+    foreach ($declared as $name => $fingerprint) {
+        $capabilities[] = new CapabilityInspection(
+            name: $name,
+            ability: 'demo.'.$name,
+            configurationFingerprint: $fingerprint,
+            configurationVersion: null,
+            confirmationRequired: false,
+            confirmationReason: null,
+            confirmationTtlSeconds: null,
+            executionTargetPolicy: null,
+            executionTargetStrategy: null,
+            rateLimit: null,
+            executionClaimPolicy: null,
+            requiresIntentRecord: null,
+            consequential: false,
+        );
+    }
+
+    app()->instance(ConfigurationInspection::class, new class($capabilities) implements ConfigurationInspection
+    {
+        /** @param list<CapabilityInspection> $capabilities */
+        public function __construct(private readonly array $capabilities) {}
+
+        public function capabilities(): array
+        {
+            return $this->capabilities;
+        }
+
+        public function rateLimits(): array
+        {
+            return [];
+        }
+
+        public function approvalRules(): ApprovalRules
+        {
+            return new ApprovalRules(ttlSeconds: null, authorizer: null, strictProvenance: false, gateAbility: 'operate-verdict-console');
+        }
+    });
+}
+
+function renderDrift(): string
+{
+    return (string) test()->blade('<x-verdict-console::configuration-drift />');
+}
+
+/**
+ * @return list<array{capability: string, fingerprint: string, current: bool, fields: array<string, string>}>
+ */
+function driftRows(string $html): array
+{
+    $document = new DOMDocument;
+    libxml_use_internal_errors(true);
+    $document->loadHTML('<?xml encoding="utf-8" ?>'.$html);
+    libxml_clear_errors();
+
+    $rows = [];
+
+    foreach ((new DOMXPath($document))->query('//*[@data-observation]') ?: [] as $node) {
+        if (! $node instanceof DOMElement) {
+            continue;
+        }
+
+        $fields = [];
+
+        foreach ((new DOMXPath($document))->query('.//*[@data-field]', $node) ?: [] as $field) {
+            if ($field instanceof DOMElement) {
+                $fields[$field->getAttribute('data-field')] = trim((string) preg_replace('/\s+/', ' ', $field->textContent));
+            }
+        }
+
+        $rows[] = [
+            'capability' => $node->getAttribute('data-capability'),
+            'fingerprint' => $node->getAttribute('data-fingerprint'),
+            'current' => $node->getAttribute('data-current') === 'true',
+            'fields' => $fields,
+        ];
+    }
+
+    return $rows;
+}
+
+beforeEach(function (): void {
+    bindDriftInspection([]);
+    bindDriftResult(EvidenceRecordingState::On);
+});
+
+/**
+ * The rows are the drift boundary's observations in its order, each carrying exact bounds and
+ * count — and the current marker sits ONLY on the row whose fingerprint matches ITS capability's
+ * declared fingerprint. billing's current fingerprint is also observed under orders, where it must
+ * not be marked: capabilities never share a marker.
+ */
+it('lists observations with exact fields and marks the current fingerprint per capability', function (): void {
+    bindDriftInspection([
+        'billing.refund' => 'sha256:fp-two',
+        'orders.cancel' => 'sha256:fp-nine',
+    ]);
+    bindDriftResult(EvidenceRecordingState::On, [
+        driftObservation('billing.refund', 'sha256:fp-two', '2026-09-01 10:20:00+00:00', '2026-09-01 10:20:00+00:00', 1),
+        driftObservation('billing.refund', 'sha256:fp-one', '2026-09-01 10:00:00+00:00', '2026-09-01 10:10:00+00:00', 3),
+        driftObservation('orders.cancel', 'sha256:fp-two', '2026-09-01 10:01:00+00:00', '2026-09-01 10:02:00+00:00', 2),
+    ]);
+
+    $rows = driftRows(renderDrift());
+
+    // Every row's own fields, not a sampled one: a loop that drops or mislabels a bound or count
+    // on any row fails here.
+    expect(array_map(fn (array $row): array => [
+        $row['capability'],
+        $row['fingerprint'],
+        $row['current'],
+        $row['fields']['first_observed'] ?? null,
+        $row['fields']['last_observed'] ?? null,
+        $row['fields']['decisions'] ?? null,
+    ], $rows))->toBe([
+        ['billing.refund', 'sha256:fp-two', true, '2026-09-01T10:20:00+00:00', '2026-09-01T10:20:00+00:00', '1'],
+        ['billing.refund', 'sha256:fp-one', false, '2026-09-01T10:00:00+00:00', '2026-09-01T10:10:00+00:00', '3'],
+        ['orders.cancel', 'sha256:fp-two', false, '2026-09-01T10:01:00+00:00', '2026-09-01T10:02:00+00:00', '2'],
+    ]);
+});
+
+/**
+ * The marker comes from the inspection BOUNDARY: these declared fingerprints are arbitrary strings
+ * no config file produced, and a declared capability the trail never observed adds no row of its
+ * own — the view lists observations, not declarations.
+ */
+it('marks nothing when the inspection declares no matching fingerprint', function (): void {
+    bindDriftInspection([
+        'billing.refund' => 'sha256:never-observed',
+        'ghost.capability' => 'sha256:also-never-observed',
+    ]);
+    bindDriftResult(EvidenceRecordingState::On, [
+        driftObservation('billing.refund', 'sha256:fp-old', '2026-09-01 10:00:00+00:00', '2026-09-01 10:00:00+00:00', 1),
+        // A capability the inspection no longer declares — removed or renamed since the trail was
+        // written. Its history still renders, unmarked, even though its fingerprint IS the one
+        // billing currently declares: observations are never filtered to current declarations.
+        driftObservation('retired.capability', 'sha256:never-observed', '2026-09-01 09:00:00+00:00', '2026-09-01 09:30:00+00:00', 4),
+    ]);
+
+    $rows = driftRows(renderDrift());
+
+    expect(array_map(fn (array $row): array => [$row['capability'], $row['current']], $rows))->toBe([
+        ['billing.refund', false],
+        ['retired.capability', false],
+    ]);
+
+    expect(renderDrift())->not->toContain('ghost.capability');
+});
+
+/** The observed-history stance is stated on the page, empty or not, in the issue's own words. */
+it('states that this is observed history, not a write log, and renders an empty trail honestly', function (): void {
+    $empty = renderDrift();
+
+    expect($empty)->toContain('Observed history, not a write log: a configuration change that never decided anything leaves no row here.')
+        ->and($empty)->toContain('No configuration observations have been recorded.')
+        ->and($empty)->not->toContain('data-observation')
+        ->and($empty)->not->toContain('recording is off');
+
+    bindDriftResult(EvidenceRecordingState::On, [
+        driftObservation('billing.refund', 'sha256:fp-one', '2026-09-01 10:00:00+00:00', '2026-09-01 10:00:00+00:00', 1),
+    ]);
+
+    expect(renderDrift())->toContain('Observed history, not a write log: a configuration change that never decided anything leaves no row here.')
+        ->and(renderDrift())->not->toContain('No configuration observations have been recorded.');
+});
+
+/** The recording states are the boundary's answer, rendered in the console's standard words. */
+it('renders the boundarys recording state instead of observations', function (): void {
+    bindDriftResult(EvidenceRecordingState::Off);
+
+    $off = renderDrift();
+
+    bindDriftResult(EvidenceRecordingState::Elsewhere, recordedBy: 'App\\Evidence\\ExternalWriter');
+
+    $elsewhere = renderDrift();
+
+    bindDriftResult(EvidenceRecordingState::Chained, recordedBy: 'main-ledger');
+
+    $chained = renderDrift();
+
+    bindDriftResult(EvidenceRecordingState::Chained);
+
+    $chainedUnnamed = renderDrift();
+
+    expect($off)->toContain('data-recording="off"')
+        ->and($off)->toContain('recording is off — blank by config.')
+        ->and($off)->not->toContain('No configuration observations')
+        ->and($elsewhere)->toContain('data-recording="elsewhere"')
+        ->and($elsewhere)->toContain('Evidence is recorded elsewhere by App\Evidence\ExternalWriter.')
+        ->and($chained)->toContain('data-recording="chained"')
+        ->and($chained)->toContain('A chained sink (main-ledger) is configured; decisions are not readable from this table.')
+        ->and($chainedUnnamed)->toContain('A chained sink is configured; decisions are not readable from this table.');
+
+    // The observed-history qualification is the page's nature, not a branch of the On state.
+    foreach ([$off, $elsewhere, $chained, $chainedUnnamed] as $html) {
+        expect($html)->toContain('Observed history, not a write log: a configuration change that never decided anything leaves no row here.');
+    }
+});
+
+/** Everything rendered is escaped: a hostile fingerprint or capability never becomes markup. */
+it('escapes every value it renders', function (): void {
+    bindDriftInspection(['<script>alert(1)</script>' => '<b>fp</b>']);
+    bindDriftResult(EvidenceRecordingState::On, [
+        driftObservation('<script>alert(1)</script>', '<b>fp</b>', '2026-09-01 10:00:00+00:00', '2026-09-01 10:00:00+00:00', 1),
+    ]);
+
+    $html = renderDrift();
+
+    // Escaped, not dropped: the literal values survive as text while never becoming markup.
+    expect($html)->not->toContain('<script>alert(1)</script>')
+        ->and($html)->not->toContain('<b>fp</b>')
+        ->and($html)->toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+        ->and($html)->toContain('&lt;b&gt;fp&lt;/b&gt;');
+
+    // And the recording states' writer/chain identity is external input too: escaped, still shown.
+    bindDriftResult(EvidenceRecordingState::Elsewhere, recordedBy: '<img src=x onerror=alert(1)>');
+
+    $elsewhere = renderDrift();
+
+    bindDriftResult(EvidenceRecordingState::Chained, recordedBy: '<i>ledger</i>');
+
+    $chained = renderDrift();
+
+    expect($elsewhere)->not->toContain('<img src=x onerror=alert(1)>')
+        ->and($elsewhere)->toContain('&lt;img src=x onerror=alert(1)&gt;')
+        ->and($chained)->not->toContain('<i>ledger</i>')
+        ->and($chained)->toContain('&lt;i&gt;ledger&lt;/i&gt;');
+
+    // Attribute context too: a double quote in a value must not open a second attribute. The DOM
+    // must hold the literal value on the row's own attribute, and no injected attribute may exist
+    // anywhere.
+    bindDriftResult(EvidenceRecordingState::On, [
+        driftObservation('cap" data-injected="yes', 'sha256:fp" onmouseover="alert(1)', '2026-09-01 10:00:00+00:00', '2026-09-01 10:00:00+00:00', 1),
+    ]);
+
+    $quoted = renderDrift();
+    $rows = driftRows($quoted);
+
+    $document = new DOMDocument;
+    libxml_use_internal_errors(true);
+    $document->loadHTML('<?xml encoding="utf-8" ?>'.$quoted);
+    libxml_clear_errors();
+
+    expect($rows[0]['capability'])->toBe('cap" data-injected="yes')
+        ->and($rows[0]['fingerprint'])->toBe('sha256:fp" onmouseover="alert(1)')
+        ->and((new DOMXPath($document))->query('//*[@data-injected]')->length)->toBe(0)
+        ->and((new DOMXPath($document))->query('//*[@onmouseover]')->length)->toBe(0);
+});
+
+/**
+ * One render is one read: the recording state and the rows come from the SAME answer. A component
+ * calling observed() twice would render this fake's contradictory second answer somewhere — or
+ * fail the call count outright.
+ */
+it('reads the drift boundary exactly once per render', function (): void {
+    $query = new class implements ConfigurationDriftQuery
+    {
+        public int $calls = 0;
+
+        public function observed(): ConfigurationDriftResult
+        {
+            $this->calls++;
+
+            if ($this->calls > 1) {
+                return new ConfigurationDriftResult(recording: EvidenceRecordingState::Off, observations: [], recordedBy: null);
+            }
+
+            return new ConfigurationDriftResult(
+                recording: EvidenceRecordingState::On,
+                observations: [driftObservation('billing.refund', 'sha256:fp-one', '2026-09-01 10:00:00+00:00', '2026-09-01 10:00:00+00:00', 1)],
+                recordedBy: null,
+            );
+        }
+    };
+
+    app()->instance(ConfigurationDriftQuery::class, $query);
+
+    $html = renderDrift();
+
+    expect($query->calls)->toBe(1)
+        ->and($html)->toContain('data-recording="on"')
+        ->and($html)->toContain('sha256:fp-one')
+        ->and($html)->not->toContain('recording is off');
+});
+
+/** An audit surface mutates nothing. */
+it('renders read-only markup with no form', function (): void {
+    bindDriftResult(EvidenceRecordingState::On, [
+        driftObservation('billing.refund', 'sha256:fp-one', '2026-09-01 10:00:00+00:00', '2026-09-01 10:00:00+00:00', 1),
+    ]);
+
+    expect(renderDrift())->not->toContain('<form');
+});

--- a/tests/Feature/ConfigurationDriftQueryTest.php
+++ b/tests/Feature/ConfigurationDriftQueryTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Evidence\DatabaseEvidenceRecorder;
+use Fissible\VerdictConsole\Contracts\ConfigurationDriftQuery;
+use Fissible\VerdictConsole\Contracts\EvidenceSinkPosture;
+use Fissible\VerdictConsole\Evidence\ConfigurationDriftResult;
+use Fissible\VerdictConsole\Evidence\DatabaseConfigurationDriftQuery;
+use Fissible\VerdictConsole\Evidence\EvidenceRecordingState;
+use Fissible\VerdictConsole\Evidence\ObservedConfiguration;
+use Fissible\VerdictConsole\Evidence\SinkPosture;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * #106: the observed-configuration aggregate — per (capability, configuration_fingerprint): first
+ * and last observation and the decision count, from the decision trail alone. This is an
+ * observation of the trail, never a write log: an unexercised configuration change leaves no row.
+ * Fixtures are this file's own.
+ */
+const DRIFT_EVIDENCE_STUBS = [
+    'create_verdict_evidence_table.php.stub',
+    'add_provenance_to_verdict_evidence_table.php.stub',
+    'add_invocation_id_to_verdict_evidence_table.php.stub',
+    'add_tool_kind_to_verdict_evidence_table.php.stub',
+    'add_configuration_fingerprint_to_verdict_evidence_table.php.stub',
+    'add_actor_and_subject_fingerprints_to_verdict_evidence_table.php.stub',
+    'add_target_source_to_verdict_evidence_table.php.stub',
+    'add_tool_description_fingerprints_to_verdict_evidence_table.php.stub',
+    'add_record_identity_to_verdict_evidence_table.php.stub',
+    'add_review_outcome_to_verdict_evidence_table.php.stub',
+    'add_intent_id_to_verdict_evidence_table.php.stub',
+];
+
+/** @param array<string, mixed> $attributes */
+function insertDriftRow(array $attributes): void
+{
+    DB::table('console_drift_evidence')->insert([
+        'id' => $attributes['id'],
+        'record_type' => $attributes['record_type'] ?? 'decision',
+        'capability' => array_key_exists('capability', $attributes) ? $attributes['capability'] : 'orders.cancel',
+        'stage' => $attributes['stage'] ?? 'proposal',
+        'disposition' => $attributes['disposition'] ?? 'permit',
+        'configuration_fingerprint' => $attributes['configuration_fingerprint'] ?? null,
+        'recorded_at' => $attributes['recorded_at'],
+    ]);
+}
+
+/** @return list<array{0: string, 1: string, 2: string, 3: string, 4: int}> capability, fingerprint, first, last, count */
+function driftTuples(ConfigurationDriftResult $result): array
+{
+    return array_map(fn (ObservedConfiguration $observed): array => [
+        $observed->capability,
+        $observed->configurationFingerprint,
+        $observed->firstObservedAt->format(DATE_ATOM),
+        $observed->lastObservedAt->format(DATE_ATOM),
+        $observed->decisionCount,
+    ], $result->observations);
+}
+
+beforeEach(function (): void {
+    config()->set('verdict.evidence.table', 'console_drift_evidence');
+    config()->set('verdict.evidence.recorder', DatabaseEvidenceRecorder::class);
+
+    $migrations = dirname(__DIR__, 2).'/vendor/fissible/verdict/database/migrations';
+
+    foreach (DRIFT_EVIDENCE_STUBS as $stub) {
+        (require $migrations.'/'.$stub)->up();
+    }
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists('console_drift_evidence');
+});
+
+/** Same guard every evidence fixture carries: a new Verdict stub must not leave this file behind. */
+it('builds its fixture from every evidence-table stub the installed Verdict publishes', function (): void {
+    $published = array_map(basename(...), glob(dirname(__DIR__, 2).'/vendor/fissible/verdict/database/migrations/*verdict_evidence_table.php.stub') ?: []);
+
+    expect(DRIFT_EVIDENCE_STUBS)->toEqualCanonicalizing($published);
+});
+
+/**
+ * The aggregate is exact: counts and both timestamp bounds per (capability, fingerprint), ordered
+ * capability-ascending then newest-last-observation first — and two capabilities sharing a
+ * fingerprint NEVER merge.
+ */
+it('aggregates observed configurations per capability with exact counts and bounds', function (): void {
+    // A non-UTC host timezone must not shift the bounds: the schema is timezone-naive and the
+    // write side mints UTC, so hydration reads UTC whatever the application is set to.
+    config()->set('app.timezone', 'America/Chicago');
+    date_default_timezone_set('America/Chicago');
+
+    insertDriftRow(['id' => 'a-old-1', 'capability' => 'billing.refund', 'configuration_fingerprint' => 'sha256:fp-one', 'recorded_at' => '2026-09-01 10:00:00']);
+    insertDriftRow(['id' => 'a-old-2', 'capability' => 'billing.refund', 'configuration_fingerprint' => 'sha256:fp-one', 'recorded_at' => '2026-09-01 10:05:00']);
+    insertDriftRow(['id' => 'a-old-3', 'capability' => 'billing.refund', 'configuration_fingerprint' => 'sha256:fp-one', 'recorded_at' => '2026-09-01 10:10:00']);
+    insertDriftRow(['id' => 'a-new-1', 'capability' => 'billing.refund', 'configuration_fingerprint' => 'sha256:fp-two', 'recorded_at' => '2026-09-01 10:20:00']);
+    // The same fingerprint under another capability: a distinct observation with its own bounds.
+    insertDriftRow(['id' => 'b-1', 'capability' => 'orders.cancel', 'configuration_fingerprint' => 'sha256:fp-one', 'recorded_at' => '2026-09-01 10:01:00']);
+    insertDriftRow(['id' => 'b-2', 'capability' => 'orders.cancel', 'configuration_fingerprint' => 'sha256:fp-one', 'recorded_at' => '2026-09-01 10:02:00']);
+    // Two fingerprints last observed at the same instant: the order is still deterministic —
+    // fingerprint ascending breaks the tie, on every engine.
+    insertDriftRow(['id' => 'z-b', 'capability' => 'zulu.charge', 'configuration_fingerprint' => 'sha256:fp-b', 'recorded_at' => '2026-09-01 10:30:00']);
+    insertDriftRow(['id' => 'z-a', 'capability' => 'zulu.charge', 'configuration_fingerprint' => 'sha256:fp-a', 'recorded_at' => '2026-09-01 10:30:00']);
+
+    $result = app(ConfigurationDriftQuery::class)->observed();
+
+    expect($result->recording)->toBe(EvidenceRecordingState::On)
+        ->and(driftTuples($result))->toBe([
+            ['billing.refund', 'sha256:fp-two', '2026-09-01T10:20:00+00:00', '2026-09-01T10:20:00+00:00', 1],
+            ['billing.refund', 'sha256:fp-one', '2026-09-01T10:00:00+00:00', '2026-09-01T10:10:00+00:00', 3],
+            ['orders.cancel', 'sha256:fp-one', '2026-09-01T10:01:00+00:00', '2026-09-01T10:02:00+00:00', 2],
+            ['zulu.charge', 'sha256:fp-a', '2026-09-01T10:30:00+00:00', '2026-09-01T10:30:00+00:00', 1],
+            ['zulu.charge', 'sha256:fp-b', '2026-09-01T10:30:00+00:00', '2026-09-01T10:30:00+00:00', 1],
+        ]);
+
+    date_default_timezone_set('UTC');
+});
+
+/** The provider ships the database aggregate on the contract, not merely something bindable. */
+it('binds the shipped database drift query to the contract', function (): void {
+    expect(app(ConfigurationDriftQuery::class))->toBeInstanceOf(DatabaseConfigurationDriftQuery::class);
+});
+
+/**
+ * Only capability-resolved decisions observe a configuration: rows with a null fingerprint, rows
+ * with no capability, and non-decision record types are excluded explicitly — never counted, never
+ * bound-shifting.
+ */
+it('excludes null fingerprints, null capabilities, and non-decision rows explicitly', function (): void {
+    insertDriftRow(['id' => 'counted', 'capability' => 'orders.cancel', 'configuration_fingerprint' => 'sha256:fp-one', 'recorded_at' => '2026-09-01 10:05:00']);
+    insertDriftRow(['id' => 'null-fingerprint', 'capability' => 'orders.cancel', 'recorded_at' => '2026-09-01 09:00:00']);
+    insertDriftRow(['id' => 'null-capability', 'capability' => null, 'configuration_fingerprint' => 'sha256:fp-one', 'recorded_at' => '2026-09-01 09:01:00']);
+    insertDriftRow(['id' => 'provenance-row', 'record_type' => 'provenance', 'capability' => 'orders.cancel', 'stage' => 'input', 'disposition' => 'recorded', 'configuration_fingerprint' => 'sha256:fp-one', 'recorded_at' => '2026-09-01 09:02:00']);
+    insertDriftRow(['id' => 'gap-row', 'record_type' => 'chain_gap', 'capability' => 'orders.cancel', 'stage' => 'decision', 'disposition' => 'gap', 'configuration_fingerprint' => 'sha256:fp-one', 'recorded_at' => '2026-09-01 09:03:00']);
+
+    $result = app(ConfigurationDriftQuery::class)->observed();
+
+    // One observation, and its bounds prove the excluded rows shifted nothing: first equals last
+    // equals the single counted decision.
+    expect(driftTuples($result))->toBe([
+        ['orders.cancel', 'sha256:fp-one', '2026-09-01T10:05:00+00:00', '2026-09-01T10:05:00+00:00', 1],
+    ]);
+});
+
+/** An empty trail is an answer, not an error. */
+it('answers an empty trail with recording on and no observations', function (): void {
+    $result = app(ConfigurationDriftQuery::class)->observed();
+
+    expect($result->recording)->toBe(EvidenceRecordingState::On)
+        ->and($result->observations)->toBe([])
+        ->and($result->recordedBy)->toBeNull();
+});
+
+/**
+ * The drift read consumes the #105 posture boundary: a non-readable posture is repeated verbatim
+ * with no observations — and nothing is queried at all, whatever tables exist.
+ */
+it('repeats a non-readable posture verbatim without touching any table', function (): void {
+    insertDriftRow(['id' => 'unreadable', 'capability' => 'orders.cancel', 'configuration_fingerprint' => 'sha256:fp-one', 'recorded_at' => '2026-09-01 10:00:00']);
+
+    foreach ([
+        [EvidenceRecordingState::Off, null],
+        [EvidenceRecordingState::Elsewhere, 'App\\Evidence\\ExternalWriter'],
+        [EvidenceRecordingState::Chained, 'drift-fake-chain'],
+    ] as [$state, $recordedBy]) {
+        app()->instance(EvidenceSinkPosture::class, new class($state, $recordedBy) implements EvidenceSinkPosture
+        {
+            public function __construct(private readonly EvidenceRecordingState $state, private readonly ?string $recordedBy) {}
+
+            public function read(): SinkPosture
+            {
+                return new SinkPosture(
+                    state: $this->state,
+                    effectiveWriter: null,
+                    recordedBy: $this->recordedBy,
+                    table: null,
+                    connection: null,
+                    chainConfigured: false,
+                );
+            }
+        });
+
+        $statements = [];
+        DB::listen(function ($query) use (&$statements): void {
+            $statements[] = $query->sql;
+        });
+
+        $result = app(ConfigurationDriftQuery::class)->observed();
+
+        expect($result->recording)->toBe($state)
+            ->and($result->recordedBy)->toBe($recordedBy)
+            ->and($result->observations)->toBe([])
+            ->and($statements)->toBe([]);
+    }
+});
+
+/** And the readable path reads what the POSTURE names — the table config names does not exist. */
+it('reads the table and connection the posture names, never the ones config names', function (): void {
+    config()->set('database.connections.drift_audit', ['driver' => 'sqlite', 'database' => ':memory:', 'prefix' => '']);
+    config()->set('verdict.evidence.table', 'config_names_a_missing_table');
+
+    Schema::connection('drift_audit')->create('drift_posture_table', function ($table): void {
+        $table->string('id')->primary();
+        $table->string('record_type');
+        $table->string('capability')->nullable();
+        $table->string('stage');
+        $table->string('disposition');
+        $table->string('configuration_fingerprint')->nullable();
+        $table->timestamp('recorded_at');
+    });
+
+    DB::connection('drift_audit')->table('drift_posture_table')->insert([
+        'id' => 'observed-there',
+        'record_type' => 'decision',
+        'capability' => 'orders.cancel',
+        'stage' => 'proposal',
+        'disposition' => 'permit',
+        'configuration_fingerprint' => 'sha256:fp-remote',
+        'recorded_at' => '2026-09-01 10:00:00',
+    ]);
+
+    app()->instance(EvidenceSinkPosture::class, new class implements EvidenceSinkPosture
+    {
+        public function read(): SinkPosture
+        {
+            return new SinkPosture(
+                state: EvidenceRecordingState::On,
+                effectiveWriter: 'Fissible\\Verdict\\Evidence\\DatabaseEvidenceRecorder',
+                recordedBy: null,
+                table: 'drift_posture_table',
+                connection: 'drift_audit',
+                chainConfigured: false,
+            );
+        }
+    });
+
+    $result = app(ConfigurationDriftQuery::class)->observed();
+
+    expect(driftTuples($result))->toBe([
+        ['orders.cancel', 'sha256:fp-remote', '2026-09-01T10:00:00+00:00', '2026-09-01T10:00:00+00:00', 1],
+    ]);
+
+    Schema::connection('drift_audit')->dropIfExists('drift_posture_table');
+});
+
+/** The contract is host-replaceable: a bound replacement answers, whatever the table holds. */
+it('binds the shipped query to a contract a host may replace', function (): void {
+    insertDriftRow(['id' => 'in-the-table', 'capability' => 'orders.cancel', 'configuration_fingerprint' => 'sha256:fp-table', 'recorded_at' => '2026-09-01 10:00:00']);
+
+    app()->instance(ConfigurationDriftQuery::class, new class implements ConfigurationDriftQuery
+    {
+        public function observed(): ConfigurationDriftResult
+        {
+            return new ConfigurationDriftResult(
+                recording: EvidenceRecordingState::On,
+                observations: [new ObservedConfiguration(
+                    capability: 'host.replaced',
+                    configurationFingerprint: 'sha256:from-the-replacement',
+                    firstObservedAt: new DateTimeImmutable('2026-09-01 09:00:00+00:00'),
+                    lastObservedAt: new DateTimeImmutable('2026-09-01 09:30:00+00:00'),
+                    decisionCount: 7,
+                )],
+                recordedBy: null,
+            );
+        }
+    });
+
+    $result = app(ConfigurationDriftQuery::class)->observed();
+
+    expect(driftTuples($result))->toBe([
+        ['host.replaced', 'sha256:from-the-replacement', '2026-09-01T09:00:00+00:00', '2026-09-01T09:30:00+00:00', 7],
+    ]);
+});

--- a/tests/Feature/DocumentationCorrectionsTest.php
+++ b/tests/Feature/DocumentationCorrectionsTest.php
@@ -224,3 +224,13 @@ it('documents the chained-sink recording state in the design of record', functio
         ->toContain('chained sink is configured; decisions are not readable from this table')
         ->toContain('never that any append succeeded');
 });
+
+/** #106 is design-first: the design must carry the surface, its boundary, and its rules. */
+it('documents the configuration drift view and its boundary in the design of record', function (): void {
+    expect(documentation('docs/design/0001-verdict-console-design.md'))
+        ->toContain('`<x-verdict-console::configuration-drift />`')
+        ->toContain('`ConfigurationDriftQuery`')
+        ->toContain('per capability')
+        ->toContain('current declared fingerprint')
+        ->toContain('not a write log');
+});


### PR DESCRIPTION
Closes #106.

Decision records carry `configuration_fingerprint` — the declared configuration of the capability that decided. No surface grouped by it, so "which decisions ran under the old rules" was unanswerable.

**The design**
- `Contracts\ConfigurationDriftQuery::observed(): ConfigurationDriftResult` — standalone and host-replaceable rather than widening `EvidenceQuery`; the result mirrors the evidence boundary's honesty-state shape so non-readable sinks render with the console's standard copy (chained sinks included).
- `ObservedConfiguration`: per (capability, fingerprint) — first/last observed (UTC, pinned under a non-UTC host timezone) and exact decision count. Ordering is deterministic: capability ascending, last-observed newest first, fingerprint ascending on ties.
- The shipped aggregate consumes the #105 `EvidenceSinkPosture` for state **and** table+connection: non-readable postures are repeated verbatim with zero SQL statements; the readable path reads a posture-named table on a posture-named connection (both proven against deliberately-wrong config).
- Exclusions pinned with bound-shift proofs: null fingerprints, null capabilities, and non-decision record types (provenance, chain_gap) never count.

**The rendering** — `<x-verdict-console::configuration-drift />`
- Rows in the boundary's order with exact bounds and counts on every row; `data-current` marks only the fingerprint matching **that capability's** current declared fingerprint from the `ConfigurationInspection` boundary — never cross-capability, and capabilities the inspection no longer declares keep their history, unmarked (observations are never filtered to current declarations).
- One render is one read (pinned with a contradictory-second-answer fake).
- Stated on the page in every state: *"Observed history, not a write log: a configuration change that never decided anything leaves no row here."* Empty trail renders honestly.
- Escaping proven in text and attribute context (quote-injection pins), hostile `recordedBy` included; read-only.

**On the record from review:** the PostgreSQL string-`COUNT(*)` concern is guarded by the explicit `(int)` cast (verified in review) and the repo's real-DB matrix harness — the sqlite suite cannot honestly detect it, so no fixture pretends to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
