### PR TITLE
feat: render tool-call collisions distinctly via verdict#425s opt-in reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ All notable changes to Verdict Console will be documented in this file.
   summary is rendered under its typed release states: released content is escaped, while withheld
   states expose no content.
 
+- **Tool-call collisions become visible (VC-96, verdict#425).** On the tool-call read path the
+  inbox now adopts Verdict 0.15's opt-in `DistinguishesStatusCollisions` seam: a tool call with
+  two or more live receipts renders as its own `collided` state — the colliding receipt ids in
+  order, close as the only offered action, and copy that says a collision, not an empty queue —
+  instead of the empty-looking unavailable state. Absence stays absence; a single match collapses
+  to the exact existing view path; readers without the opt-in interface, and rows that already
+  hold a receipt id, keep today's behavior unchanged.
+
 ## [0.9.0] - 2026-09-01
 
 - **Reviewer queue (#48).** The console now renders the scoped, poll-consistent review queue over

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
   "extra": {
     "verdict-console": {
       "dependency_constraints": {
-        "fissible/verdict": "^0.14 only: the console tracks the current Verdict minor (0.14, the approvals design milestone), and ^0.x disjunctions make prefer-lowest skip the supported current minor."
+        "fissible/verdict": "^0.15 only: the console tracks the current Verdict minor (0.15, shipping the review lane and #425's collision seam), and ^0.x disjunctions make prefer-lowest skip the supported current minor."
       }
     },
     "laravel": {

--- a/resources/views/components/approvals.blade.php
+++ b/resources/views/components/approvals.blade.php
@@ -33,6 +33,13 @@
                 <p>already decided</p>
             @elseif ($state === 'receipt_unavailable')
                 <p>receipt unavailable</p>
+            @elseif ($state === 'collided')
+                <p>This tool call matches {{ count($item->collidedReceiptIds) }} receipts — a collision, not an empty queue.</p>
+                <ul>
+                    @foreach ($item->collidedReceiptIds as $receiptId)
+                        <li><code>{{ $receiptId }}</code></li>
+                    @endforeach
+                </ul>
             @elseif ($state === 'not_console_actionable')
                 <p>not actionable from this console: <code>{{ $item->unresumableReason }}</code></p>
             @endif

--- a/src/Approvals/ApprovalItem.php
+++ b/src/Approvals/ApprovalItem.php
@@ -32,6 +32,7 @@ final readonly class ApprovalItem
      * @param  list<ApprovalVerb>  $verbs
      * @param  array<string, mixed>|null  $provenance
      * @param  array<string, string>|null  $approverSummary
+     * @param  list<string>  $collidedReceiptIds
      */
     private function __construct(
         public string $id,
@@ -50,14 +51,19 @@ final readonly class ApprovalItem
         public array $verbs,
         public ?array $provenance,
         public ?array $approverSummary,
+        public array $collidedReceiptIds = [],
     ) {}
 
-    /** @param list<ApprovalVerb> $verbs */
+    /**
+     * @param  list<ApprovalVerb>  $verbs
+     * @param  list<string>  $collidedReceiptIds
+     */
     public static function from(
         PendingApproval $approval,
         ?ApprovalStatusView $view,
         ?ApprovalChallenge $challenge,
         array $verbs,
+        array $collidedReceiptIds = [],
     ): self {
         $pending = $view?->status === ApprovalReceiptStatus::Pending;
         $unlapsed = $view !== null && $view->expiresAt > now();
@@ -74,9 +80,11 @@ final readonly class ApprovalItem
             // The view owns live rendering fields. Its createdAt is the receipt issuance instant
             // that Verdict #300 threads onto the challenge; the console row is only ingestion.
             waitingSince: $view?->createdAt,
-            state: $view === null
+            state: $collidedReceiptIds !== []
+                ? 'collided'
+                : ($view === null
                 ? 'receipt_unavailable'
-                : ($pending && $unlapsed ? 'pending' : ($pending ? 'lapsed_undecided' : 'already_decided')),
+                : ($pending && $unlapsed ? 'pending' : ($pending ? 'lapsed_undecided' : 'already_decided'))),
             receiptStatus: $view?->status->value,
             resumability: $approval->resumability->value,
             unresumableReason: $approval->unresumable_reason?->value,
@@ -85,6 +93,7 @@ final readonly class ApprovalItem
             approverSummary: $pending && $unlapsed
                 ? self::approverSummary($challenge?->approverSummaryRelease, $challenge?->approverSummary)
                 : null,
+            collidedReceiptIds: $collidedReceiptIds,
         );
     }
 
@@ -108,6 +117,7 @@ final readonly class ApprovalItem
             'verbs' => array_map(static fn (ApprovalVerb $verb): string => $verb->value, $this->verbs),
             'provenance' => $this->provenance,
             'approver_summary' => $this->approverSummary,
+            'collided_receipt_ids' => $this->collidedReceiptIds,
         ];
     }
 

--- a/src/Approvals/ApprovalItemFactory.php
+++ b/src/Approvals/ApprovalItemFactory.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Fissible\VerdictConsole\Approvals;
 
+use Fissible\Verdict\Approvals\ApprovalLookupOutcome;
 use Fissible\Verdict\Approvals\ApprovalReceiptStatus;
 use Fissible\Verdict\Approvals\ApprovalStatusView;
 use Fissible\Verdict\Contracts\ApprovalStatusReader;
+use Fissible\Verdict\Contracts\DistinguishesStatusCollisions;
 
 /** Assembles an item at render time from the console index and the supported live Verdict read. */
 final readonly class ApprovalItemFactory
@@ -19,9 +21,17 @@ final readonly class ApprovalItemFactory
 
     public function make(PendingApproval $approval): ApprovalItem
     {
-        $view = $approval->receipt_id === null
-            ? $this->statuses->statusForToolCall($approval->tool_call_id)
-            : $this->statuses->statusFor($approval->receipt_id);
+        $collidedReceiptIds = [];
+
+        if ($approval->receipt_id === null && $this->statuses instanceof DistinguishesStatusCollisions) {
+            $lookup = $this->statuses->statusLookupForToolCall($approval->tool_call_id);
+            $view = $lookup->status;
+            $collidedReceiptIds = $lookup->outcome === ApprovalLookupOutcome::Multiple ? $lookup->receiptIds : [];
+        } else {
+            $view = $approval->receipt_id === null
+                ? $this->statuses->statusForToolCall($approval->tool_call_id)
+                : $this->statuses->statusFor($approval->receipt_id);
+        }
 
         $verbs = $this->verbs->resolve($approval, $view);
 
@@ -36,6 +46,6 @@ final readonly class ApprovalItemFactory
             ? $this->challenges->challengeForToolCall($approval->tool_call_id)
             : null;
 
-        return ApprovalItem::from($approval, $view, $challenge, $verbs);
+        return ApprovalItem::from($approval, $view, $challenge, $verbs, $collidedReceiptIds);
     }
 }

