### PR TITLE
The reviewer queue: a scoped, record-only rendering of the review lane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Reviewer queue (#48).** The console now renders the scoped, poll-consistent review queue over
+  Verdict 0.15's review substrate. `verdict-console.reviews.gate` (default
+  `review-verdict-action`) and `verdict-console.reviews.scope` keep this separate from approval
+  authority and refuse an unscoped list. Approve and reject record only through Verdict's review
+  manager: they never mint a receipt, resume an agent, or execute a tool. The reader exposes no
+  provenance, so that limitation remains recorded rather than fabricated by the surface.
+
 - **Receipt-transition notifications (#46).** Decisions resolved through other clients and
   model-consumed receipts now notify from Verdict's observed transition event. `Consumed` is a new
   host-visible `ApprovalNotificationRecipients` routing key (`approval-consumed`).

--- a/config/verdict-console.php
+++ b/config/verdict-console.php
@@ -34,6 +34,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Review authority and scope
+    |--------------------------------------------------------------------------
+    | Reviews are a separate, record-only lane. The host names both the Gate
+    | ability and the non-empty approval-context scope; an absent scope refuses
+    | enumeration rather than widening it to every pending review.
+    */
+    'reviews' => [
+        'gate' => 'review-verdict-action',
+        'scope' => [],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Approval routes
     |--------------------------------------------------------------------------
     | Routes mount by default: every endpoint is fail-closed behind the host's

--- a/docs/adr/0001-approval-surface-contract.md
+++ b/docs/adr/0001-approval-surface-contract.md
@@ -231,6 +231,13 @@ decided.** The console's obligations are:
 the console's own operational state, not a change to any authoritative record. The item stays open
 until a human records a verdict.
 
+**Amended 2026-09-01 — shipped review lane (#48).** Verdict's review request now carries the
+upstream-computed TTL. `lapsed, undecided` is a console-rendered clock comparison, not a stored
+status or a console SLA obligation; the upstream expiry supersedes that proposed obligation. Review
+approve/reject record no reviewer reason, execute nothing, and mint nothing. The lane reads only
+Verdict's `ReviewStatusReader`, whose view intentionally carries no provenance; that decline stays
+recorded rather than being reconstructed from another store or evidence surface.
+
 ### 4. Approval authority is itself authorized
 
 Approving is a permissioned action on a specific row, not a role. The rule, already shipped in VC-7

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -318,6 +318,16 @@ Over `DecisionEvidence`, honoring ADR 0008 (fingerprints, not raw), surfacing `c
 A listener persists the ephemeral events into a console-owned incidents table, because they do not
 survive the process. The alarm queue/history reads from that projection, not from the events.
 
+### 6.5.1 Review lane — record-only
+The shipped reviewer queue reads Verdict's scoped `ReviewStatusReader`; it does not derive review
+work from evidence or query around the reader. A non-empty `verdict-console.reviews.scope` is
+required, and `verdict-console.reviews.gate` (default `review-verdict-action`) is a separate host
+grant. Verdict owns the upstream-computed TTL: the console renders a pending request past it as
+`lapsed, undecided`, never persists a second lifecycle state or console SLA. Approve/reject pass the
+reviewer's opaque actor key to Verdict's `ReviewManager` with no reviewer reason; they mint no
+receipt, resume no agent, and execute no tool. The reader deliberately exposes no provenance, so the
+surface names no provenance state until that upstream contract changes.
+
 **Five sources, not four.** Verdict's four anomaly events, plus this package's own
 `ApprovalIngestionIncident` (§6.3). Until this section ships, that fifth source is an event and a log
 line only — which is why the ingestion row carries its `unresumableReason` durably instead of relying

--- a/resources/views/components/reviews.blade.php
+++ b/resources/views/components/reviews.blade.php
@@ -1,0 +1,27 @@
+<section data-review-queue>
+    @if ($queue->state === \Fissible\VerdictConsole\Reviews\ReviewQueueState::Unconfigured)
+        <p>The review lane is not configured.</p>
+    @elseif ($queue->state === \Fissible\VerdictConsole\Reviews\ReviewQueueState::Unscoped)
+        <p>No review scope is configured.</p>
+    @else
+        @forelse ($queue->items as $item)
+            <article data-review-request="{{ $item->requestId }}">
+                <p>{{ $item->capability }}</p>
+                @if ($item->reason !== null)
+                    <p>{{ $item->reason }}</p>
+                @endif
+                @if ($item->summaryFingerprint !== null)
+                    <p>{{ $item->summaryFingerprint }}</p>
+                @endif
+                @if ($item->state === \Fissible\VerdictConsole\Reviews\ReviewItemState::LapsedUndecided)
+                    <p>lapsed, undecided</p>
+                @endif
+                @foreach ($verbs->resolve($item) as $verb)
+                    <button type="button" data-review-verb="{{ $verb->value }}">{{ ucfirst($verb->value) }}</button>
+                @endforeach
+            </article>
+        @empty
+            <p>No reviews are waiting.</p>
+        @endforelse
+    @endif
+</section>

--- a/src/Exceptions/ReviewSurfaceContractViolation.php
+++ b/src/Exceptions/ReviewSurfaceContractViolation.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Exceptions;
+
+use Fissible\VerdictConsole\Reviews\ReviewVerb;
+use LogicException;
+
+final class ReviewSurfaceContractViolation extends LogicException
+{
+    /**
+     * @param  list<ReviewVerb>  $expected
+     * @param  list<ReviewVerb>  $actual
+     */
+    public function __construct(public readonly array $expected, public readonly array $actual)
+    {
+        parent::__construct(sprintf(
+            'Review surface verb contract violated: expected [%s], rendered [%s].',
+            implode(', ', array_map(static fn (ReviewVerb $verb): string => $verb->value, $expected)),
+            implode(', ', array_map(static fn (ReviewVerb $verb): string => $verb->value, $actual)),
+        ));
+    }
+}

--- a/src/Reviews/DatabaseReviewStatusReader.php
+++ b/src/Reviews/DatabaseReviewStatusReader.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Reviews;
+
+use Fissible\Verdict\Contracts\ReviewStatusReader;
+use Fissible\Verdict\Reviews\DatabaseReviewRequestStore;
+use Fissible\Verdict\Reviews\ReviewRequest;
+use Fissible\Verdict\Reviews\ReviewScopeMatch;
+use Fissible\Verdict\Reviews\ReviewStatus;
+use Fissible\Verdict\Reviews\ReviewStatusView;
+
+/**
+ * The database store's paired observational reader.
+ *
+ * The queue neither queries nor re-filters it: this reader owns the documented typed containment
+ * and stable order, just as a host-provided ReviewStatusReader owns those rules for another store.
+ */
+final readonly class DatabaseReviewStatusReader implements ReviewStatusReader
+{
+    public function __construct(private DatabaseReviewRequestStore $store) {}
+
+    public function statusFor(string $requestId): ?ReviewStatusView
+    {
+        return ReviewStatusView::fromNullableRequest($this->store->find($requestId));
+    }
+
+    public function pendingWithin(array $scope): array
+    {
+        ReviewScopeMatch::assertScope($scope);
+        $requests = [];
+
+        foreach ($this->store->connection()->table($this->store->table())->where('status', ReviewStatus::Pending->value)->get() as $row) {
+            $request = $this->store->find($row->id);
+
+            if ($request !== null && ReviewScopeMatch::matches($request->approvalContext, $scope)) {
+                $requests[] = $request;
+            }
+        }
+
+        usort($requests, static fn (ReviewRequest $a, ReviewRequest $b): int => [$a->createdAt->format('Y-m-d H:i:s'), $a->id] <=> [$b->createdAt->format('Y-m-d H:i:s'), $b->id]);
+
+        return array_map(ReviewStatusView::fromRequest(...), $requests);
+    }
+}

--- a/src/Reviews/ReviewItem.php
+++ b/src/Reviews/ReviewItem.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Reviews;
+
+use DateTimeImmutable;
+
+/** Display-safe projection of one Verdict review-status view. */
+final readonly class ReviewItem
+{
+    public function __construct(
+        public string $requestId,
+        public string $capability,
+        public ReviewItemState $state,
+        public ?string $reason,
+        public ?string $summaryFingerprint,
+        public DateTimeImmutable $createdAt,
+        public DateTimeImmutable $expiresAt,
+        public ?string $resolvedBy,
+        public ?DateTimeImmutable $resolvedAt,
+    ) {}
+}

--- a/src/Reviews/ReviewItemState.php
+++ b/src/Reviews/ReviewItemState.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Reviews;
+
+enum ReviewItemState: string
+{
+    case Pending = 'pending';
+    case LapsedUndecided = 'lapsed_undecided';
+}

--- a/src/Reviews/ReviewQueue.php
+++ b/src/Reviews/ReviewQueue.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Reviews;
+
+use Fissible\Verdict\Contracts\ReviewStatusReader;
+use Fissible\Verdict\Reviews\ReviewStatusView;
+use Illuminate\Contracts\Config\Repository as Config;
+use Illuminate\Contracts\Container\Container;
+
+/** Read-only, never-widened queue of pending review requests. */
+final readonly class ReviewQueue
+{
+    public function __construct(private Container $app, private Config $config) {}
+
+    public function items(): ReviewQueueResult
+    {
+        if (! is_string($this->config->get('verdict.reviews.store'))) {
+            return new ReviewQueueResult(ReviewQueueState::Unconfigured, []);
+        }
+
+        $scope = $this->config->get('verdict-console.reviews.scope');
+
+        if (! is_array($scope) || $scope === []) {
+            return new ReviewQueueResult(ReviewQueueState::Unscoped, []);
+        }
+
+        /** @var non-empty-array<string, string|int> $scope */
+        $views = $this->app->make(ReviewStatusReader::class)->pendingWithin($scope);
+
+        return new ReviewQueueResult(ReviewQueueState::Ready, array_map(function (ReviewStatusView $view): ReviewItem {
+            $state = $view->expiresAt > now()
+                ? ReviewItemState::Pending
+                : ReviewItemState::LapsedUndecided;
+
+            return new ReviewItem(
+                requestId: $view->requestId,
+                capability: $view->capability,
+                state: $state,
+                reason: $view->reason,
+                summaryFingerprint: $view->summaryFingerprint,
+                createdAt: $view->createdAt,
+                expiresAt: $view->expiresAt,
+                resolvedBy: $view->resolvedBy,
+                resolvedAt: $view->resolvedAt,
+            );
+        }, $views));
+    }
+}

--- a/src/Reviews/ReviewQueueResult.php
+++ b/src/Reviews/ReviewQueueResult.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Reviews;
+
+/** @phpstan-type ReviewItems list<ReviewItem> */
+final readonly class ReviewQueueResult
+{
+    /** @param list<ReviewItem> $items */
+    public function __construct(
+        public ReviewQueueState $state,
+        public array $items,
+    ) {}
+}

--- a/src/Reviews/ReviewQueueState.php
+++ b/src/Reviews/ReviewQueueState.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Reviews;
+
+/** The honest availability state of the separate, asynchronous review lane. */
+enum ReviewQueueState: string
+{
+    case Unconfigured = 'unconfigured';
+    case Unscoped = 'unscoped';
+    case Ready = 'ready';
+}

--- a/src/Reviews/ReviewResolutionService.php
+++ b/src/Reviews/ReviewResolutionService.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Reviews;
+
+use Fissible\Verdict\Contracts\ReviewStatusReader;
+use Fissible\Verdict\Reviews\ReviewManager;
+use Fissible\Verdict\Reviews\ReviewTransition;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Config\Repository as Config;
+
+/** Records one authorized upstream review decision; it never starts, resumes, or mints a run. */
+final readonly class ReviewResolutionService
+{
+    private const string AUTHORIZATION_REFUSAL_MESSAGE = 'This reviewer may not resolve this review.';
+
+    public function __construct(
+        private ReviewManager $reviews,
+        private ReviewStatusReader $statuses,
+        private Gate $gate,
+        private Config $config,
+    ) {}
+
+    public function approve(string $requestId, ?Authenticatable $reviewer): ReviewTransition
+    {
+        return $this->resolve($requestId, $reviewer, true);
+    }
+
+    public function reject(string $requestId, ?Authenticatable $reviewer): ReviewTransition
+    {
+        return $this->resolve($requestId, $reviewer, false);
+    }
+
+    private function resolve(string $requestId, ?Authenticatable $reviewer, bool $approve): ReviewTransition
+    {
+        if ($reviewer === null || ! $this->gate->forUser($reviewer)->allows($this->ability(), $requestId)) {
+            throw new AuthorizationException(self::AUTHORIZATION_REFUSAL_MESSAGE);
+        }
+
+        $scope = $this->config->get('verdict-console.reviews.scope');
+        $view = $this->statuses->statusFor($requestId);
+
+        if (! is_array($scope) || $scope === [] || $view === null || ! $this->contains($view->approvalContext, $scope)) {
+            throw new AuthorizationException(self::AUTHORIZATION_REFUSAL_MESSAGE);
+        }
+
+        $actor = $reviewer->getAuthIdentifier();
+
+        if ($actor === null || (is_string($actor) && trim($actor) === '')) {
+            throw new AuthorizationException(self::AUTHORIZATION_REFUSAL_MESSAGE);
+        }
+
+        return $approve
+            ? $this->reviews->approve($requestId, (string) $actor)
+            : $this->reviews->reject($requestId, (string) $actor);
+    }
+
+    /**
+     * @param  ?array<string, string|int>  $context
+     * @param  array<string, mixed>  $scope
+     */
+    private function contains(?array $context, array $scope): bool
+    {
+        if ($context === null || $context === []) {
+            return false;
+        }
+
+        foreach ($scope as $key => $value) {
+            if ((! is_string($value) && ! is_int($value))
+                || ! array_key_exists($key, $context) || $context[$key] !== $value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function ability(): string
+    {
+        $ability = $this->config->get('verdict-console.reviews.gate');
+
+        return is_string($ability) && $ability !== '' ? $ability : 'review-verdict-action';
+    }
+}

--- a/src/Reviews/ReviewSurfaceContract.php
+++ b/src/Reviews/ReviewSurfaceContract.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Reviews;
+
+use Fissible\VerdictConsole\Exceptions\ReviewSurfaceContractViolation;
+
+/** The one assertion every review rendering surface uses for its offered controls. */
+final readonly class ReviewSurfaceContract
+{
+    public function __construct(private ReviewVerbs $verbs) {}
+
+    /** @param list<ReviewVerb> $rendered */
+    public function assertRendered(array $rendered, ReviewItem $item): void
+    {
+        $expected = $this->normalized($this->verbs->resolve($item));
+        $actual = $this->normalized($rendered);
+
+        if ($actual !== $expected) {
+            throw new ReviewSurfaceContractViolation($this->verbs->resolve($item), $rendered);
+        }
+    }
+
+    /**
+     * @param  list<ReviewVerb>  $verbs
+     * @return list<string>
+     */
+    private function normalized(array $verbs): array
+    {
+        $values = array_map(static fn (ReviewVerb $verb): string => $verb->value, $verbs);
+        sort($values);
+
+        return $values;
+    }
+}

--- a/src/Reviews/ReviewVerb.php
+++ b/src/Reviews/ReviewVerb.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Reviews;
+
+/** Review requests are record-only: there is deliberately no close or resume verb. */
+enum ReviewVerb: string
+{
+    case Approve = 'approve';
+    case Reject = 'reject';
+}

--- a/src/Reviews/ReviewVerbs.php
+++ b/src/Reviews/ReviewVerbs.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Reviews;
+
+/** Resolves the only controls a review surface may offer from its rendered item. */
+final class ReviewVerbs
+{
+    /** @return list<ReviewVerb> */
+    public function resolve(ReviewItem $item): array
+    {
+        return $item->state === ReviewItemState::Pending
+            ? [ReviewVerb::Approve, ReviewVerb::Reject]
+            : [];
+    }
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -6,9 +6,17 @@ namespace Fissible\VerdictConsole;
 
 use Fissible\Verdict\Approvals\Events\ApprovalReceiptTransitioned;
 use Fissible\Verdict\Capabilities\Events\CapabilityConfigurationUnrecorded;
+use Fissible\Verdict\Contracts\Clock;
+use Fissible\Verdict\Contracts\ReviewDecisionAuthorizer;
+use Fissible\Verdict\Contracts\ReviewRequestStore;
+use Fissible\Verdict\Contracts\ReviewStatusReader;
 use Fissible\Verdict\Evidence\Events\ChainWriteFailed;
 use Fissible\Verdict\Evidence\Events\ConsequentialActionUnrecorded;
 use Fissible\Verdict\Evidence\Events\EvidenceWriteFailed;
+use Fissible\Verdict\Reviews\DatabaseReviewRequestStore;
+use Fissible\Verdict\Reviews\ReviewManager;
+use Fissible\Verdict\Reviews\StoreBackedReviewStatusReader;
+use Fissible\Verdict\Support\SystemClock;
 use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
 use Fissible\VerdictConsole\Approvals\ApprovalChallengeReader;
 use Fissible\VerdictConsole\Approvals\GateApproverAuthority;
@@ -45,7 +53,11 @@ use Fissible\VerdictConsole\Listeners\RecordConversationInvocation;
 use Fissible\VerdictConsole\Notifications\UnconfiguredApprovalNotificationRecipients;
 use Fissible\VerdictConsole\Participants\UnconfiguredConversationParticipants;
 use Fissible\VerdictConsole\Presentation\DefaultApprovalPresenter;
+use Fissible\VerdictConsole\Reviews\DatabaseReviewStatusReader;
+use Illuminate\Contracts\Config\Repository as Config;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\DatabaseManager;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Ai\Events\AgentPrompted;
@@ -102,6 +114,60 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         $this->app->singleton(ConfigurationInspection::class, VerdictConfigurationInspection::class);
 
         $this->app->singleton(IncidentStore::class);
+
+        // Verdict binds its configured store at registration time, but a runtime-configured test
+        // harness has no such binding. These guarded fallbacks therefore serve that case, while
+        // Verdict's or a host's prior store, reader, and manager bindings remain authoritative.
+        if (! $this->app->bound(ReviewRequestStore::class)) {
+            $this->app->singleton(ReviewRequestStore::class, function (Container $app): ReviewRequestStore {
+                $config = $app->make(Config::class);
+                $store = $config->get('verdict.reviews.store');
+
+                if (! is_string($store)) {
+                    throw new \LogicException('The Verdict review request store configuration must contain a class name.');
+                }
+
+                if ($store === DatabaseReviewRequestStore::class) {
+                    $connection = $config->get('verdict.reviews.connection');
+                    $table = $config->get('verdict.reviews.table');
+                    $database = $app->make(DatabaseManager::class)->connection(is_string($connection) ? $connection : null);
+
+                    return is_string($table)
+                        ? new DatabaseReviewRequestStore($database, $table)
+                        : new DatabaseReviewRequestStore($database);
+                }
+
+                $instance = $app->make($store);
+
+                if (! $instance instanceof ReviewRequestStore) {
+                    throw new \LogicException("The [{$store}] review request store must implement ".ReviewRequestStore::class.'.');
+                }
+
+                return $instance;
+            });
+        }
+
+        if (! $this->app->bound(ReviewStatusReader::class)) {
+            $this->app->singleton(ReviewStatusReader::class, function (Container $app): ReviewStatusReader {
+                $store = $app->make(ReviewRequestStore::class);
+
+                return $store instanceof DatabaseReviewRequestStore
+                    ? new DatabaseReviewStatusReader($store)
+                    : new StoreBackedReviewStatusReader($store);
+            });
+        }
+
+        if (! $this->app->bound(ReviewManager::class)) {
+            $this->app->scoped(ReviewManager::class, fn (Container $app): ReviewManager => new ReviewManager(
+                reviews: $app->make(ReviewRequestStore::class),
+                clock: $app->bound(Clock::class) ? $app->make(Clock::class) : new SystemClock,
+                authorizer: static function () use ($app): ?ReviewDecisionAuthorizer {
+                    $authorizer = $app->make(Config::class)->get('verdict.reviews.authorizer');
+
+                    return is_string($authorizer) ? $app->make($authorizer) : null;
+                },
+            ));
+        }
     }
 
     public function boot(Dispatcher $events): void

--- a/src/View/Components/Reviews.php
+++ b/src/View/Components/Reviews.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\View\Components;
+
+use Fissible\VerdictConsole\Reviews\ReviewQueue;
+use Fissible\VerdictConsole\Reviews\ReviewVerbs;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+/** Server-rendered, record-only lane for scoped Verdict reviews. */
+final class Reviews extends Component
+{
+    public function __construct(private ReviewQueue $queue, private ReviewVerbs $verbs) {}
+
+    public function render(): View
+    {
+        return view('verdict-console::components.reviews', [
+            'queue' => $this->queue->items(),
+            'verbs' => $this->verbs,
+        ]);
+    }
+}

--- a/tests/Feature/ReviewLaneTest.php
+++ b/tests/Feature/ReviewLaneTest.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Contracts\ReviewStatusReader;
+use Fissible\Verdict\Reviews\DatabaseReviewRequestStore;
+use Fissible\Verdict\Reviews\ReviewStatus;
+use Fissible\Verdict\Reviews\ReviewStatusView;
+use Fissible\Verdict\Testing\AllowAllReviewAuthorizer;
+use Fissible\VerdictConsole\Exceptions\ReviewSurfaceContractViolation;
+use Fissible\VerdictConsole\Reviews\ReviewItem;
+use Fissible\VerdictConsole\Reviews\ReviewItemState;
+use Fissible\VerdictConsole\Reviews\ReviewQueue;
+use Fissible\VerdictConsole\Reviews\ReviewQueueState;
+use Fissible\VerdictConsole\Reviews\ReviewSurfaceContract;
+use Fissible\VerdictConsole\Reviews\ReviewVerb;
+use Fissible\VerdictConsole\Reviews\ReviewVerbs;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * VC-48, the read half: the asynchronous review lane rendered from verdict#297's shipped substrate
+ * through the #298 reader. Nothing pauses and nothing resumes — the queue is a scoped read of
+ * durable review requests, honest about the three ways it can have nothing to show: the lane is
+ * not configured, the console has no review scope, or the scope simply holds no pending request.
+ *
+ * Recorded decline: ADR 0026's four-state provenance rendering cannot be built on this lane yet —
+ * the shipped ReviewStatusView exposes reason and summary fingerprint but no provenance at all.
+ * That is an upstream read-contract question, not something to query around the reader for.
+ */
+function reviewRow(
+    string $requestId,
+    string $capability = 'orders.refund',
+    string $status = 'pending',
+    string $expiresAt = '+1 hour',
+    ?array $context = ['team' => 'payments'],
+    ?string $reason = 'Refunds over the limit need review.',
+    ?string $resolvedBy = null,
+): string {
+    $id = hash('sha256', $requestId);
+
+    DB::table('verdict_review_requests')->insert([
+        'id' => $id,
+        'capability' => $capability,
+        'binding_fingerprint' => hash('sha256', 'binding-'.$requestId),
+        'status' => $status,
+        'reason' => $reason,
+        'expires_at' => now()->modify($expiresAt),
+        'resolved_by' => $resolvedBy,
+        'resolved_at' => $resolvedBy === null ? null : now()->subMinutes(2),
+        'approval_context' => $context === null ? null : json_encode($context, JSON_THROW_ON_ERROR),
+        'approver_summary' => json_encode([
+            'content' => 'Refund #881 for customer X.',
+            'fingerprint' => hash('sha256', 'Refund #881 for customer X.'),
+        ], JSON_THROW_ON_ERROR),
+        'created_at' => now()->subMinutes(10),
+        'updated_at' => now()->subMinutes(10),
+    ]);
+
+    return $id;
+}
+
+beforeEach(function (): void {
+    config()->set('verdict.reviews.store', DatabaseReviewRequestStore::class);
+    config()->set('verdict.reviews.authorizer', AllowAllReviewAuthorizer::class);
+    config()->set('verdict-console.reviews.scope', ['team' => 'payments']);
+
+    (require dirname(__DIR__, 2).'/vendor/fissible/verdict/database/migrations/create_verdict_review_requests_table.php.stub')->up();
+});
+
+// --- queue states ---------------------------------------------------------------------------------
+
+it('reports the lane unconfigured when verdict has no review store, without touching any table', function (): void {
+    config()->set('verdict.reviews.store', null);
+
+    $result = app(ReviewQueue::class)->items();
+
+    expect($result->state)->toBe(ReviewQueueState::Unconfigured)
+        ->and($result->items)->toBe([]);
+});
+
+it('reports the queue unscoped when the console has no review scope, refusing to enumerate', function (): void {
+    reviewRow('request-visible');
+    config()->set('verdict-console.reviews.scope', []);
+
+    // The reader refuses unscoped enumeration by design (ADR 0035 §4); the console must surface
+    // that refusal as its own honest state, never widen it into enumerate-everything.
+    $result = app(ReviewQueue::class)->items();
+
+    expect($result->state)->toBe(ReviewQueueState::Unscoped)
+        ->and($result->items)->toBe([]);
+});
+
+it('lists pending requests inside the scope, oldest first, and nothing outside it', function (): void {
+    $inside = reviewRow('request-inside');
+    $insideNewer = reviewRow('request-inside-newer');
+    DB::table('verdict_review_requests')->where('id', $insideNewer)->update(['created_at' => now()->subMinutes(5)]);
+    $richerContext = reviewRow('request-richer-context', context: ['team' => 'payments', 'region' => 'eu']);
+    DB::table('verdict_review_requests')->where('id', $richerContext)->update(['created_at' => now()->subMinutes(2)]);
+    reviewRow('request-other-team', context: ['team' => 'fulfilment']);
+    reviewRow('request-no-context', context: null);
+    reviewRow('request-decided', status: 'approved', resolvedBy: 'reviewer-2');
+
+    // Containment is scope-subset-of-context: a request carrying more context than the scope asks
+    // about still belongs to it (ADR 0035 §4's typed containment, proven through the console).
+    $result = app(ReviewQueue::class)->items();
+
+    expect($result->state)->toBe(ReviewQueueState::Ready)
+        ->and(array_map(fn (ReviewItem $item): string => $item->requestId, $result->items))->toBe([$inside, $insideNewer, $richerContext]);
+});
+
+it('keeps the scope typed end to end: an integer never matches its string twin', function (): void {
+    config()->set('verdict-console.reviews.scope', ['tenant' => 1]);
+    $typed = reviewRow('request-typed-int', context: ['tenant' => 1]);
+    reviewRow('request-string-twin', context: ['tenant' => '1']);
+
+    $result = app(ReviewQueue::class)->items();
+
+    expect(array_map(fn (ReviewItem $item): string => $item->requestId, $result->items))->toBe([$typed]);
+});
+
+it('breaks a created-at tie by request id, so two same-second requests cannot swap between polls', function (): void {
+    $tieA = reviewRow('request-tie-a');
+    $tieB = reviewRow('request-tie-b');
+    $tied = now()->subMinutes(3)->startOfSecond();
+    DB::table('verdict_review_requests')->whereIn('id', [$tieA, $tieB])->update(['created_at' => $tied]);
+
+    [$first, $second] = strcmp($tieA, $tieB) < 0 ? [$tieA, $tieB] : [$tieB, $tieA];
+
+    expect(array_map(fn (ReviewItem $item): string => $item->requestId, app(ReviewQueue::class)->items()->items))
+        ->toBe([$first, $second]);
+});
+
+/**
+ * The escape a real deterministic store cannot expose: a queue could read the table itself and,
+ * against this database, agree with the reader on every test above. Here the bound reader answers
+ * with an order and a member the table contradicts — what renders is what the reader said, asked
+ * with exactly the configured scope, or this test fails.
+ */
+it('renders the readers answer in the readers order, asked with the configured scope', function (): void {
+    reviewRow('request-in-table-only');
+
+    $viewFor = function (string $requestId, string $createdAt, ?array $context = ['team' => 'payments']): ReviewStatusView {
+        return new ReviewStatusView(
+            requestId: hash('sha256', $requestId),
+            capability: 'orders.refund',
+            status: ReviewStatus::Pending,
+            reason: 'Scripted.',
+            summaryFingerprint: null,
+            createdAt: new DateTimeImmutable($createdAt),
+            expiresAt: new DateTimeImmutable('+1 hour'),
+            resolvedBy: null,
+            resolvedAt: null,
+            approvalContext: $context,
+        );
+    };
+
+    // The contextless view could never come from the real reader — so a queue that re-filters
+    // the answer by context locally drops it and fails. pendingWithin() owns filtering.
+    $reader = new class($viewFor('scripted-newer', '-1 minute'), $viewFor('scripted-older', '-10 minutes'), $viewFor('scripted-contextless', '-20 minutes', null)) implements ReviewStatusReader
+    {
+        /** @var list<array<string, string|int>> */
+        public array $asked = [];
+
+        /** @var list<ReviewStatusView> */
+        private array $views;
+
+        public function __construct(ReviewStatusView ...$views)
+        {
+            $this->views = array_values($views);
+        }
+
+        public function statusFor(string $requestId): ?ReviewStatusView
+        {
+            return null;
+        }
+
+        public function pendingWithin(array $scope): array
+        {
+            $this->asked[] = $scope;
+
+            return $this->views;
+        }
+    };
+    app()->instance(ReviewStatusReader::class, $reader);
+
+    $result = app(ReviewQueue::class)->items();
+
+    expect(array_map(fn (ReviewItem $item): string => $item->requestId, $result->items))
+        ->toBe([hash('sha256', 'scripted-newer'), hash('sha256', 'scripted-older'), hash('sha256', 'scripted-contextless')])
+        ->and(array_map(fn (ReviewItem $item): string => $item->requestId, $result->items))->not->toContain(hash('sha256', 'request-in-table-only'))
+        ->and($reader->asked)->toBe([['team' => 'payments']]);
+});
+
+// --- item read-model ------------------------------------------------------------------------------
+
+it('builds display-safe items carrying the request vocabulary and computed lapse', function (): void {
+    $pending = reviewRow('request-pending');
+    $lapsed = reviewRow('request-lapsed', expiresAt: '-1 minute');
+
+    $items = app(ReviewQueue::class)->items()->items;
+    $byId = array_combine(array_map(fn (ReviewItem $item): string => $item->requestId, $items), $items);
+
+    // Expiry is the console's clock comparison over the reader's expiresAt — never a stored
+    // status (ADR 0031 §5 / 0035 §4): the lapsed request still enumerates, as its own state.
+    expect($byId[$pending]->state)->toBe(ReviewItemState::Pending)
+        ->and($byId[$pending]->capability)->toBe('orders.refund')
+        ->and($byId[$pending]->reason)->toBe('Refunds over the limit need review.')
+        ->and($byId[$pending]->summaryFingerprint)->toBe(hash('sha256', 'Refund #881 for customer X.'))
+        ->and($byId[$lapsed]->state)->toBe(ReviewItemState::LapsedUndecided);
+});
+
+// --- verbs ----------------------------------------------------------------------------------------
+
+it('offers approve and reject for a live pending request and nothing for any other state', function (): void {
+    $verbs = app(ReviewVerbs::class);
+
+    $pendingId = reviewRow('verbs-pending');
+    $lapsedId = reviewRow('verbs-lapsed', expiresAt: '-1 minute');
+    $decidedId = reviewRow('verbs-decided', status: 'approved', resolvedBy: 'reviewer-2');
+
+    $items = [];
+
+    foreach (app(ReviewQueue::class)->items()->items as $item) {
+        $items[$item->requestId] = $item;
+    }
+
+    // Only the live pending request is in the queue; lapsed enumerates too, decided does not.
+    expect($verbs->resolve($items[$pendingId]))->toBe([ReviewVerb::Approve, ReviewVerb::Reject])
+        ->and($verbs->resolve($items[$lapsedId]))->toBe([]);
+
+    // There is no close verb anywhere on this lane: nothing is waiting, so there is nothing to
+    // resume or dismiss — a workflow-exit control here would imply a run that does not exist.
+    expect(ReviewVerb::cases())->toHaveCount(2);
+});
+
+// --- surface contract -----------------------------------------------------------------------------
+
+it('judges every rendered verb set through one surface contract', function (): void {
+    $pendingId = reviewRow('contract-pending');
+
+    $items = app(ReviewQueue::class)->items()->items;
+    $item = $items[array_key_first($items)];
+
+    $contract = app(ReviewSurfaceContract::class);
+
+    $contract->assertRendered([ReviewVerb::Approve, ReviewVerb::Reject], $item);
+
+    // A stale approve control on a lapsed item is exactly what the contract exists to refuse.
+    $lapsed = new ReviewItem(
+        requestId: $item->requestId,
+        capability: $item->capability,
+        state: ReviewItemState::LapsedUndecided,
+        reason: $item->reason,
+        summaryFingerprint: $item->summaryFingerprint,
+        createdAt: $item->createdAt,
+        expiresAt: $item->expiresAt,
+        resolvedBy: null,
+        resolvedAt: null,
+    );
+
+    expect(fn () => $contract->assertRendered([ReviewVerb::Approve], $lapsed))
+        ->toThrow(ReviewSurfaceContractViolation::class);
+});

--- a/tests/Feature/ReviewPageComponentTest.php
+++ b/tests/Feature/ReviewPageComponentTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Reviews\DatabaseReviewRequestStore;
+use Fissible\Verdict\Testing\AllowAllReviewAuthorizer;
+use Fissible\VerdictConsole\Reviews\ReviewQueue;
+use Fissible\VerdictConsole\Reviews\ReviewSurfaceContract;
+use Fissible\VerdictConsole\Reviews\ReviewVerb;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * VC-48, the rendered half: the review queue Blade component is a rendering of the lane's read
+ * model and verbs — honest about every way it can be empty, offering approve and reject only
+ * where the surface contract admits them, and never a control that implies a run is waiting.
+ */
+function pageReviewRow(
+    string $requestId,
+    string $status = 'pending',
+    string $expiresAt = '+1 hour',
+    ?string $resolvedBy = null,
+): string {
+    $id = hash('sha256', $requestId);
+    // Issuance-faithful: a decided row always records who and when.
+    $resolvedBy = $status === 'pending' ? $resolvedBy : ($resolvedBy ?? 'reviewer-2');
+
+    DB::table('verdict_review_requests')->insert([
+        'id' => $id,
+        'capability' => 'orders.refund',
+        'binding_fingerprint' => hash('sha256', 'binding-'.$requestId),
+        'status' => $status,
+        'reason' => 'Refunds over the limit need review.',
+        'expires_at' => now()->modify($expiresAt),
+        'resolved_by' => $resolvedBy,
+        'resolved_at' => $resolvedBy === null ? null : now()->subMinutes(2),
+        'approval_context' => json_encode(['team' => 'payments'], JSON_THROW_ON_ERROR),
+        'approver_summary' => json_encode([
+            'content' => 'Refund #881 for customer X.',
+            'fingerprint' => hash('sha256', 'Refund #881 for customer X.'),
+        ], JSON_THROW_ON_ERROR),
+        'created_at' => now()->subMinutes(10),
+        'updated_at' => now()->subMinutes(10),
+    ]);
+
+    return $id;
+}
+
+function renderReviews(): string
+{
+    return (string) test()->blade('<x-verdict-console::reviews />');
+}
+
+beforeEach(function (): void {
+    config()->set('verdict.reviews.store', DatabaseReviewRequestStore::class);
+    config()->set('verdict.reviews.authorizer', AllowAllReviewAuthorizer::class);
+    config()->set('verdict-console.reviews.scope', ['team' => 'payments']);
+
+    (require dirname(__DIR__, 2).'/vendor/fissible/verdict/database/migrations/create_verdict_review_requests_table.php.stub')->up();
+});
+
+it('says the review lane is not configured instead of rendering an empty queue', function (): void {
+    config()->set('verdict.reviews.store', null);
+
+    $html = renderReviews();
+
+    expect($html)->toContain('The review lane is not configured.')
+        ->not->toContain('No reviews are waiting.');
+});
+
+it('says the console has no review scope, and renders no request from outside one', function (): void {
+    pageReviewRow('page-hidden');
+    config()->set('verdict-console.reviews.scope', []);
+
+    $html = renderReviews();
+
+    expect($html)->toContain('No review scope is configured.')
+        ->not->toContain(hash('sha256', 'page-hidden'));
+});
+
+it('says no reviews are waiting when the scope is simply empty', function (): void {
+    expect(renderReviews())->toContain('No reviews are waiting.');
+});
+
+it('renders a pending request with its vocabulary and both lane verbs', function (): void {
+    $id = pageReviewRow('page-pending');
+
+    $html = renderReviews();
+
+    expect($html)->toContain($id)
+        ->toContain('orders.refund')
+        ->toContain('Refunds over the limit need review.')
+        ->toContain('data-review-verb="approve"')
+        ->toContain('data-review-verb="reject"');
+});
+
+it('renders a lapsed request as lapsed, undecided — with no verb control at all', function (): void {
+    $id = pageReviewRow('page-lapsed', expiresAt: '-1 minute');
+
+    $html = renderReviews();
+
+    // Lapse is computed from the reader's expiresAt, never written; the row stays visible as its
+    // own honest state, and a stale approve control here is the surface contract's one refusal.
+    expect($html)->toContain($id)
+        ->toContain('lapsed, undecided')
+        ->not->toContain('data-review-verb=');
+});
+
+/**
+ * The queue idiom's judgment, per row: every rendered verb set — extracted from the markup, keyed
+ * by data-review-request — must answer to the one surface contract, with a pending and a lapsed
+ * row rendered together so a component that resolves verbs once for all rows fails.
+ *
+ * The extraction below is itself a pinned markup contract: each item renders as one flat row
+ * element opening with data-review-request="<id>", and every verb control for that item appears
+ * after its marker and before the next marker or the section's close. Nesting one row's controls
+ * inside another's region would mis-associate them here — by design, not by accident.
+ */
+it('judges every rows rendered verb set through the surface contract', function (): void {
+    pageReviewRow('page-contract-pending');
+    pageReviewRow('page-contract-lapsed', expiresAt: '-1 minute');
+
+    $html = renderReviews();
+
+    $items = [];
+
+    foreach (app(ReviewQueue::class)->items()->items as $item) {
+        $items[$item->requestId] = $item;
+    }
+
+    preg_match_all('/data-review-request="([^"]+)"(.*?)(?=data-review-request="|<\/section>)/s', $html, $rows, PREG_SET_ORDER);
+
+    expect($rows)->toHaveCount(2);
+
+    $contract = app(ReviewSurfaceContract::class);
+
+    foreach ($rows as $row) {
+        preg_match_all('/data-review-verb="([^"]+)"/', $row[2], $verbs);
+        $rendered = array_map(fn (string $verb): ReviewVerb => ReviewVerb::from($verb), $verbs[1]);
+
+        $contract->assertRendered($rendered, $items[$row[1]]);
+    }
+});
+
+it('renders the approver summary fingerprint, display-safe, on a pending row', function (): void {
+    pageReviewRow('page-summary');
+
+    expect(renderReviews())->toContain(hash('sha256', 'Refund #881 for customer X.'));
+});
+
+it('never renders the raw binding fingerprint anywhere', function (): void {
+    pageReviewRow('page-safe');
+
+    expect(renderReviews())->not->toContain(hash('sha256', 'binding-page-safe'));
+});

--- a/tests/Feature/ReviewResolutionServiceTest.php
+++ b/tests/Feature/ReviewResolutionServiceTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\Verdict\Contracts\ReviewDecisionAuthorizer;
+use Fissible\Verdict\Reviews\DatabaseReviewRequestStore;
+use Fissible\Verdict\Reviews\ReviewDecisionKind;
+use Fissible\Verdict\Reviews\ReviewOutcome;
+use Fissible\Verdict\Reviews\ReviewRequest;
+use Fissible\Verdict\Testing\AllowAllReviewAuthorizer;
+use Fissible\VerdictConsole\Contracts\ResumableAgents;
+use Fissible\VerdictConsole\Reviews\ReviewResolutionService;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\GenericUser;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * VC-48, the decision half: approve and reject drive verdict#297's reviewed transition with the
+ * actor key — and nothing else. No receipt is minted, no agent is resumed, no execution happens;
+ * what the host does with a recorded review is application policy (ADR 0001 §3). Authority is the
+ * lane's own Gate ability, fail-closed, and never the confirmation lane's.
+ */
+function resolutionRow(
+    string $requestId,
+    string $status = 'pending',
+    string $expiresAt = '+1 hour',
+    ?array $context = ['team' => 'payments'],
+): string {
+    $id = hash('sha256', $requestId);
+
+    DB::table('verdict_review_requests')->insert([
+        'id' => $id,
+        'capability' => 'orders.refund',
+        'binding_fingerprint' => hash('sha256', 'binding-'.$requestId),
+        'status' => $status,
+        'reason' => 'Refunds over the limit need review.',
+        'expires_at' => now()->modify($expiresAt),
+        // Issuance-faithful: a real transition always records who and when.
+        'resolved_by' => $status === 'pending' ? null : 'reviewer-2',
+        'resolved_at' => $status === 'pending' ? null : now()->subMinutes(2),
+        'approval_context' => $context === null ? null : json_encode($context, JSON_THROW_ON_ERROR),
+        'approver_summary' => json_encode([
+            'content' => 'Refund #881 for customer X.',
+            'fingerprint' => hash('sha256', 'Refund #881 for customer X.'),
+        ], JSON_THROW_ON_ERROR),
+        'created_at' => now()->subMinutes(10),
+        'updated_at' => now()->subMinutes(10),
+    ]);
+
+    return $id;
+}
+
+function reviewer(): GenericUser
+{
+    return new GenericUser(['id' => 'reviewer-1']);
+}
+
+beforeEach(function (): void {
+    config()->set('verdict.reviews.store', DatabaseReviewRequestStore::class);
+    config()->set('verdict.reviews.authorizer', AllowAllReviewAuthorizer::class);
+    Gate::define('review-verdict-action', fn (): bool => true);
+    config()->set('verdict-console.reviews.scope', ['team' => 'payments']);
+
+    (require dirname(__DIR__, 2).'/vendor/fissible/verdict/database/migrations/create_verdict_review_requests_table.php.stub')->up();
+    (require dirname(__DIR__, 2).'/vendor/fissible/verdict/database/migrations/create_verdict_approval_receipts_table.php.stub')->up();
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists('verdict_approval_receipts');
+});
+
+it('approves a pending review: the reviewed transition, the actor key, and nothing else', function (): void {
+    $id = resolutionRow('resolve-approve');
+
+    $outcome = app(ReviewResolutionService::class)->approve($id, reviewer());
+
+    $row = DB::table('verdict_review_requests')->where('id', $id)->first();
+
+    expect($outcome->succeeded())->toBeTrue()
+        ->and($row->status)->toBe('approved')
+        ->and($row->resolved_by)->toBe('reviewer-1')
+        ->and($row->resolved_at)->not->toBeNull()
+        // Record-only, asserted: approving a review must not mint authority for any execution.
+        ->and(DB::table('verdict_approval_receipts')->count())->toBe(0);
+});
+
+it('rejects a pending review with the same shape and the opposite outcome', function (): void {
+    $id = resolutionRow('resolve-reject');
+
+    $outcome = app(ReviewResolutionService::class)->reject($id, reviewer());
+
+    expect($outcome->succeeded())->toBeTrue()
+        ->and(DB::table('verdict_review_requests')->where('id', $id)->value('status'))->toBe('rejected');
+});
+
+it('resumes no agent and touches no conversation, ever', function (): void {
+    $recorded = new class
+    {
+        public array $calls = [];
+    };
+    app(ResumableAgents::class)->register(
+        'review@v1',
+        function () use ($recorded): never {
+            $recorded->calls[] = 'resolved';
+            throw new RuntimeException('The review lane must never reach the agent registry.');
+        },
+        fn (object $agent): bool => false,
+    );
+
+    $id = resolutionRow('resolve-no-resume');
+    app(ReviewResolutionService::class)->approve($id, reviewer());
+
+    expect($recorded->calls)->toBe([]);
+});
+
+it('refuses an anonymous reviewer before anything is looked up or transitioned', function (): void {
+    $id = resolutionRow('resolve-anonymous');
+
+    expect(fn () => app(ReviewResolutionService::class)->approve($id, null))
+        ->toThrow(AuthorizationException::class, 'This reviewer may not resolve this review.');
+
+    expect(DB::table('verdict_review_requests')->where('id', $id)->value('status'))->toBe('pending');
+});
+
+it('fails closed when the configured ability is genuinely undefined, and refuses a denied reviewer', function (): void {
+    $undefined = resolutionRow('resolve-undefined-gate');
+
+    // Genuinely absent: the configured ability is one nothing ever registered. Laravel Gates deny
+    // unknown abilities, and the lane inherits that — never defaulting open because a host forgot
+    // to wire authority.
+    config()->set('verdict-console.reviews.gate', 'never-defined-review-ability');
+
+    expect(fn () => app(ReviewResolutionService::class)->approve($undefined, reviewer()))
+        ->toThrow(AuthorizationException::class, 'This reviewer may not resolve this review.');
+
+    expect(DB::table('verdict_review_requests')->where('id', $undefined)->value('status'))->toBe('pending');
+
+    // And a defined-but-denying ability refuses identically, leaving the row identically alone.
+    config()->set('verdict-console.reviews.gate', 'review-verdict-action');
+    Gate::define('review-verdict-action', fn (): bool => false);
+
+    $denied = resolutionRow('resolve-denied');
+
+    expect(fn () => app(ReviewResolutionService::class)->reject($denied, reviewer()))
+        ->toThrow(AuthorizationException::class, 'This reviewer may not resolve this review.');
+
+    expect(DB::table('verdict_review_requests')->where('id', $denied)->value('status'))->toBe('pending');
+});
+
+it('never accepts the confirmation lanes authority: an approver is not a reviewer', function (): void {
+    $id = resolutionRow('resolve-wrong-lane');
+
+    Gate::define('approve-verdict-action', fn (): bool => true);
+    Gate::define('review-verdict-action', fn (): bool => false);
+
+    expect(fn () => app(ReviewResolutionService::class)->approve($id, reviewer()))
+        ->toThrow(AuthorizationException::class, 'This reviewer may not resolve this review.');
+});
+
+it('honours a configurable review ability name', function (): void {
+    config()->set('verdict-console.reviews.gate', 'tenant-review-ability');
+    Gate::define('tenant-review-ability', fn (): bool => true);
+
+    $id = resolutionRow('resolve-configured-gate');
+
+    expect(app(ReviewResolutionService::class)->approve($id, reviewer())->succeeded())->toBeTrue();
+});
+
+it('reports a lapsed or already-decided request as verdicts refusal outcome, transitioning nothing', function (): void {
+    $lapsed = resolutionRow('resolve-lapsed', expiresAt: '-1 minute');
+    $decided = resolutionRow('resolve-decided', status: 'approved');
+
+    $lapsedOutcome = app(ReviewResolutionService::class)->approve($lapsed, reviewer());
+    $decidedOutcome = app(ReviewResolutionService::class)->reject($decided, reviewer());
+
+    // The manager's own vocabulary surfaces unaltered: an operator reads expired or
+    // invalid_state, never a success and never a masked authorization failure.
+    expect($lapsedOutcome->succeeded())->toBeFalse()
+        ->and($lapsedOutcome->outcome)->toBe(ReviewOutcome::Expired)
+        ->and($decidedOutcome->succeeded())->toBeFalse()
+        ->and($decidedOutcome->outcome)->toBe(ReviewOutcome::InvalidState)
+        ->and(DB::table('verdict_review_requests')->where('id', $lapsed)->value('status'))->toBe('pending')
+        // The refused reject must leave the original decision untouched — including who made it.
+        ->and(DB::table('verdict_review_requests')->where('id', $decided)->value('resolved_by'))->toBe('reviewer-2');
+});
+
+it('surfaces verdicts own authorizer denial: the gate is not the only refusal in the chain', function (): void {
+    config()->set('verdict.reviews.authorizer', DenyAllReviewDecisionAuthorizer::class);
+
+    $id = resolutionRow('resolve-upstream-denied');
+
+    // A service driving the store's transition directly would approve here: only the manager
+    // consults the review authorizer, and it refuses before the store is ever reached.
+    $outcome = app(ReviewResolutionService::class)->approve($id, reviewer());
+
+    expect($outcome->succeeded())->toBeFalse()
+        ->and($outcome->outcome)->toBe(ReviewOutcome::Unauthorized)
+        ->and(DB::table('verdict_review_requests')->where('id', $id)->value('status'))->toBe('pending')
+        ->and(DB::table('verdict_review_requests')->where('id', $id)->value('resolved_by'))->toBeNull();
+});
+
+it('refuses to resolve a request outside the consoles review scope, without disclosing it exists', function (): void {
+    $foreign = resolutionRow('resolve-foreign-scope', context: ['team' => 'fulfilment']);
+    $contextless = resolutionRow('resolve-no-context', context: null);
+
+    foreach ([$foreign, $contextless] as $id) {
+        expect(fn () => app(ReviewResolutionService::class)->approve($id, reviewer()))
+            ->toThrow(AuthorizationException::class, 'This reviewer may not resolve this review.');
+
+        expect(DB::table('verdict_review_requests')->where('id', $id)->value('status'))->toBe('pending');
+    }
+});
+
+final class DenyAllReviewDecisionAuthorizer implements ReviewDecisionAuthorizer
+{
+    public function authorize(ReviewRequest $request, ReviewDecisionKind $kind, string $decidedBy): bool
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
Closes #48.

Verdict 0.15 shipped #297's review substrate and the #298 reader, so the lane the issue gated on now exists — with three shipped-reality divergences from the issue text, each recorded in a dated ADR 0001 §3 amendment: reviews carry an **upstream-computed TTL** (so `lapsed, undecided` is a rendered clock comparison and the proposed console-owned SLA obligation is superseded — a duplicate clock is the one thing worse than none), `approve/reject` take **no reviewer reason**, and enumeration is **scoped or refused** (`pendingWithin` requires a non-empty scope).

What ships: `ReviewQueue` with three honest empty states (lane unconfigured / no console scope / nothing waiting), the `ReviewItem` read model, `ReviewVerbs` + `ReviewSurfaceContract` (exactly two verbs — no Close: nothing pauses on this lane, so there is no run to release), `ReviewResolutionService` (own fail-closed Gate ability `verdict-console.reviews.gate`, anonymous refused pre-Gate, out-of-scope refused without disclosure, and only Verdict's `ReviewManager` ever drives the transition — a configured denying `ReviewDecisionAuthorizer` surfaces `Unauthorized` with the row untouched), and the Blade queue component under a pinned flat-row markup contract. Record-only is asserted, not implied: zero receipts minted, a poisoned agent registry proving no resume.

**Two upstream gaps recorded rather than worked around:** `ReviewStatusView` exposes no provenance, so ADR 0026's four-state provenance rendering cannot be built through the reader (the surface names no provenance state); and verdict ships no paired enumerating reader for its own database store — its store-backed reader refuses `pendingWithin` by design — so that reader lives here for now. Both belong on verdict's tracker.

The console's review wiring (store, reader, manager) registers only when nothing else has bound it: verdict's or a host's wiring stays authoritative wherever present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)