### PR TITLE
waiting_since from the issuance instant, and the approver summary rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Issued-at approval rendering (#47).** `waiting_since` is now populated from the receipt
+  issuance instant in the live status view, including lapsed and decided rows. The #306 approver
+  summary is rendered under its typed release states: released content is escaped, while withheld
+  states expose no content.
+
 ## [0.9.0] - 2026-09-01
 
 - **Reviewer queue (#48).** The console now renders the scoped, poll-consistent review queue over

--- a/docs/adr/0001-approval-surface-contract.md
+++ b/docs/adr/0001-approval-surface-contract.md
@@ -366,6 +366,10 @@ impossible to miss and impossible to mistake for its absence:
   and a lapsed one is never shown as actionable. "Waiting for *N* minutes" is rendered from
   `ApprovalChallenge::issuedAt` once #300 ships and is **nullable until then** — the console's own
   row timestamp is ingestion time, not issuance time, and must not be relabelled as the latter.
+
+**2026-09-01 amendment — shipped.** `waiting_since` is populated from the status view's issuance
+instant (`createdAt`), the same value #300 threads onto the challenge. It is present for pending,
+lapsed, and decided rows; only an unavailable view leaves it null.
 - **Capability name and argument fingerprint** anchor the item to the one call it is about. The
   fingerprint is correlation, not disclosure (ADR 0008): the console does not attempt to reverse it
   and does not claim it identifies the target.

--- a/resources/views/components/approvals.blade.php
+++ b/resources/views/components/approvals.blade.php
@@ -36,6 +36,16 @@
             @elseif ($state === 'not_console_actionable')
                 <p>not actionable from this console: <code>{{ $item->unresumableReason }}</code></p>
             @endif
+            @if ($item->waitingSince !== null)
+                <time datetime="{{ $item->waitingSince->format(DATE_ATOM) }}">{{ $item->waitingSince->format(DATE_ATOM) }}</time>
+            @endif
+            @if ($item->approverSummary !== null)
+                @if ($item->approverSummary['state'] === 'released')
+                    <p>{{ $item->approverSummary['content'] }}</p>
+                @elseif ($item->approverSummary['state'] === 'release_denied')
+                    <p data-approver-summary="release_denied">release_denied</p>
+                @endif
+            @endif
             @if ($item->provenance !== null)
                 <div data-provenance="{{ $item->provenance['state'] }}">
                 @if ($item->provenance['state'] === 'declared')

--- a/src/Approvals/ApprovalItem.php
+++ b/src/Approvals/ApprovalItem.php
@@ -8,10 +8,12 @@ use DateTimeImmutable;
 use Fissible\Verdict\Approvals\ApprovalChallenge;
 use Fissible\Verdict\Approvals\ApprovalReceiptStatus;
 use Fissible\Verdict\Approvals\ApprovalStatusView;
+use Fissible\Verdict\Approvals\ApproverSummaryRelease;
 use Fissible\Verdict\Approvals\ProposalProvenance;
 use Fissible\Verdict\Approvals\ProvenanceDisclosure;
 use Fissible\Verdict\Approvals\UpstreamSource;
 use Fissible\Verdict\Context\Trust;
+use Fissible\Verdict\Support\ApproverSummary;
 
 /**
  * A render-time projection of one console row and its live Verdict status view.
@@ -29,6 +31,7 @@ final readonly class ApprovalItem
      * @param  array<string, mixed>|null  $presentation
      * @param  list<ApprovalVerb>  $verbs
      * @param  array<string, mixed>|null  $provenance
+     * @param  array<string, string>|null  $approverSummary
      */
     private function __construct(
         public string $id,
@@ -46,6 +49,7 @@ final readonly class ApprovalItem
         public ?string $unresumableReason,
         public array $verbs,
         public ?array $provenance,
+        public ?array $approverSummary,
     ) {}
 
     /** @param list<ApprovalVerb> $verbs */
@@ -67,8 +71,9 @@ final readonly class ApprovalItem
             reason: $view?->reason,
             reasonLabel: 'Why this capability is gated',
             expiresAt: $view?->expiresAt,
-            // Verdict #300 adds issuedAt. The console row's created_at is ingestion time, not it.
-            waitingSince: null,
+            // The view owns live rendering fields. Its createdAt is the receipt issuance instant
+            // that Verdict #300 threads onto the challenge; the console row is only ingestion.
+            waitingSince: $view?->createdAt,
             state: $view === null
                 ? 'receipt_unavailable'
                 : ($pending && $unlapsed ? 'pending' : ($pending ? 'lapsed_undecided' : 'already_decided')),
@@ -77,6 +82,9 @@ final readonly class ApprovalItem
             unresumableReason: $approval->unresumable_reason?->value,
             verbs: $verbs,
             provenance: $pending && $unlapsed ? self::provenance($challenge?->provenance) : null,
+            approverSummary: $pending && $unlapsed
+                ? self::approverSummary($challenge?->approverSummaryRelease, $challenge?->approverSummary)
+                : null,
         );
     }
 