--- a/src/Approvals/ApprovalResolutionService.php
+++ b/src/Approvals/ApprovalResolutionService.php
@@ -333,6 +333,8 @@ final readonly class ApprovalResolutionService
      */
     private function statusFor(PendingApproval $approval): ?ApprovalStatusView
     {
+        // #96 renders the collision question in the inbox; this deliberately ambiguous read keeps
+        // absence and multiple matches as the same refusal outcome for resolution.
         $view = $approval->receipt_id === null
             ? $this->statuses->statusForToolCall($approval->tool_call_id)
             : $this->statuses->statusFor($approval->receipt_id);

--- a/tests/Feature/ApprovalInboxComponentTest.php
+++ b/tests/Feature/ApprovalInboxComponentTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Fissible\Verdict\Approvals\ApprovalChallenge;
 use Fissible\Verdict\Approvals\ApprovalReceiptStatus;
+use Fissible\Verdict\Approvals\ApprovalStatusLookup;
 use Fissible\Verdict\Approvals\ApprovalStatusView;
 use Fissible\Verdict\Approvals\ApproverSummaryRelease;
 use Fissible\Verdict\Approvals\ProposalProvenance;
@@ -13,6 +14,7 @@ use Fissible\Verdict\Context\DataClass;
 use Fissible\Verdict\Context\Source;
 use Fissible\Verdict\Context\Trust;
 use Fissible\Verdict\Contracts\ApprovalStatusReader;
+use Fissible\Verdict\Contracts\DistinguishesStatusCollisions;
 use Fissible\Verdict\Support\ApproverSummary;
 use Fissible\VerdictConsole\Approvals\ApprovalChallengeReader;
 use Fissible\VerdictConsole\Approvals\ApprovalSurfaceContract;
@@ -616,4 +618,115 @@ it('renders a released approver summary escaped, and a denied release as its sta
     expect($rows[$denied->id])->toContain('release_denied')
         ->not->toContain('order #7')
         ->not->toContain('WITHHELD');
+});
+
+/** The #425 opt-in read for the widget: scripted per-tool-call lookups beside per-receipt views. */
+final class DistinguishingInboxStatuses implements ApprovalStatusReader, DistinguishesStatusCollisions
+{
+    /** @var list<string> every read the widget made, in order, as "method:key" */
+    public array $reads = [];
+
+    /** @var array<string, ApprovalStatusView|null> */
+    private array $byReceiptId = [];
+
+    /** @var array<string, ApprovalStatusLookup> */
+    private array $lookups = [];
+
+    public function with(string $receiptId, ?ApprovalStatusView $view): self
+    {
+        $this->byReceiptId[$receiptId] = $view;
+
+        return $this;
+    }
+
+    public function withLookup(string $toolCallId, ApprovalStatusLookup $lookup): self
+    {
+        $this->lookups[$toolCallId] = $lookup;
+
+        return $this;
+    }
+
+    public function statusFor(string $receiptId): ?ApprovalStatusView
+    {
+        $this->reads[] = 'statusFor:'.$receiptId;
+
+        return $this->byReceiptId[$receiptId] ?? null;
+    }
+
+    public function statusForToolCall(string $toolCallId): ?ApprovalStatusView
+    {
+        $this->reads[] = 'statusForToolCall:'.$toolCallId;
+
+        return ($this->lookups[$toolCallId] ?? null)?->status;
+    }
+
+    public function pendingWithin(array $scope): array
+    {
+        return [];
+    }
+
+    public function statusLookupForToolCall(string $toolCallId): ApprovalStatusLookup
+    {
+        $this->reads[] = 'statusLookupForToolCall:'.$toolCallId;
+
+        return $this->lookups[$toolCallId] ?? ApprovalStatusLookup::absent();
+    }
+}
+
+/**
+ * #96 / verdict#425: a tool call with more than one live receipt is a collision — its own row
+ * state with its own copy and the colliding ids, never the empty inbox and never the unavailable
+ * receipt's rendering. Only close is offered: no single receipt exists to approve.
+ */
+it('renders a collision distinctly from an empty inbox and an unavailable receipt', function (): void {
+    VerdictConsoleRoutes::register();
+    $collided = $this->store->ingest('call_collided', conversationId: 'c1', receiptId: null, presentation: inboxPresentation(), resumability: Resumability::Drivable);
+    $statuses = (new DistinguishingInboxStatuses)->withLookup('call_collided', ApprovalStatusLookup::multiple(['receipt-a', 'receipt-b']));
+    app()->instance(ApprovalStatusReader::class, $statuses);
+
+    $html = renderInbox();
+    $rows = inboxRows($html);
+
+    expect(rowAttribute($rows[$collided->id], 'data-state'))->toBe('collided')
+        ->and($rows[$collided->id])->toContain('This tool call matches 2 receipts — a collision, not an empty queue.')
+        ->and($rows[$collided->id])->toContain('receipt-a')
+        ->and($rows[$collided->id])->toContain('receipt-b')
+        // The one control is the real close POST form to the named route — not an inert element,
+        // and not a close label wired to a deciding route.
+        ->and(renderedVerbs($rows[$collided->id]))->toBe([ApprovalVerb::Close])
+        ->and($rows[$collided->id])->toContain('action="'.route('verdict-console.approvals.close', $collided->id).'"')
+        ->and($rows[$collided->id])->toContain('name="_token"')
+        ->and($rows[$collided->id])->not->toContain('data-verb="approve"')
+        ->and($rows[$collided->id])->not->toContain('data-verb="reject"')
+        ->and($html)->not->toContain('No approvals are waiting.')
+        ->and($html)->not->toContain('receipt unavailable')
+        ->and($statuses->reads)->toBe(['statusLookupForToolCall:call_collided']);
+});
+
+/** The acceptance line verbatim: absence and a collision produce different console output. */
+it('renders absence and a collision differently', function (): void {
+    $row = $this->store->ingest('call_q', conversationId: 'c1', receiptId: null, presentation: inboxPresentation(), resumability: Resumability::Drivable);
+
+    app()->instance(ApprovalStatusReader::class, (new DistinguishingInboxStatuses)->withLookup('call_q', ApprovalStatusLookup::absent()));
+
+    $absent = renderInbox();
+
+    app()->instance(ApprovalStatusReader::class, (new DistinguishingInboxStatuses)->withLookup('call_q', ApprovalStatusLookup::multiple(['receipt-a', 'receipt-b', 'receipt-c'])));
+
+    $collided = renderInbox();
+
+    expect(rowAttribute(inboxRows($absent)[$row->id], 'data-state'))->toBe('receipt_unavailable')
+        ->and($absent)->toContain('receipt unavailable')
+        ->and($absent)->not->toContain('collision')
+        ->and(rowAttribute(inboxRows($collided)[$row->id], 'data-state'))->toBe('collided')
+        // The count is the list's, not a hard-coded pair — three receipts say three, and the row
+        // renders every colliding id in the lookup's order, none elided.
+        ->and($collided)->toContain('This tool call matches 3 receipts — a collision, not an empty queue.')
+        ->and($collided)->not->toContain('receipt unavailable');
+
+    $collidedRow = inboxRows($collided)[$row->id];
+
+    expect(strpos($collidedRow, 'receipt-a'))->toBeInt()
+        ->and(strpos($collidedRow, 'receipt-a'))->toBeLessThan((int) strpos($collidedRow, 'receipt-b'))
+        ->and(strpos($collidedRow, 'receipt-b'))->toBeLessThan((int) strpos($collidedRow, 'receipt-c'));
 });

