### PR TITLE
feat: the evidence-sink review and the explicit-decision finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Evidence-sink review and the explicit-decision gate (#107).** `<x-verdict-console::sink-review />`
+  renders the #105 posture as a reviewable decision — undecided Off, acknowledged Off, On,
+  Elsewhere, and the chained state each distinctly — and the doctor now reports
+  `evidence_recording_unacknowledged` at error severity whenever the posture is Off and no explicit
+  decision is recorded. The complaint ends by decision, not dismissal: only the literal
+  `verdict-console.evidence.accepted_off: true` silences it, and the finding's own copy records the
+  one-way tradeoff — configuring the shipped attest recorder chains records written by later
+  `record()` calls; it neither backfills nor makes pre-existing rows verifiable through the chain.
+  The decision stays at config-file level; a UI write path needs its own ADR.
+
 - **Issued-at approval rendering (#47).** `waiting_since` is now populated from the receipt
   issuance instant in the live status view, including lapsed and decided rows. The #306 approver
   summary is rendered under its typed release states: released content is escaped, while withheld

--- a/config/verdict-console.php
+++ b/config/verdict-console.php
@@ -22,6 +22,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Evidence recording decision
+    |--------------------------------------------------------------------------
+    | An Off recorder remains an error until the host explicitly decides to accept
+    | it: the complaint ends by decision, not dismissal. Enabling the shipped
+    | attest recorder later only chains future records; it cannot repair earlier,
+    | unverifiable rows.
+    */
+    'evidence' => [
+        'accepted_off' => false,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Approver authority
     |--------------------------------------------------------------------------
     | Who may approve is the HOST's decision, delegated to a Laravel Gate. The

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -299,6 +299,11 @@ Over `DecisionEvidence`, honoring ADR 0008 (fingerprints, not raw), surfacing `c
   design*. The UI must detect it and say *"recording is off — blank by config,"* never render an
   empty table that reads as "nothing happened." [`config/verdict.php`]
 - **Attest recorder is a chained sink** — when configured, the UI says a chained sink is configured; decisions are not readable from this table, never rendering its chain-gap table as an empty decision history. This state claims configuration only: never that any append succeeded, that the chain verifies, or that no gap exists.
+- **Sink review** — `<x-verdict-console::sink-review />` reads the `EvidenceSinkPosture` boundary and
+  makes an Off recorder reviewable. An Off posture is undecided unless the host has set
+  `verdict-console.evidence.accepted_off` to the literal boolean `true`; that decision ends the
+  complaint by decision, not dismissal. Both Off variants state the one-way tradeoff: configuring the shipped attest recorder chains records written by later `record()` calls; it neither backfills nor makes pre-existing rows verifiable through the chain. This is read-only: a UI write path for
+  this decision is out of scope and needs its own ADR.
 - **`DecisionEvidence` has `invocationId` but no `conversationId`.**
   [`src/Evidence/DecisionEvidence.php`] "Filter evidence by conversation" is therefore **not native** —
   it depends on a console-owned correlation projection (invocationId ↔ conversationId), captured at

--- a/resources/views/components/sink-review.blade.php
+++ b/resources/views/components/sink-review.blade.php
@@ -1,0 +1,25 @@
+<section data-verdict-console="sink-review" data-posture="{{ $reviewState }}">
+    @if ($reviewState === 'off')
+        <p>No evidence is being recorded, and no one has decided that.</p>
+        <p>configuring the shipped attest recorder chains records written by later record() calls; it neither backfills nor makes pre-existing rows verifiable through the chain</p>
+    @elseif ($reviewState === 'off_acknowledged')
+        <p>Recording is off by explicit decision (verdict-console.evidence.accepted_off).</p>
+        <p>configuring the shipped attest recorder chains records written by later record() calls; it neither backfills nor makes pre-existing rows verifiable through the chain</p>
+    @elseif ($reviewState === 'on')
+        <table data-evidence-sink>
+            <tbody>
+                <tr><th>Writer</th><td>{{ $posture->effectiveWriter }}</td></tr>
+                <tr><th>Table</th><td>{{ $posture->table }}</td></tr>
+                <tr><th>Connection</th><td>{{ $posture->connection }}</td></tr>
+            </tbody>
+        </table>
+    @elseif ($reviewState === 'elsewhere')
+        @if ($posture->recordedBy !== null)
+            <p>Evidence is recorded elsewhere by {{ $posture->recordedBy }}.</p>
+        @else
+            <p>Evidence is recorded elsewhere; the writer is not nameable.</p>
+        @endif
+    @elseif ($reviewState === 'chained')
+        <p>A chained sink{{ $posture->recordedBy === null ? '' : ' ('.$posture->recordedBy.')' }} is configured; decisions are not readable from this table.</p>
+    @endif
+</section>

--- a/src/Doctor/Doctor.php
+++ b/src/Doctor/Doctor.php
@@ -10,7 +10,9 @@ use Fissible\Verdict\LaravelAi\BoundTool;
 use Fissible\Verdict\LaravelAi\VerdictApprovalMiddleware;
 use Fissible\Verdict\LaravelAi\VerdictProvenanceMiddleware;
 use Fissible\Verdict\Testing\AllowAllApprovalAuthorizer;
+use Fissible\VerdictConsole\Contracts\EvidenceSinkPosture;
 use Fissible\VerdictConsole\Contracts\ResumableAgents;
+use Fissible\VerdictConsole\Evidence\EvidenceRecordingState;
 use Fissible\VerdictConsole\Exceptions\ResumableAgentFailure;
 use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Contracts\Foundation\Application;
@@ -53,6 +55,7 @@ final readonly class Doctor
         $findings = [
             ...$this->inspectPersistence(),
             ...$this->inspectEvidenceCorrelation(),
+            ...$this->inspectEvidenceRecording(),
             ...$this->inspectApprovalAuthorizer(),
             ...$this->inspectAgents(),
             ...$this->inspectCapabilities(),
@@ -62,6 +65,30 @@ final readonly class Doctor
             <=> [$b->severity === Severity::Warning, $b->subject]);
 
         return $findings;
+    }
+
+    /** @return list<Finding> */
+    private function inspectEvidenceRecording(): array
+    {
+        // Resolve at run time so a host replacement remains the source of truth for this run, just
+        // as the read surfaces do. Configuration proves neither recording nor its absence.
+        $posture = $this->app->make(EvidenceSinkPosture::class)->read();
+
+        if ($posture->state !== EvidenceRecordingState::Off
+            || $this->config->get('verdict-console.evidence.accepted_off') === true) {
+            return [];
+        }
+
+        return [new Finding(
+            code: FindingCode::EvidenceRecordingUnacknowledged,
+            severity: Severity::Error,
+            subject: 'verdict.evidence.recorder',
+            summary: 'No evidence is being recorded and no explicit decision accepts that state: configuring '
+                .'the shipped attest recorder chains records written by later record() calls; it neither '
+                .'backfills nor makes pre-existing rows verifiable through the chain.',
+            fix: 'Configure a durable evidence recorder, or record the decision by setting '
+                .'verdict-console.evidence.accepted_off to true.',
+        )];
     }
 
     /** @return list<Finding> */

--- a/src/Doctor/FindingCode.php
+++ b/src/Doctor/FindingCode.php
@@ -12,6 +12,12 @@ namespace Fissible\VerdictConsole\Doctor;
  */
 enum FindingCode: string
 {
+    /**
+     * An Off recorder is an error until the host decides it is acceptable: the complaint ends by
+     * decision, not dismissal, because an attest chain configured later cannot repair this gap.
+     */
+    case EvidenceRecordingUnacknowledged = 'evidence_recording_unacknowledged';
+
     /** A registered resolver key does not rebuild an agent. The preventive stage of design §6.3. */
     case ResolverKeyUnresolvable = 'resolver_key_unresolvable';
 

--- a/src/View/Components/SinkReview.php
+++ b/src/View/Components/SinkReview.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\View\Components;
+
+use Fissible\VerdictConsole\Contracts\EvidenceSinkPosture;
+use Fissible\VerdictConsole\Evidence\EvidenceRecordingState;
+use Illuminate\Contracts\Config\Repository as Config;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+final class SinkReview extends Component
+{
+    public function __construct(
+        private EvidenceSinkPosture $sinkPosture,
+        private Config $config,
+    ) {}
+
+    public function render(): View
+    {
+        $posture = $this->sinkPosture->read();
+        $acknowledged = $posture->state === EvidenceRecordingState::Off
+            && $this->config->get('verdict-console.evidence.accepted_off') === true;
+
+        return view('verdict-console::components.sink-review', [
+            'posture' => $posture,
+            'reviewState' => $acknowledged ? 'off_acknowledged' : $posture->state->value,
+        ]);
+    }
+}

--- a/tests/Feature/DocumentationCorrectionsTest.php
+++ b/tests/Feature/DocumentationCorrectionsTest.php
@@ -234,3 +234,12 @@ it('documents the configuration drift view and its boundary in the design of rec
         ->toContain('current declared fingerprint')
         ->toContain('not a write log');
 });
+
+/** #107: the design records the sink review, the decision key, and the write-path boundary. */
+it('documents the sink review and the evidence-recording decision in the design of record', function (): void {
+    expect(documentation('docs/design/0001-verdict-console-design.md'))
+        ->toContain('`<x-verdict-console::sink-review />`')
+        ->toContain('verdict-console.evidence.accepted_off')
+        ->toContain('configuring the shipped attest recorder chains records written by later `record()` calls; it neither backfills nor makes pre-existing rows verifiable through the chain')
+        ->toContain('needs its own ADR');
+});

--- a/tests/Feature/SinkReviewPageTest.php
+++ b/tests/Feature/SinkReviewPageTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\VerdictConsole\Contracts\EvidenceSinkPosture;
+use Fissible\VerdictConsole\Evidence\EvidenceRecordingState;
+use Fissible\VerdictConsole\Evidence\SinkPosture;
+
+/**
+ * #107: the evidence-sink review — a rendering of the #105 posture that makes the recording
+ * decision reviewable. Off is two different facts: nobody decided, or the host explicitly recorded
+ * the decision to run without evidence (verdict-console.evidence.accepted_off). The page is a pure
+ * function of the posture contract and that config key; no database exists in this file.
+ */
+const SINK_REVIEW_TRADEOFF = 'configuring the shipped attest recorder chains records written by later record() calls; it neither backfills nor makes pre-existing rows verifiable through the chain';
+
+function bindSinkPosture(
+    EvidenceRecordingState $state,
+    ?string $effectiveWriter = null,
+    ?string $recordedBy = null,
+    ?string $table = null,
+    ?string $connection = null,
+    bool $chainConfigured = false,
+): void {
+    $posture = new SinkPosture(
+        state: $state,
+        effectiveWriter: $effectiveWriter,
+        recordedBy: $recordedBy,
+        table: $table,
+        connection: $connection,
+        chainConfigured: $chainConfigured,
+    );
+
+    app()->instance(EvidenceSinkPosture::class, new class($posture) implements EvidenceSinkPosture
+    {
+        public function __construct(private readonly SinkPosture $posture) {}
+
+        public function read(): SinkPosture
+        {
+            return $this->posture;
+        }
+    });
+}
+
+function renderSinkReview(): string
+{
+    return (string) test()->blade('<x-verdict-console::sink-review />');
+}
+
+function sinkReviewState(string $html): ?string
+{
+    return preg_match('/<section\b[^>]*\bdata-verdict-console="sink-review"[^>]*\bdata-posture="([^"]*)"/', $html, $m) === 1 ? $m[1] : null;
+}
+
+/**
+ * The five review states render distinctly — and the two Off variants are different facts: an
+ * undecided Off names the missing decision; an acknowledged Off names the decision that was made.
+ */
+it('renders undecided off, acknowledged off, on, elsewhere, and chained distinctly', function (): void {
+    bindSinkPosture(EvidenceRecordingState::Off, effectiveWriter: 'Fissible\\Verdict\\Evidence\\NullEvidenceRecorder');
+
+    $off = renderSinkReview();
+
+    config()->set('verdict-console.evidence.accepted_off', true);
+
+    $acknowledged = renderSinkReview();
+
+    config()->set('verdict-console.evidence.accepted_off', false);
+    bindSinkPosture(EvidenceRecordingState::On, effectiveWriter: 'Fissible\\Verdict\\Evidence\\DatabaseEvidenceRecorder', table: 'host_evidence', connection: 'audit');
+
+    $on = renderSinkReview();
+
+    bindSinkPosture(EvidenceRecordingState::Elsewhere, effectiveWriter: 'App\\Evidence\\ExternalWriter', recordedBy: 'App\\Evidence\\ExternalWriter');
+
+    $elsewhere = renderSinkReview();
+
+    bindSinkPosture(EvidenceRecordingState::Chained, effectiveWriter: 'Fissible\\Verdict\\Evidence\\AttestEvidenceRecorder', recordedBy: 'main-ledger', chainConfigured: true);
+
+    $chained = renderSinkReview();
+
+    expect(sinkReviewState($off))->toBe('off')
+        ->and($off)->toContain('No evidence is being recorded, and no one has decided that.')
+        ->and(sinkReviewState($acknowledged))->toBe('off_acknowledged')
+        ->and($acknowledged)->toContain('Recording is off by explicit decision (verdict-console.evidence.accepted_off).')
+        ->and($acknowledged)->not->toContain('no one has decided')
+        ->and(sinkReviewState($on))->toBe('on')
+        ->and($on)->toContain('host_evidence')
+        ->and($on)->toContain('audit')
+        ->and($on)->toContain('Fissible\Verdict\Evidence\DatabaseEvidenceRecorder')
+        ->and(sinkReviewState($elsewhere))->toBe('elsewhere')
+        ->and($elsewhere)->toContain('Evidence is recorded elsewhere by App\Evidence\ExternalWriter.')
+        ->and(sinkReviewState($chained))->toBe('chained')
+        ->and($chained)->toContain('A chained sink (main-ledger) is configured; decisions are not readable from this table.');
+});
+
+/**
+ * The one-way tradeoff is part of reviewing the decision, so both Off variants state it verbatim:
+ * choosing the attest recorder later does not repair the gap being created now.
+ */
+it('states the non-retroactivity tradeoff on both off variants', function (): void {
+    bindSinkPosture(EvidenceRecordingState::Off, effectiveWriter: 'Fissible\\Verdict\\Evidence\\NullEvidenceRecorder');
+
+    expect(renderSinkReview())->toContain(SINK_REVIEW_TRADEOFF);
+
+    config()->set('verdict-console.evidence.accepted_off', true);
+
+    expect(renderSinkReview())->toContain(SINK_REVIEW_TRADEOFF);
+});
+
+/** Only the literal boolean true is a decision; a malformed acknowledgement is not one. */
+it('does not read a malformed acknowledgement as a decision', function (?string $note, mixed $value): void {
+    bindSinkPosture(EvidenceRecordingState::Off, effectiveWriter: 'Fissible\\Verdict\\Evidence\\NullEvidenceRecorder');
+    config()->set('verdict-console.evidence.accepted_off', $value);
+
+    expect(sinkReviewState(renderSinkReview()))->toBe('off');
+})->with([
+    'string true' => ['string', 'true'],
+    'integer one' => ['int', 1],
+    'yes' => ['yes', 'yes'],
+    'null' => ['null', null],
+]);
+
+/** The acknowledgement qualifies OFF alone: a readable or chained sink ignores the key entirely. */
+it('never renders an acknowledged variant for a non-off posture', function (): void {
+    config()->set('verdict-console.evidence.accepted_off', true);
+    bindSinkPosture(EvidenceRecordingState::On, effectiveWriter: 'Fissible\\Verdict\\Evidence\\DatabaseEvidenceRecorder', table: 'verdict_evidence');
+
+    expect(sinkReviewState(renderSinkReview()))->toBe('on');
+
+    bindSinkPosture(EvidenceRecordingState::Chained, effectiveWriter: 'Fissible\\Verdict\\Evidence\\AttestEvidenceRecorder', recordedBy: 'main-ledger', chainConfigured: true);
+
+    expect(sinkReviewState(renderSinkReview()))->toBe('chained');
+
+    bindSinkPosture(EvidenceRecordingState::Elsewhere, effectiveWriter: 'App\\Evidence\\ExternalWriter', recordedBy: 'App\\Evidence\\ExternalWriter');
+
+    expect(sinkReviewState(renderSinkReview()))->toBe('elsewhere', 'An acknowledged key never converts an unreadable sink into an acknowledged off.');
+});
+
+/** An unnameable writer or identity stays unnamed: no dangling "by .", no invented identity. */
+it('renders unnamed elsewhere and chained postures without inventing an identity', function (): void {
+    bindSinkPosture(EvidenceRecordingState::Elsewhere, effectiveWriter: null, recordedBy: null);
+
+    $elsewhere = renderSinkReview();
+
+    bindSinkPosture(EvidenceRecordingState::Chained, effectiveWriter: 'Fissible\\Verdict\\Evidence\\AttestEvidenceRecorder', recordedBy: null, chainConfigured: false);
+
+    $chained = renderSinkReview();
+
+    expect(sinkReviewState($elsewhere))->toBe('elsewhere')
+        ->and($elsewhere)->toContain('Evidence is recorded elsewhere; the writer is not nameable.')
+        ->and($elsewhere)->not->toContain('elsewhere by')
+        ->and(sinkReviewState($chained))->toBe('chained')
+        ->and($chained)->toContain('A chained sink is configured; decisions are not readable from this table.')
+        ->and($chained)->not->toContain('A chained sink (');
+});
+
+/** Everything rendered is escaped on every state: writers, tables, connections, identities. */
+it('escapes every value it renders', function (): void {
+    bindSinkPosture(EvidenceRecordingState::Elsewhere, effectiveWriter: '<script>alert(1)</script>', recordedBy: '<script>alert(1)</script>');
+
+    $elsewhere = renderSinkReview();
+
+    bindSinkPosture(EvidenceRecordingState::On, effectiveWriter: '<b>writer</b>', table: '<i>table</i>', connection: '<u>conn</u>');
+
+    $on = renderSinkReview();
+
+    bindSinkPosture(EvidenceRecordingState::Chained, effectiveWriter: '<b>attest</b>', recordedBy: '<i>ledger</i>', chainConfigured: true);
+
+    $chained = renderSinkReview();
+
+    expect($elsewhere)->not->toContain('<script>alert(1)</script>')
+        ->and($elsewhere)->toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+        ->and($on)->not->toContain('<b>writer</b>')
+        ->and($on)->toContain('&lt;b&gt;writer&lt;/b&gt;')
+        ->and($on)->not->toContain('<i>table</i>')
+        ->and($on)->toContain('&lt;i&gt;table&lt;/i&gt;')
+        ->and($on)->not->toContain('<u>conn</u>')
+        ->and($on)->toContain('&lt;u&gt;conn&lt;/u&gt;')
+        ->and($chained)->not->toContain('<i>ledger</i>')
+        ->and($chained)->toContain('&lt;i&gt;ledger&lt;/i&gt;');
+});
+
+/** A review mutates nothing: the decision lives at config-file level, deliberately. */
+it('renders read-only markup with no form', function (): void {
+    bindSinkPosture(EvidenceRecordingState::Off, effectiveWriter: 'Fissible\\Verdict\\Evidence\\NullEvidenceRecorder');
+
+    expect(renderSinkReview())->not->toContain('<form');
+});

--- a/tests/Integration/DoctorTest.php
+++ b/tests/Integration/DoctorTest.php
@@ -22,10 +22,13 @@ use Fissible\Verdict\Targets\ExecutionTargetPolicy;
 use Fissible\Verdict\Testing\AllowAllApprovalAuthorizer;
 use Fissible\Verdict\VerdictManager;
 use Fissible\VerdictConsole\Agents\AgentResolverRegistry;
+use Fissible\VerdictConsole\Contracts\EvidenceSinkPosture;
 use Fissible\VerdictConsole\Contracts\ResumableAgents;
 use Fissible\VerdictConsole\Doctor\Doctor;
 use Fissible\VerdictConsole\Doctor\FindingCode;
 use Fissible\VerdictConsole\Doctor\Severity;
+use Fissible\VerdictConsole\Evidence\EvidenceRecordingState;
+use Fissible\VerdictConsole\Evidence\SinkPosture;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\JsonSchema\Types\Type;
 use Illuminate\Support\Facades\Schema;
@@ -290,6 +293,11 @@ function doctorFor(array $agents = []): Doctor
 }
 
 beforeEach(function (): void {
+    // #107's evidence-recording finding fires whenever the sink posture is Off and no explicit
+    // decision is recorded. This harness's default recorder IS the null one, so the baseline run
+    // records the decision the way a host would — the finding's own suppression semantics.
+    config()->set('verdict-console.evidence.accepted_off', true);
+
     // The conversation tables are a real precondition; migrate them so the default run is clean.
     (require dirname(__DIR__, 2).'/vendor/laravel/ai/database/migrations/2026_01_11_000001_create_agent_conversations_table.php')->up();
 
@@ -668,4 +676,141 @@ it('fails a warning-only run only under --strict', function (): void {
 
     $this->artisan('verdict-console:doctor')->assertSuccessful();
     $this->artisan('verdict-console:doctor', ['--strict' => true])->assertFailed();
+});
+
+/** #107: bind a scripted posture so the finding is proven to consume the boundary, not config. */
+function doctorPosture(EvidenceRecordingState $state, ?string $effectiveWriter = null): void
+{
+    $posture = new SinkPosture(
+        state: $state,
+        effectiveWriter: $effectiveWriter,
+        recordedBy: null,
+        table: null,
+        connection: null,
+        chainConfigured: false,
+    );
+
+    app()->instance(EvidenceSinkPosture::class, new class($posture) implements EvidenceSinkPosture
+    {
+        public function __construct(private readonly SinkPosture $posture) {}
+
+        public function read(): SinkPosture
+        {
+            return $this->posture;
+        }
+    });
+}
+
+/**
+ * #107: an undecided Off posture is an error until someone decides — and the complaint ends by
+ * decision, not dismissal. The finding pins its exact code, severity, subject, the verbatim
+ * one-way-tradeoff sentence, and the fix that names the decision key. The posture boundary is the
+ * source: config here says a database recorder, and the finding still fires.
+ */
+it('reports an undecided off posture as an error with the recorded tradeoff', function (): void {
+    config()->set('verdict-console.evidence.accepted_off', false);
+    config()->set('verdict.evidence.recorder', 'Fissible\\Verdict\\Evidence\\DatabaseEvidenceRecorder');
+    doctorPosture(EvidenceRecordingState::Off, 'Fissible\\Verdict\\Evidence\\NullEvidenceRecorder');
+
+    $findings = array_values(array_filter(doctorFor()->run(), fn ($finding) => $finding->code === FindingCode::EvidenceRecordingUnacknowledged));
+
+    expect($findings)->toHaveCount(1)
+        ->and($findings[0]->code->value)->toBe('evidence_recording_unacknowledged')
+        ->and($findings[0]->severity)->toBe(Severity::Error)
+        ->and($findings[0]->subject)->toBe('verdict.evidence.recorder')
+        ->and($findings[0]->summary)->toContain('configuring the shipped attest recorder chains records written by later record() calls; it neither backfills nor makes pre-existing rows verifiable through the chain')
+        ->and($findings[0]->fix)->toContain('verdict-console.evidence.accepted_off')
+        ->and($findings[0]->fix)->toContain('durable evidence recorder');
+});
+
+/** The explicit decision — and only the literal boolean — silences the finding. */
+it('silences the finding only for the literal boolean acknowledgement', function (mixed $value, bool $suppressed): void {
+    config()->set('verdict-console.evidence.accepted_off', $value);
+    doctorPosture(EvidenceRecordingState::Off, 'Fissible\\Verdict\\Evidence\\NullEvidenceRecorder');
+
+    $codes = array_map(fn ($finding) => $finding->code, doctorFor()->run());
+
+    expect(in_array(FindingCode::EvidenceRecordingUnacknowledged, $codes, true))->toBe(! $suppressed);
+})->with([
+    'true suppresses' => [true, true],
+    'false does not' => [false, false],
+    'string true does not' => ['true', false],
+    'integer one does not' => [1, false],
+    'yes does not' => ['yes', false],
+]);
+
+/** No key at all is the core failure — an absent decision is not a made one. */
+it('reports when no decision key exists at all', function (): void {
+    config()->set('verdict-console.evidence', []);
+    doctorPosture(EvidenceRecordingState::Off, 'Fissible\\Verdict\\Evidence\\NullEvidenceRecorder');
+
+    $codes = array_map(fn ($finding) => $finding->code, doctorFor()->run());
+
+    expect(in_array(FindingCode::EvidenceRecordingUnacknowledged, $codes, true))->toBeTrue();
+});
+
+/** A readable, chained, or elsewhere sink is a made decision: no finding, whatever the key says. */
+it('reports nothing for non-off postures regardless of the acknowledgement key', function (): void {
+    config()->set('verdict-console.evidence.accepted_off', false);
+
+    foreach ([EvidenceRecordingState::On, EvidenceRecordingState::Elsewhere, EvidenceRecordingState::Chained] as $state) {
+        doctorPosture($state, 'Fissible\\Verdict\\Evidence\\DatabaseEvidenceRecorder');
+
+        $codes = array_map(fn ($finding) => $finding->code, doctorFor()->run());
+
+        expect(in_array(FindingCode::EvidenceRecordingUnacknowledged, $codes, true))->toBeFalse();
+    }
+});
+
+/** The finding joins the run beside unrelated findings without displacing or duplicating any. */
+it('adds exactly one finding to the acknowledged baseline, changing nothing else', function (): void {
+    config()->set('verdict.approvals.authorizer', null);
+    doctorPosture(EvidenceRecordingState::Off, 'Fissible\\Verdict\\Evidence\\NullEvidenceRecorder');
+
+    config()->set('verdict-console.evidence.accepted_off', true);
+
+    $baseline = array_map(fn ($finding) => $finding->code, doctorFor()->run());
+
+    config()->set('verdict-console.evidence.accepted_off', false);
+
+    $undecided = array_map(fn ($finding) => $finding->code, doctorFor()->run());
+
+    $withoutNew = array_values(array_filter($undecided, fn ($code) => $code !== FindingCode::EvidenceRecordingUnacknowledged));
+
+    // Exactly the baseline plus the one new finding: nothing dropped, nothing duplicated.
+    expect(count($undecided))->toBe(count($baseline) + 1)
+        ->and($withoutNew)->toBe($baseline)
+        ->and(in_array(FindingCode::ApprovalAuthorizerMissing, $baseline, true))->toBeTrue();
+});
+
+/** The finding reaches the command surface too: an undecided Off names its code and fails the run. */
+it('fails the doctor command for an undecided off posture, naming the finding', function (): void {
+    doctorFor(['healthy' => new HealthyAgent]);
+    config()->set('verdict-console.evidence.accepted_off', false);
+    doctorPosture(EvidenceRecordingState::Off, 'Fissible\\Verdict\\Evidence\\NullEvidenceRecorder');
+
+    $this->artisan('verdict-console:doctor')
+        ->expectsOutputToContain('evidence_recording_unacknowledged')
+        ->assertFailed();
+
+    config()->set('verdict-console.evidence.accepted_off', true);
+
+    $this->artisan('verdict-console:doctor')->assertSuccessful();
+});
+
+/**
+ * A fresh install has NOT decided: the published default is false, and — through the REAL
+ * registered posture reader over the shipped Null-recorder default, no fakes anywhere — the
+ * finding fires. A missing posture binding or a wrong fresh-install posture fails here.
+ */
+it('ships the acknowledgement default as false so a fresh install is nagged', function (): void {
+    $published = require dirname(__DIR__, 2).'/config/verdict-console.php';
+
+    expect($published['evidence']['accepted_off'])->toBeFalse();
+
+    config()->set('verdict-console.evidence.accepted_off', $published['evidence']['accepted_off']);
+
+    $codes = array_map(fn ($finding) => $finding->code, doctorFor()->run());
+
+    expect(in_array(FindingCode::EvidenceRecordingUnacknowledged, $codes, true))->toBeTrue();
 });

--- a/tests/Integration/OpsViewsTest.php
+++ b/tests/Integration/OpsViewsTest.php
@@ -29,6 +29,11 @@ use Laravel\Ai\Promptable;
  * the same tier their services are tested in. Both are read-only projections of VC-3 and VC-16.
  */
 beforeEach(function (): void {
+    // #107: the default recorder is the null one, so a run without a recorded decision now carries
+    // the evidence_recording_unacknowledged error by design. This harness records the decision the
+    // way a host would, keeping the clean-run pins about everything else.
+    config()->set('verdict-console.evidence.accepted_off', true);
+
     (require dirname(__DIR__, 2).'/vendor/laravel/ai/database/migrations/2026_01_11_000001_create_agent_conversations_table.php')->up();
     (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_conversation_invocations_table.php.stub')->up();
     (require dirname(__DIR__, 2).'/vendor/fissible/verdict/database/migrations/create_verdict_execution_claims_table.php.stub')->up();


### PR DESCRIPTION
Closes #107.

The default recorder is Null, so a fresh install records nothing; surfaces say so honestly, but nothing demanded a decision — and one tradeoff is one-way: configuring the shipped attest recorder chains records written by later `record()` calls; it neither backfills nor makes pre-existing rows verifiable through the chain.

**What this does**
- **The review surface** — `<x-verdict-console::sink-review />`: renders the #105 posture as a reviewable decision. Five states, each distinct and pinned: undecided Off (*"No evidence is being recorded, and no one has decided that."*), acknowledged Off (naming the decision key), On (writer/table/connection), Elsewhere (named, or honestly unnameable — never a dangling "by ."), and #104's chained state (identity-aware). Both Off variants state the one-way tradeoff verbatim. Read-only: the decision lives at config-file level, deliberately.
- **The nagging finding** — `evidence_recording_unacknowledged`, **error** severity, subject `verdict.evidence.recorder`: fires through `Doctor::run()` (and thus every surface and the CI-facing `verdict-console:doctor` command, which fails and names it) whenever the posture is Off and no explicit decision is recorded. Suppressed **only** by the literal `verdict-console.evidence.accepted_off: true` — `'true'`, `1`, `'yes'`, `false`, and an absent key all keep the complaint (data-set pinned). It consumes the #105 posture boundary, proven by contradiction (config names a database recorder; a bound Off posture still fires it). The shipped default is pinned `false` **from the published config file**, and a no-fakes integration test proves a fresh install is nagged through the real posture reader.
- **The run stays coherent**: an exact baseline-plus-one comparison pins that the finding displaces and duplicates nothing.
- **The harnesses dogfood the semantics**: DoctorTest and OpsViewsTest record the decision (`accepted_off: true`, commented) exactly the way a host would — the finding's own suppression path, not a bypass.
- **The design records part (c)**: the component, the decision key, the verbatim tradeoff, and that a UI write path for this decision is out of scope and needs its own ADR.

Blocking startup remains explicitly out of scope, per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