@@ -99,7 +107,32 @@ final readonly class ApprovalItem
             'unresumable_reason' => $this->unresumableReason,
             'verbs' => array_map(static fn (ApprovalVerb $verb): string => $verb->value, $this->verbs),
             'provenance' => $this->provenance,
+            'approver_summary' => $this->approverSummary,
         ];
+    }
+
+    /** @return array<string, string>|null */
+    private static function approverSummary(
+        ?ApproverSummaryRelease $release,
+        ?ApproverSummary $summary,
+    ): ?array {
+        if ($release === null) {
+            return null;
+        }
+
+        if ($release === ApproverSummaryRelease::Released) {
+            if ($summary === null) {
+                return null;
+            }
+
+            return [
+                'state' => $release->value,
+                'content' => $summary->content,
+                'fingerprint' => $summary->fingerprint,
+            ];
+        }
+
+        return ['state' => $release->value];
     }
 
     /** @return array<string, mixed> */

--- a/tests/.pest/snapshots/Feature/ApprovalInboxComponentTest/it_matches_the_snapshot_of_the_five_state_matrix.snap
+++ b/tests/.pest/snapshots/Feature/ApprovalInboxComponentTest/it_matches_the_snapshot_of_the_five_state_matrix.snap
@@ -22,6 +22,7 @@ data-receipt-status="rejected"             >
 </dl>
 <dl><dt>Why this capability is gated</dt><dd>Cancelling an order needs confirmation.</dd></dl>
 <p>already decided</p>
+<time datetime="2026-08-30T09:00:00+00:00">2026-08-30T09:00:00+00:00</time>
 <form method="post" action="http://localhost/verdict-console/approvals/{approval-4}/close" data-verb="close">
 <input type="hidden" name="_token" value="{token}" autocomplete="off">                        <button type="submit">Close</button>
 </form>
@@ -36,6 +37,7 @@ data-receipt-status="rejected"             >
 </dl>
 <dl><dt>Why this capability is gated</dt><dd>Cancelling an order needs confirmation.</dd></dl>
 <p>lapsed, undecided <time datetime="2000-01-02T03:04:05+00:00">2000-01-02T03:04:05+00:00</time></p>
+<time datetime="2026-08-30T09:00:00+00:00">2026-08-30T09:00:00+00:00</time>
 <form method="post" action="http://localhost/verdict-console/approvals/{approval-3}/close" data-verb="close">
 <input type="hidden" name="_token" value="{token}" autocomplete="off">                        <button type="submit">Close</button>
 </form>
@@ -50,6 +52,7 @@ data-unresumable-reason="agent_unresolvable" >
 </dl>
 <dl><dt>Why this capability is gated</dt><dd>Cancelling an order needs confirmation.</dd></dl>
 <p>not actionable from this console: <code>agent_unresolvable</code></p>
+<time datetime="2026-08-30T09:00:00+00:00">2026-08-30T09:00:00+00:00</time>
 <div data-provenance="unknown">
 <p>provenance unknown — no derivation was declared</p>
 </div>
@@ -64,6 +67,7 @@ data-unresumable-reason="agent_unresolvable" >
 </dl>
 <dl><dt>Why this capability is gated</dt><dd>Cancelling an order needs confirmation.</dd></dl>
 <time datetime="2030-01-02T03:04:05+00:00">2030-01-02T03:04:05+00:00</time>
+<time datetime="2026-08-30T09:00:00+00:00">2026-08-30T09:00:00+00:00</time>
 <div data-provenance="declared">
 <ul>
 <li data-source-warning="true">external · search · untrusted · public · retrieved_document</li>

--- a/tests/Feature/ApprovalInboxComponentTest.php
+++ b/tests/Feature/ApprovalInboxComponentTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Fissible\Verdict\Approvals\ApprovalChallenge;
 use Fissible\Verdict\Approvals\ApprovalReceiptStatus;
 use Fissible\Verdict\Approvals\ApprovalStatusView;