--- a/tests/Feature/ApprovalItemTest.php
+++ b/tests/Feature/ApprovalItemTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Fissible\Verdict\Approvals\ApprovalChallenge;
 use Fissible\Verdict\Approvals\ApprovalReceiptStatus;
+use Fissible\Verdict\Approvals\ApprovalStatusLookup;
 use Fissible\Verdict\Approvals\ApprovalStatusView;
 use Fissible\Verdict\Approvals\ApproverSummaryRelease;
 use Fissible\Verdict\Approvals\ProposalProvenance;
@@ -13,6 +14,7 @@ use Fissible\Verdict\Context\DataClass;
 use Fissible\Verdict\Context\Source;
 use Fissible\Verdict\Context\Trust;
 use Fissible\Verdict\Contracts\ApprovalStatusReader;
+use Fissible\Verdict\Contracts\DistinguishesStatusCollisions;
 use Fissible\Verdict\Support\ApproverSummary;
 use Fissible\VerdictConsole\Approvals\ApprovalChallengeReader;
 use Fissible\VerdictConsole\Approvals\ApprovalItem;
@@ -52,6 +54,44 @@ final class ItemStatuses implements ApprovalStatusReader
     public function pendingWithin(array $scope): array
     {
         return [];
+    }
+}
+
+/**
+ * The #425 opt-in read: a reader that CAN tell absence from a tool-call collision. instanceof is
+ * the discovery mechanism, so this fake implements the interface and answers a scripted lookup.
+ */
+final class DistinguishingItemStatuses implements ApprovalStatusReader, DistinguishesStatusCollisions
+{
+    /** @var list<string> every read the factory made, in order, as "method:key" */
+    public array $reads = [];
+
+    public function __construct(private ApprovalStatusLookup $lookup) {}
+
+    public function statusFor(string $receiptId): ?ApprovalStatusView
+    {
+        $this->reads[] = 'statusFor:'.$receiptId;
+
+        return $this->lookup->status;
+    }
+
+    public function statusForToolCall(string $toolCallId): ?ApprovalStatusView
+    {
+        $this->reads[] = 'statusForToolCall:'.$toolCallId;
+
+        return $this->lookup->status;
+    }
+
+    public function pendingWithin(array $scope): array
+    {
+        return [];
+    }
+
+    public function statusLookupForToolCall(string $toolCallId): ApprovalStatusLookup
+    {
+        $this->reads[] = 'statusLookupForToolCall:'.$toolCallId;
+
+        return $this->lookup;
     }
 }
 
@@ -380,4 +420,102 @@ it('carries no summary for a receipt state whose challenge is never read', funct
 
     expect($decided->toArray()['approver_summary'])->toBeNull()
         ->and($lapsed->toArray()['approver_summary'])->toBeNull();
+});
+
+/**
+ * #96 / verdict#425: on the tool-call path a distinguishing reader replaces the ambiguous read,
+ * and a collision becomes its own state — never the empty-looking receipt_unavailable, never a
+ * canonicalized receipt. The colliding ids travel with the item, and no challenge is fetched:
+ * there is no single receipt to disclose for.
+ */
+it('renders a tool-call collision as its own state with the colliding receipt ids', function (): void {
+    $approval = $this->store->ingest(toolCallId: 'call_9', conversationId: 'conversation_1', receiptId: null, presentation: ['tool' => 'orders.cancel'], resumability: Resumability::Drivable);
+    // Three colliding receipts, not two: "two or more" means the whole list travels untruncated.
+    $statuses = new DistinguishingItemStatuses(ApprovalStatusLookup::multiple(['receipt-a', 'receipt-b', 'receipt-c']));
+    $challenges = new ItemChallenges(challenge());
+
+    $item = (new ApprovalItemFactory($statuses, $challenges, new ApprovalVerbs($this->store)))->make($approval);
+
+    expect($item->state)->toBe('collided')
+        ->and($item->toArray()['collided_receipt_ids'])->toBe(['receipt-a', 'receipt-b', 'receipt-c'])
+        ->and($item->receiptId)->toBeNull('No canonical receipt exists to expose.')
+        ->and($item->receiptStatus)->toBeNull()
+        ->and($item->toArray()['verbs'])->toBe(['close'], 'No single receipt exists to approve or reject; the console row can only be closed.')
+        ->and($item->provenance)->toBeNull()
+        ->and($challenges->reads)->toBe([], 'A collision names no single receipt: no challenge is fetched.')
+        ->and($statuses->reads)->toBe(['statusLookupForToolCall:call_9'], 'The distinguishing read replaces the ambiguous one on the tool-call path.');
+});
+
+/** The acceptance line: absence and a collision are different facts with different output. */
+it('keeps absence as receipt_unavailable under a distinguishing reader', function (): void {
+    $approval = $this->store->ingest(toolCallId: 'call_9', conversationId: 'conversation_1', receiptId: null, presentation: [], resumability: Resumability::Drivable);
+    $statuses = new DistinguishingItemStatuses(ApprovalStatusLookup::absent());
+
+    $item = (new ApprovalItemFactory($statuses, new ItemChallenges, new ApprovalVerbs($this->store)))->make($approval);
+
+    expect($item->state)->toBe('receipt_unavailable')
+        ->and($item->toArray()['collided_receipt_ids'])->toBe([])
+        ->and($statuses->reads)->toBe(['statusLookupForToolCall:call_9']);
+});
+
+it('collapses a single lookup to the exact existing view path, cross-wire guard included', function (): void {
+    $approval = $this->store->ingest(toolCallId: 'call_9', conversationId: 'conversation_1', receiptId: null, presentation: [], resumability: Resumability::Drivable);
+    $statuses = new DistinguishingItemStatuses(ApprovalStatusLookup::single(itemStatusView(toolCallId: 'call_9', receiptId: 'receipt-single')));
+    $challenges = new ItemChallenges(challenge());
+
+    $item = (new ApprovalItemFactory($statuses, $challenges, new ApprovalVerbs($this->store)))->make($approval);
+
+    // The complete live-view projection, not a sampled field: the opt-in branch must copy every
+    // field the ambiguous path copies, with the deliberately disagreeing challenge contributing
+    // provenance alone.
+    expect($item->toArray())->toMatchArray([
+        'receipt_id' => 'receipt-single',
+        'capability' => 'orders.cancel',
+        'reason' => 'Cancelling an order needs confirmation.',
+        'reason_label' => 'Why this capability is gated',
+        'expires_at' => '2030-01-02T03:04:05+00:00',
+        'state' => 'pending',
+        'receipt_status' => 'pending',
+        'verbs' => ['approve', 'reject'],
+        'collided_receipt_ids' => [],
+        'provenance' => ['state' => 'issued_before_provenance_capture', 'message' => 'issued before provenance capture'],
+    ])
+        ->and($challenges->reads)->toBe(['call_9']);
+
+    // A single view for some OTHER tool call stays cross-wire-guarded exactly as before — and
+    // nothing of the foreign view leaks: no live fields, no verbs, no challenge fetched.
+    $crossWired = new DistinguishingItemStatuses(ApprovalStatusLookup::single(itemStatusView(toolCallId: 'call_other', receiptId: 'receipt-other')));
+    $guardedChallenges = new ItemChallenges(challenge());
+
+    $guarded = (new ApprovalItemFactory($crossWired, $guardedChallenges, new ApprovalVerbs($this->store)))->make($approval);
+
+    expect($guarded->state)->toBe('receipt_unavailable')
+        ->and($guarded->receiptId)->toBeNull()
+        ->and($guarded->capability)->toBeNull()
+        ->and($guarded->reason)->toBeNull()
+        ->and($guarded->expiresAt)->toBeNull()
+        ->and($guarded->receiptStatus)->toBeNull()
+        ->and($guarded->provenance)->toBeNull()
+        ->and($guarded->toArray()['verbs'])->toBe([])
+        ->and($guardedChallenges->reads)->toBe([], 'A cross-wired view discloses nothing, a challenge included.');
+});
+
+it('never uses the lookup when the row already holds a receipt id', function (): void {
+    $statuses = new DistinguishingItemStatuses(ApprovalStatusLookup::multiple(['receipt-a', 'receipt-b']));
+
+    (new ApprovalItemFactory($statuses, new ItemChallenges, new ApprovalVerbs($this->store)))->make($this->approval);
+
+    expect($statuses->reads)->toBe(['statusFor:persisted-receipt-id'], 'statusFor was never ambiguous; the collision question only arises on the tool-call path.');
+});
+
+/** A reader that cannot distinguish keeps today's exact behavior: ambiguity stays ambiguous. */
+it('keeps the ambiguous read unchanged for a reader without the opt-in interface', function (): void {
+    $approval = $this->store->ingest(toolCallId: 'call_9', conversationId: 'conversation_1', receiptId: null, presentation: [], resumability: Resumability::Drivable);
+    $statuses = new ItemStatuses(null);
+
+    $item = (new ApprovalItemFactory($statuses, new ItemChallenges, new ApprovalVerbs($this->store)))->make($approval);
+
+    expect($item->state)->toBe('receipt_unavailable')
+        ->and($item->toArray()['collided_receipt_ids'])->toBe([])
+        ->and($statuses->reads)->toBe([['statusForToolCall', 'call_9']]);
 });