+use Fissible\Verdict\Approvals\ApproverSummaryRelease;
 use Fissible\Verdict\Approvals\ProposalProvenance;
 use Fissible\Verdict\Approvals\UpstreamSource;
 use Fissible\Verdict\Context\ContextChannel;
@@ -12,6 +13,7 @@ use Fissible\Verdict\Context\DataClass;
 use Fissible\Verdict\Context\Source;
 use Fissible\Verdict\Context\Trust;
 use Fissible\Verdict\Contracts\ApprovalStatusReader;
+use Fissible\Verdict\Support\ApproverSummary;
 use Fissible\VerdictConsole\Approvals\ApprovalChallengeReader;
 use Fissible\VerdictConsole\Approvals\ApprovalSurfaceContract;
 use Fissible\VerdictConsole\Approvals\ApprovalVerb;
@@ -133,8 +135,13 @@ final readonly class InboxConversationScope implements ApprovalScope
     }
 }
 
-function inboxChallenge(string $toolCallId, ?ProposalProvenance $provenance = null, string $expiresAt = '2030-01-02T03:04:05+00:00'): ApprovalChallenge
-{
+function inboxChallenge(
+    string $toolCallId,
+    ?ProposalProvenance $provenance = null,
+    string $expiresAt = '2030-01-02T03:04:05+00:00',
+    ?ApproverSummary $summary = null,
+    ?ApproverSummaryRelease $release = null,
+): ApprovalChallenge {
     return new ApprovalChallenge(
         receiptId: 'receipt-'.$toolCallId,
         toolCallId: $toolCallId,
@@ -142,6 +149,8 @@ function inboxChallenge(string $toolCallId, ?ProposalProvenance $provenance = nu
         reason: 'Cancelling an order needs confirmation.',
         expiresAt: new DateTimeImmutable($expiresAt),
         provenance: $provenance,
+        approverSummary: $summary,
+        approverSummaryRelease: $release,
     );
 }
 
@@ -560,4 +569,51 @@ it('renders only one conversations rows when given a conversation, and nothing w
 
     expect(inboxRows($empty))->toBe([])
         ->and($empty)->not->toContain('No approvals are waiting.');
+});
+
+/**
+ * VC-47: the issuance instant, rendered. waiting_since carries the view's createdAt — the
+ * receipt's issuance, verdict#300's value — never the console row's ingestion time.
+ */
+it('renders how long a pending approval has been waiting, from issuance rather than ingestion', function (): void {
+    $approval = $this->store->ingest('call_waiting', conversationId: 'c1', receiptId: 'receipt-call_waiting', presentation: inboxPresentation(), resumability: Resumability::Drivable);
+    $this->statuses->with('receipt-call_waiting', inboxView('call_waiting'));
+    $this->challenges->with('call_waiting', inboxChallenge('call_waiting'));
+
+    $row = inboxRows(renderInbox())[$approval->id];
+
+    expect($row)->toContain('2026-08-30T09:00:00+00:00')
+        ->not->toContain($approval->created_at->toIso8601String());
+});
+
+/**
+ * VC-47's #306 companion, rendered: a Released summary's content appears escaped at render time —
+ * it is untrusted display text — a denied release names only its state, and no summary control of
+ * any kind renders content the release state withheld.
+ */
+it('renders a released approver summary escaped, and a denied release as its state alone', function (): void {
+    $released = $this->store->ingest('call_summary', conversationId: 'c1', receiptId: 'receipt-call_summary', presentation: inboxPresentation(), resumability: Resumability::Drivable);
+    $denied = $this->store->ingest('call_denied_summary', conversationId: 'c2', receiptId: 'receipt-call_denied_summary', presentation: inboxPresentation(), resumability: Resumability::Drivable);
+
+    $this->statuses
+        ->with('receipt-call_summary', inboxView('call_summary'))
+        ->with('receipt-call_denied_summary', inboxView('call_denied_summary'));
+    $this->challenges
+        ->with('call_summary', inboxChallenge('call_summary', summary: new ApproverSummary(
+            'Cancel <b>order #7</b> for customer X.',
+            hash('sha256', 'Cancel <b>order #7</b> for customer X.'),
+        ), release: ApproverSummaryRelease::Released))
+        ->with('call_denied_summary', inboxChallenge('call_denied_summary', summary: new ApproverSummary(
+            'WITHHELD: must never surface.',
+            hash('sha256', 'WITHHELD: must never surface.'),
+        ), release: ApproverSummaryRelease::ReleaseDenied));
+
+    $rows = inboxRows(renderInbox());
+
+    expect($rows[$released->id])->toContain('Cancel &lt;b&gt;order #7&lt;/b&gt; for customer X.')
+        ->not->toContain('<b>order #7</b>');
+
+    expect($rows[$denied->id])->toContain('release_denied')
+        ->not->toContain('order #7')
+        ->not->toContain('WITHHELD');
 });

--- a/tests/Feature/ApprovalItemTest.php
+++ b/tests/Feature/ApprovalItemTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Fissible\Verdict\Approvals\ApprovalChallenge;
 use Fissible\Verdict\Approvals\ApprovalReceiptStatus;
 use Fissible\Verdict\Approvals\ApprovalStatusView;
+use Fissible\Verdict\Approvals\ApproverSummaryRelease;
 use Fissible\Verdict\Approvals\ProposalProvenance;
 use Fissible\Verdict\Approvals\UpstreamSource;
 use Fissible\Verdict\Context\ContextChannel;
@@ -12,6 +13,7 @@ use Fissible\Verdict\Context\DataClass;
 use Fissible\Verdict\Context\Source;
 use Fissible\Verdict\Context\Trust;
 use Fissible\Verdict\Contracts\ApprovalStatusReader;
+use Fissible\Verdict\Support\ApproverSummary;
 use Fissible\VerdictConsole\Approvals\ApprovalChallengeReader;
 use Fissible\VerdictConsole\Approvals\ApprovalItem;
 use Fissible\VerdictConsole\Approvals\ApprovalItemFactory;
@@ -105,8 +107,11 @@ function approvalItem(
 }
 
 /** The live challenge deliberately disagrees with the view everywhere they overlap, so any field it leaks into fails. */
-function challenge(?ProposalProvenance $provenance = null): ApprovalChallenge
-{
+function challenge(
+    ?ProposalProvenance $provenance = null,
+    ?ApproverSummary $summary = null,
+    ?ApproverSummaryRelease $release = null,
+): ApprovalChallenge {
     return new ApprovalChallenge(
         receiptId: 'live-receipt-id',
         toolCallId: 'call_1',
@@ -114,6 +119,11 @@ function challenge(?ProposalProvenance $provenance = null): ApprovalChallenge
         reason: 'A different reason the challenge must not contribute.',
         expiresAt: new DateTimeImmutable('2031-05-06T07:08:09+00:00'),
         provenance: $provenance,
+        // Deliberately not the view's createdAt: waiting_since is the view's field, and a
+        // challenge instant leaking into it fails here.
+        issuedAt: new DateTimeImmutable('2029-09-09T09:09:09+00:00'),
+        approverSummary: $summary,
+        approverSummaryRelease: $release,
     );
 }
 
@@ -145,7 +155,7 @@ it('renders every provenance disclosure distinctly from the live challenge', fun
         'reason' => 'Cancelling an order needs confirmation.',
         'reason_label' => 'Why this capability is gated',
         'expires_at' => '2030-01-02T03:04:05+00:00',
-        'waiting_since' => null,
+        'waiting_since' => '2026-08-30T09:00:00+00:00',
         'state' => 'pending',
         'receipt_status' => 'pending',
         'verbs' => ['approve', 'reject'],
@@ -304,4 +314,67 @@ it('does not warn for an untrusted user source', function (): void {
     ])));
 
     expect($item->toArray()['provenance']['sources'][0]['warning'])->toBeFalse();
+});
+
+/**
+ * VC-47: verdict#300's issuance instant, adopted through the view. The status view's createdAt is
+ * the receipt's issuance instant — the same value #300 threads onto the challenge — and the view
+ * owns every live rendering field, so waiting_since is present whenever a receipt is readable and
+ * null only when none is. The console row's created_at is ingestion time and never stands in; the
+ * challenge's own issuedAt is staged to a different instant and must never leak.
+ */
+it('reports waiting_since as the views issuance instant for every readable receipt state', function (): void {
+    $pending = approvalItem($this->store, $this->approval, itemStatusView(), challenge());
+    $lapsed = approvalItem($this->store, $this->approval, itemStatusView(expiresAt: '2020-01-01T00:00:00+00:00'));
+    $decided = approvalItem($this->store, $this->approval, itemStatusView(ApprovalReceiptStatus::Approved));
+    $unavailable = approvalItem($this->store, $this->approval, null);
+
+    foreach ([$pending, $lapsed, $decided] as $item) {
+        expect($item->waitingSince?->format(DATE_ATOM))->toBe('2026-08-30T09:00:00+00:00');
+    }
+
+    expect($unavailable->waitingSince)->toBeNull()
+        // Ingestion stamped the row moments ago; issuance was staged years apart. Equality here
+        // would mean the row's created_at was relabelled as waiting time.
+        ->and($this->approval->created_at->toIso8601String())->not->toBe('2026-08-30T09:00:00+00:00');
+});
+
+/**
+ * VC-47's #306 companion: the approver summary rides the challenge like provenance does, under
+ * ADR 0038's typed release states. Content appears only for a Released summary; a denied release
+ * names its state and nothing else — the raw text of a withheld candidate is never retained, so
+ * there is nothing this surface could show; a null release is the pre-feature storage era.
+ */
+it('renders the approver summary only as its typed release state admits', function (?ApproverSummary $summary, ?ApproverSummaryRelease $release, ?array $expected): void {
+    $item = approvalItem($this->store, $this->approval, itemStatusView(), challenge(summary: $summary, release: $release));
+
+    expect($item->toArray()['approver_summary'])->toBe($expected);
+})->with([
+    'released' => [
+        new ApproverSummary('Cancel order #7 for customer X.', hash('sha256', 'Cancel order #7 for customer X.')),
+        ApproverSummaryRelease::Released,
+        ['state' => 'released', 'content' => 'Cancel order #7 for customer X.', 'fingerprint' => hash('sha256', 'Cancel order #7 for customer X.')],
+    ],
+    // A denied release carrying a (mis)persisted summary is the sharpest case: the withheld
+    // content must not surface through any key, so the projection is state-only regardless.
+    'release denied by policy' => [
+        new ApproverSummary('WITHHELD: must never surface.', hash('sha256', 'WITHHELD: must never surface.')),
+        ApproverSummaryRelease::ReleaseDenied,
+        ['state' => 'release_denied'],
+    ],
+    'not released' => [null, ApproverSummaryRelease::NotReleased, ['state' => 'not_released']],
+    'pre-feature era' => [null, null, null],
+]);
+
+it('carries no summary for a receipt state whose challenge is never read', function (): void {
+    $poisoned = challenge(
+        summary: new ApproverSummary('Must not surface.', hash('sha256', 'Must not surface.')),
+        release: ApproverSummaryRelease::Released,
+    );
+
+    $decided = approvalItem($this->store, $this->approval, itemStatusView(ApprovalReceiptStatus::Approved), $poisoned);
+    $lapsed = approvalItem($this->store, $this->approval, itemStatusView(expiresAt: '2020-01-01T00:00:00+00:00'), $poisoned);
+
+    expect($decided->toArray()['approver_summary'])->toBeNull()
+        ->and($lapsed->toArray()['approver_summary'])->toBeNull();
 });

--- a/tests/Feature/ApprovalItemTest.php
+++ b/tests/Feature/ApprovalItemTest.php
@@ -363,6 +363,9 @@ it('renders the approver summary only as its typed release state admits', functi
         ['state' => 'release_denied'],
     ],
     'not released' => [null, ApproverSummaryRelease::NotReleased, ['state' => 'not_released']],
+    // An inconsistent upstream pair — Released with nothing to release — projects nothing: a
+    // state-only 'released' would promise content the renderer cannot have.
+    'released without a summary' => [null, ApproverSummaryRelease::Released, null],
     'pre-feature era' => [null, null, null],
 ]);
 


### PR DESCRIPTION
Closes #47.

verdict#300 shipped inside 0.15's approver-summary feature (#306), so this adopts both. `waiting_since` is populated from the status view's `createdAt` — the receipt's issuance instant, the same value #300 threads onto the challenge — rather than the challenge itself: the view owns live rendering fields, and challenge-sourcing would null the field exactly for lapsed rows, where "waited N minutes and expired" matters most. It is present for pending, lapsed, and decided rows, null only for `receipt_unavailable`, and the console row's `created_at` remains ingestion time (pinned unequal). ADR 0001 §5 carries the dated amendment.

The approver summary rides the challenge like provenance (pending, unlapsed rows only) under ADR 0038's typed release states: `released` renders content and fingerprint with the content escaped at render (it is untrusted display text); `release_denied` and `not_released` name their state and nothing more — a withheld candidate's text never surfaces through any key, pinned with a poisoned fixture; a `Released` state arriving without a summary projects nothing rather than promising content the renderer cannot have; a null release is the pre-feature storage era.

🤖 Generated with [Claude Code](https://claude.com/claude-code)