### PR DESCRIPTION
Closes #96.

`ApprovalReceiptStore::findForToolCall()` returns null for two different facts — no receipt, and two-or-more receipts sharing a provider-supplied tool-call id — so the inbox rendered a collision as if nothing existed. Verdict 0.15 ships #425's opt-in seam; this adopts it where the console must see the difference.

**What this does**
- `ApprovalItemFactory` probes `instanceof DistinguishesStatusCollisions` on the tool-call path and uses `statusLookupForToolCall()`:
  - **Absent** → the existing `receipt_unavailable` state, unchanged.
  - **Single** → the exact existing view path — complete projection pinned via `toMatchArray`, cross-wire toolCallId guard proven leak-free (no foreign fields, no verbs, no challenge read).
  - **Multiple** → a new `collided` item state carrying the ordered colliding receipt ids (untruncated — pinned with three), null receipt id (no canonical receipt to expose), no challenge fetch, and **close as the only verb** — no single receipt exists to approve or reject.
- The inbox renders `data-state="collided"` with *"This tool call matches N receipts — a collision, not an empty queue."*, every id in order, and the close control pinned as the real POST form to the named close route — distinguishable from the empty inbox **and** from `receipt_unavailable` (the acceptance's absence-vs-collision comparison is a test).
- **Unchanged by construction, pinned:** readers without the opt-in interface keep today's ambiguous behavior; rows already holding a `receipt_id` never consult the lookup (`statusFor()` was never ambiguous).
- **Deliberately out of scope:** `ApprovalResolutionService` keeps the ambiguous read — Absent and Multiple both yield null there and the same refusals (Verdict's own docblock: the manager is correct either way); a comment marks the choice at the call site.
- Constraint criterion: `^0.15` already ships #425; the stale `^0.14` pinning note in `composer.json` is corrected to name 0.15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
