### PR TITLE
The evidence-integrity boundary: five states, dated claims, and a claim intake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Verdict Console will be documented in this file.
 
 ## [Unreleased]
 
+- **Evidence integrity read boundary (#119).** The console now exposes host-replaceable,
+  dated chain-integrity claims, a two-group per-chain verification record, operator claim intake,
+  topology diagnostics, and integrity rendering. The default never verifies on render or reads a
+  chained evidence table: it reports only named topology from the effective sink posture and leaves
+  gap information unavailable until an attest bridge can own that read.
+
 - **Trace correlation design (#103).** `docs/design/0002-trace-correlation-design.md` records, per
   correlation edge, the measured walkability verdict, the authoritative source, missing producer
   data, cross-connection behavior, and the display-safe values each hop may surface — correcting

--- a/config/verdict-console.php
+++ b/config/verdict-console.php
@@ -35,6 +35,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Evidence integrity
+    |--------------------------------------------------------------------------
+    | A resolver cannot be enumerated from this process-wide surface. Resolver
+    | hosts name the chains they want integrity reported for, in display order.
+    | A fixed Verdict chain remains authoritative and ignores this list.
+    */
+    'integrity' => [
+        'chains' => [],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Approver authority
     |--------------------------------------------------------------------------
     | Who may approve is the HOST's decision, delegated to a Laravel Gate. The

--- a/database/migrations/create_verdict_console_chain_verifications_table.php.stub
+++ b/database/migrations/create_verdict_console_chain_verifications_table.php.stub
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/** The current dated integrity claim and newest attempt for each host-named chain. */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('verdict_console_chain_verifications', function (Blueprint $table): void {
+            $table->id();
+            $table->string('chain_id')->unique();
+
+            foreach (['last_completed', 'last_attempt'] as $group) {
+                $table->string($group.'_outcome')->nullable();
+                $table->timestamp($group.'_ran_at')->nullable();
+                $table->string($group.'_ran_by')->nullable();
+                $table->unsignedBigInteger($group.'_from_seq')->nullable();
+                $table->unsignedBigInteger($group.'_to_seq_requested')->nullable();
+                $table->unsignedBigInteger($group.'_verified_through_seq')->nullable();
+                $table->unsignedBigInteger($group.'_broken_at_seq')->nullable();
+                $table->string($group.'_attest_outcome')->nullable();
+                $table->string($group.'_policy_fingerprint')->nullable();
+                $table->string($group.'_source')->nullable();
+                $table->string($group.'_output_digest')->nullable();
+                $table->string($group.'_error_class')->nullable();
+                $table->json($group.'_verifier_versions')->nullable();
+            }
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('verdict_console_chain_verifications');
+    }
+};

--- a/docs/adr/0002-evidence-integrity-read-boundary.md
+++ b/docs/adr/0002-evidence-integrity-read-boundary.md
@@ -57,6 +57,7 @@ final readonly class ChainIntegrityView
 {
     public string $chainId;
     public ChainIntegrityState $state;       // §2 — derived from lastCompleted, never lastAttempt
+    public ?UnnameableReason $unnameableReason;   // §3 — which refusal an Unnameable view renders
     public ?RecordedVerification $lastCompleted;   // the standing claim; null before any completes
     public ?RecordedVerification $lastAttempt;     // newest attempt of any outcome, errored included
     public ?GapTrace $gaps;                  // null when the provider cannot read gap marks (§6)
@@ -76,6 +77,7 @@ final readonly class RecordedVerification
     public string $policyFingerprint;        // hash of the verification inputs (§4)
     public string $source;                   // 'automated' | 'recorded' — who produced the values (§4)
     public ?string $outputDigest;            // sha256 of the run's output artifact when supplied (§4)
+    public ?string $errorClass;              // errored only — the exception class, never a message (§4)
     /** @var array<string, string> every executed component: recorder, attest-laravel, attest, verdict */
     public array $verifierVersions;          // immutable map, stored as written
 }
@@ -89,6 +91,10 @@ final readonly class GapTrace
 
 The core binds a `NullEvidenceIntegrity` default that derives `NotApplicable` / `Unnameable` /
 `Unverified` from configuration alone and never reads a table.
+
+**Amended 2026-09-02 (#119):** `ChainIntegrityView` gains `unnameableReason` — §3 defines two
+distinct refusals whose copy the original field set could not tell apart — and
+`RecordedVerification` gains `errorClass`, §4's "exception class only" datum the original omitted.
 
 ### 2. Five states, and the copy each one is allowed
 
@@ -123,10 +129,13 @@ enumerated from a process-wide surface — Verdict's own CLI refuses exactly thi
 resolver-backed deployments name their chains or render `Unnameable`. The console never derives
 chain ids from data.
 
-A configuration Verdict itself rejects — a fixed chain and a resolver both set — is not a topology
-to report on: the provider fails closed to `Unnameable` with its own copy variant, "Chain
-configuration is invalid; integrity cannot be reported.", and the misconfiguration is the
-Doctor's to flag (a finding shipped with the core slice, exact code and fix text pinned there).
+A configuration Verdict itself rejects — a fixed chain and a resolver both set, or an attest sink
+with **neither** set (upstream requires exactly one) — is not a topology to report on: the
+provider fails closed to `Unnameable` with `unnameableReason: InvalidTopology` and its own copy
+variant, "Chain configuration is invalid; integrity cannot be reported.", and the misconfiguration
+is the Doctor's to flag (a finding shipped with the core slice, exact code and fix text pinned
+there). `verdict-console.integrity.chains` is a resolver-topology affordance: beside a fixed
+chain it is ignored, and the fixed chain alone reports. (Both clarifications 2026-09-02, #119.)
 
 ### 4. Verification results are dated claims, recorded durably by the console
 

--- a/docs/design/0001-verdict-console-design.md
+++ b/docs/design/0001-verdict-console-design.md
@@ -80,6 +80,17 @@ draws UI, owning only operational state and its own durable projections.**
 
 ## 5. Verdict-side read dependency
 
+### Evidence integrity
+
+Integrity is a separate, host-replaceable read boundary beside the evidence state read. It renders
+only dated, chain-and-range claims recorded by the console or a host bridge: it never verifies on
+render, never reads chained evidence rows, and never turns best-effort gap marks into a count of
+failures. The default names a fixed chain from the effective sink posture or uses the host's explicit
+`verdict-console.integrity.chains` list for a resolver; an unnamed resolver and invalid topology
+refuse to report. The console stores the last completed claim separately from the last attempt, so an
+errored run cannot erase a standing verified or failed claim. The future attest bridge waits for a
+stable upstream programmatic verification seam.
+
 The filed per-receipt read and enumeration dependency has shipped as Verdict ADR 0031's
 `ApprovalStatusReader`: an observational receipt-status read that returns
 an `ApprovalStatusView` by receipt id or, only when the row has no receipt id, by tool-call id. The

--- a/resources/views/components/integrity.blade.php
+++ b/resources/views/components/integrity.blade.php
@@ -1,0 +1,23 @@
+@foreach ($chains as $chain)
+    @if ($chain->state->value !== 'not_applicable')
+        <section data-verdict-console="integrity" data-chain="{{ $chain->chainId }}" data-state="{{ $chain->state->value }}">
+            @if ($chain->state->value === 'unnameable')
+                <p>{{ $chain->unnameableReason?->value === 'invalid_topology' ? 'Chain configuration is invalid; integrity cannot be reported.' : 'Chained through a resolver; no chains are named for integrity reporting.' }}</p>
+            @elseif ($chain->state->value === 'unverified')
+                <p>Not yet verified.</p>
+            @elseif ($chain->state->value === 'verified')
+                <p>Verified through sequence {{ $chain->lastCompleted?->verifiedThroughSeq }} at {{ $chain->lastCompleted?->ranAt->format(DATE_ATOM) }}{{ $chain->lastCompleted?->source === 'recorded' ? ', as recorded by ' : ' by ' }}{{ $chain->lastCompleted?->ranBy }}.</p>
+            @elseif ($chain->state->value === 'failed')
+                <p>Verification failed at sequence {{ $chain->lastCompleted?->brokenAtSeq }} ({{ $chain->lastCompleted?->attestOutcome }}) at {{ $chain->lastCompleted?->ranAt->format(DATE_ATOM) }}.</p>
+            @endif
+
+            @if ($chain->lastAttempt?->outcome === 'errored' && $chain->lastAttempt?->ranAt != $chain->lastCompleted?->ranAt)
+                <p>Last verification attempt errored at {{ $chain->lastAttempt->ranAt->format(DATE_ATOM) }}.</p>
+            @endif
+
+            @if ($chain->gaps !== null)
+                <p>{{ $chain->gaps->persistedMarks }} chain-write gap marks (latest {{ $chain->gaps->latestMarkAt?->format(DATE_ATOM) }}).</p>
+            @endif
+        </section>
+    @endif
+@endforeach

--- a/src/Console/Commands/RecordVerificationCommand.php
+++ b/src/Console/Commands/RecordVerificationCommand.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Console\Commands;
+
+use Fissible\VerdictConsole\Integrity\ChainVerificationStore;
+use Fissible\VerdictConsole\Integrity\RecordedVerification;
+use Illuminate\Console\Command;
+
+/** Records an operator-supplied dated claim; it does not run an attest verification. */
+final class RecordVerificationCommand extends Command
+{
+    protected $signature = 'verdict-console:record-verification
+        {chain : The named chain id}
+        {outcome : verified, failed, or errored}
+        {--from= : First sequence examined}
+        {--to= : Last sequence requested}
+        {--verified-through= : Last sequence actually verified}
+        {--broken-at= : Sequence at which verification failed}
+        {--attest-outcome= : Attest outcome word}
+        {--policy-fingerprint= : Hash of verification inputs}
+        {--component-version=* : Executed component version as key=value}
+        {--output-digest= : SHA-256 of a run output artifact}
+        {--error-class= : Exception class for an errored attempt}';
+
+    protected $description = 'Record a dated chain-verification claim supplied by the executing operator.';
+
+    public function handle(ChainVerificationStore $store): int
+    {
+        $outcome = $this->argument('outcome');
+        if (! in_array($outcome, ['verified', 'failed', 'errored'], true)) {
+            return $this->invalid('Outcome must be verified, failed, or errored.');
+        }
+
+        $from = $this->integerOption('from', true);
+        $to = $this->integerOption('to');
+        $verifiedThrough = $this->integerOption('verified-through');
+        $brokenAt = $this->integerOption('broken-at');
+        $fingerprint = $this->option('policy-fingerprint');
+        $digest = $this->option('output-digest');
+        $errorClass = $this->option('error-class');
+
+        if (! is_int($from) || $to === false || $verifiedThrough === false || $brokenAt === false
+            || ! is_string($fingerprint) || $fingerprint === '') {
+            return $this->invalid('A non-negative --from and non-empty --policy-fingerprint are required; sequence options must be integers.');
+        }
+
+        if ($digest !== null && preg_match('/^[0-9a-f]{64}$/', $digest) !== 1) {
+            return $this->invalid('--output-digest must be a lowercase SHA-256 digest.');
+        }
+
+        if ($outcome !== 'errored' && $errorClass !== null) {
+            return $this->invalid('--error-class is only valid for errored outcomes.');
+        }
+
+        if ($outcome === 'errored' && (! is_string($errorClass) || $errorClass === '' || preg_match('/^[^\s:]+$/', $errorClass) !== 1)) {
+            return $this->invalid('--error-class is required for errored outcomes and must be a class-shaped value without spaces or colons.');
+        }
+
+        $versions = $this->versions();
+        if ($versions === null) {
+            return $this->invalid('Every --component-version must be written as key=value.');
+        }
+
+        $chain = $this->argument('chain');
+        if ($chain === '') {
+            return $this->invalid('Chain must be non-empty.');
+        }
+
+        $store->record($chain, new RecordedVerification(
+            outcome: $outcome,
+            ranAt: now()->toDateTimeImmutable(),
+            ranBy: PHP_SAPI.':'.gethostname(),
+            fromSeq: $from,
+            toSeqRequested: $to,
+            verifiedThroughSeq: $verifiedThrough,
+            brokenAtSeq: $brokenAt,
+            attestOutcome: $this->option('attest-outcome'),
+            policyFingerprint: $fingerprint,
+            source: 'recorded',
+            outputDigest: $digest,
+            errorClass: $errorClass,
+            verifierVersions: $versions,
+        ));
+
+        return self::SUCCESS;
+    }
+
+    private function integerOption(string $name, bool $required = false): int|false|null
+    {
+        $value = $this->option($name);
+        if ($value === null || $value === '') {
+            return $required ? false : null;
+        }
+
+        if (is_int($value) && $value >= 0) {
+            return $value;
+        }
+
+        return is_string($value) && preg_match('/^\d+$/', $value) === 1 ? (int) $value : false;
+    }
+
+    /** @return array<string, string>|null */
+    private function versions(): ?array
+    {
+        $versions = [];
+        foreach ($this->option('component-version') as $component) {
+            if (! is_string($component) || ! str_contains($component, '=')) {
+                return null;
+            }
+            [$key, $version] = explode('=', $component, 2);
+            if ($key === '' || $version === '') {
+                return null;
+            }
+            $versions[$key] = $version;
+        }
+
+        return $versions;
+    }
+
+    private function invalid(string $message): int
+    {
+        $this->components->error($message);
+
+        return self::FAILURE;
+    }
+}

--- a/src/Contracts/EvidenceIntegrity.php
+++ b/src/Contracts/EvidenceIntegrity.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Contracts;
+
+use Fissible\VerdictConsole\Integrity\ChainIntegrityView;
+
+/** Console-owned, host-replaceable read boundary for dated chain-integrity claims. */
+interface EvidenceIntegrity
+{
+    /** @return list<ChainIntegrityView> */
+    public function chains(): array;
+}

--- a/src/Doctor/Doctor.php
+++ b/src/Doctor/Doctor.php
@@ -56,6 +56,7 @@ final readonly class Doctor
             ...$this->inspectPersistence(),
             ...$this->inspectEvidenceCorrelation(),
             ...$this->inspectEvidenceRecording(),
+            ...$this->inspectChainTopology(),
             ...$this->inspectApprovalAuthorizer(),
             ...$this->inspectAgents(),
             ...$this->inspectCapabilities(),
@@ -89,6 +90,25 @@ final readonly class Doctor
             fix: 'Configure a durable evidence recorder, or record the decision by setting '
                 .'verdict-console.evidence.accepted_off to true.',
         )];
+    }
+
+    /** @return list<Finding> */
+    private function inspectChainTopology(): array
+    {
+        $posture = $this->app->make(EvidenceSinkPosture::class)->read();
+
+        if ($posture->state !== EvidenceRecordingState::Chained
+            || ($posture->configuredChain === null) === ($posture->chainResolver === null)) {
+            return $posture->state === EvidenceRecordingState::Chained ? [new Finding(
+                code: FindingCode::ChainTopologyInvalid,
+                severity: Severity::Error,
+                subject: 'verdict.evidence.attest',
+                summary: 'An attest evidence sink must configure exactly one fixed chain or chain resolver.',
+                fix: 'Configure exactly one of verdict.evidence.attest.chain and verdict.evidence.attest.chain_resolver; use chain_resolver for tenant-selected chains.',
+            )] : [];
+        }
+
+        return [];
     }
 
     /** @return list<Finding> */

--- a/src/Doctor/FindingCode.php
+++ b/src/Doctor/FindingCode.php
@@ -12,6 +12,9 @@ namespace Fissible\VerdictConsole\Doctor;
  */
 enum FindingCode: string
 {
+    /** An attest writer requires exactly one fixed chain or chain resolver. */
+    case ChainTopologyInvalid = 'chain_topology_invalid';
+
     /**
      * An Off recorder is an error until the host decides it is acceptable: the complaint ends by
      * decision, not dismissal, because an attest chain configured later cannot repair this gap.

--- a/src/Evidence/ConfigurationSinkPosture.php
+++ b/src/Evidence/ConfigurationSinkPosture.php
@@ -34,6 +34,8 @@ final readonly class ConfigurationSinkPosture implements EvidenceSinkPosture
                 table: null,
                 connection: null,
                 chainConfigured: $this->chainConfigured($chain, $resolver),
+                configuredChain: $this->normalized($chain),
+                chainResolver: $this->normalized($resolver),
             );
         }
 
@@ -85,6 +87,8 @@ final readonly class ConfigurationSinkPosture implements EvidenceSinkPosture
             table: $state === EvidenceRecordingState::On ? (is_string($table) ? $table : 'verdict_evidence') : null,
             connection: is_string($connection) ? $connection : null,
             chainConfigured: $this->chainConfigured($chain, $resolver),
+            configuredChain: $this->normalized($chain),
+            chainResolver: $this->normalized($resolver),
         );
     }
 
@@ -99,5 +103,10 @@ final readonly class ConfigurationSinkPosture implements EvidenceSinkPosture
     private function chainConfigured(mixed $chain, mixed $resolver): bool
     {
         return (is_string($chain) && $chain !== '') || (is_string($resolver) && $resolver !== '');
+    }
+
+    private function normalized(mixed $value): ?string
+    {
+        return is_string($value) && $value !== '' ? $value : null;
     }
 }

--- a/src/Evidence/SinkPosture.php
+++ b/src/Evidence/SinkPosture.php
@@ -13,5 +13,9 @@ final readonly class SinkPosture
         public ?string $table,
         public ?string $connection,
         public bool $chainConfigured,
+        /** The normalized fixed chain declaration, when the configured writer is attest. */
+        public ?string $configuredChain = null,
+        /** The normalized resolver declaration, when the configured writer is attest. */
+        public ?string $chainResolver = null,
     ) {}
 }

--- a/src/Integrity/ChainIntegrityState.php
+++ b/src/Integrity/ChainIntegrityState.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Integrity;
+
+enum ChainIntegrityState: string
+{
+    case NotApplicable = 'not_applicable';
+    case Unnameable = 'unnameable';
+    case Unverified = 'unverified';
+    case Verified = 'verified';
+    case Failed = 'failed';
+}

--- a/src/Integrity/ChainIntegrityView.php
+++ b/src/Integrity/ChainIntegrityView.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Integrity;
+
+final readonly class ChainIntegrityView
+{
+    public function __construct(
+        public string $chainId,
+        public ChainIntegrityState $state,
+        public ?UnnameableReason $unnameableReason,
+        public ?RecordedVerification $lastCompleted,
+        public ?RecordedVerification $lastAttempt,
+        public ?GapTrace $gaps,
+    ) {}
+}

--- a/src/Integrity/ChainVerificationRecord.php
+++ b/src/Integrity/ChainVerificationRecord.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Integrity;
+
+/** The two independently replaced record groups held for one chain. */
+final readonly class ChainVerificationRecord
+{
+    public function __construct(
+        public ?RecordedVerification $lastCompleted,
+        public ?RecordedVerification $lastAttempt,
+    ) {}
+}

--- a/src/Integrity/ChainVerificationStore.php
+++ b/src/Integrity/ChainVerificationStore.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Integrity;
+
+use DateTimeImmutable;
+use Illuminate\Database\ConnectionInterface;
+
+/** Stores the current standing claim and newest attempt, not a verification-run history. */
+final readonly class ChainVerificationStore
+{
+    private const string TABLE = 'verdict_console_chain_verifications';
+
+    public function __construct(private ConnectionInterface $database) {}
+
+    public function record(string $chainId, RecordedVerification $verification): void
+    {
+        $attempt = $this->columns('last_attempt', $verification);
+        $completed = in_array($verification->outcome, ['verified', 'failed'], true)
+            ? $this->columns('last_completed', $verification)
+            : [];
+
+        $existing = $this->database->table(self::TABLE)->where('chain_id', $chainId)->first();
+        $values = [...$attempt, ...$completed, 'updated_at' => now()];
+
+        if ($existing === null) {
+            $this->database->table(self::TABLE)->insert([
+                'chain_id' => $chainId,
+                ...$values,
+                'created_at' => now(),
+            ]);
+
+            return;
+        }
+
+        $this->database->table(self::TABLE)->where('chain_id', $chainId)->update($values);
+    }
+
+    public function latestFor(string $chainId): ?ChainVerificationRecord
+    {
+        $row = $this->database->table(self::TABLE)->where('chain_id', $chainId)->first();
+
+        if ($row === null) {
+            return null;
+        }
+
+        return new ChainVerificationRecord(
+            lastCompleted: $row->last_completed_outcome === null ? null : $this->verification($row, 'last_completed'),
+            lastAttempt: $row->last_attempt_outcome === null ? null : $this->verification($row, 'last_attempt'),
+        );
+    }
+
+    /** @return array<string, DateTimeImmutable|int|string|array<string, string>|null> */
+    private function columns(string $prefix, RecordedVerification $verification): array
+    {
+        return [
+            $prefix.'_outcome' => $verification->outcome,
+            $prefix.'_ran_at' => $verification->ranAt->format('Y-m-d H:i:s'),
+            $prefix.'_ran_by' => $verification->ranBy,
+            $prefix.'_from_seq' => $verification->fromSeq,
+            $prefix.'_to_seq_requested' => $verification->toSeqRequested,
+            $prefix.'_verified_through_seq' => $verification->verifiedThroughSeq,
+            $prefix.'_broken_at_seq' => $verification->brokenAtSeq,
+            $prefix.'_attest_outcome' => $verification->attestOutcome,
+            $prefix.'_policy_fingerprint' => $verification->policyFingerprint,
+            $prefix.'_source' => $verification->source,
+            $prefix.'_output_digest' => $verification->outputDigest,
+            $prefix.'_error_class' => $verification->errorClass,
+            $prefix.'_verifier_versions' => json_encode($verification->verifierVersions, JSON_THROW_ON_ERROR),
+        ];
+    }
+
+    private function verification(object $row, string $prefix): RecordedVerification
+    {
+        /** @var array<string, string> $versions */
+        $versions = json_decode($row->{$prefix.'_verifier_versions'}, true, 512, JSON_THROW_ON_ERROR);
+
+        return new RecordedVerification(
+            outcome: $row->{$prefix.'_outcome'},
+            ranAt: new DateTimeImmutable($row->{$prefix.'_ran_at'}),
+            ranBy: $row->{$prefix.'_ran_by'},
+            fromSeq: (int) $row->{$prefix.'_from_seq'},
+            toSeqRequested: $row->{$prefix.'_to_seq_requested'} === null ? null : (int) $row->{$prefix.'_to_seq_requested'},
+            verifiedThroughSeq: $row->{$prefix.'_verified_through_seq'} === null ? null : (int) $row->{$prefix.'_verified_through_seq'},
+            brokenAtSeq: $row->{$prefix.'_broken_at_seq'} === null ? null : (int) $row->{$prefix.'_broken_at_seq'},
+            attestOutcome: $row->{$prefix.'_attest_outcome'},
+            policyFingerprint: $row->{$prefix.'_policy_fingerprint'},
+            source: $row->{$prefix.'_source'},
+            outputDigest: $row->{$prefix.'_output_digest'},
+            errorClass: $row->{$prefix.'_error_class'},
+            verifierVersions: $versions,
+        );
+    }
+}

--- a/src/Integrity/GapTrace.php
+++ b/src/Integrity/GapTrace.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Integrity;
+
+use DateTimeImmutable;
+
+final readonly class GapTrace
+{
+    public function __construct(
+        public int $persistedMarks,
+        public ?DateTimeImmutable $latestMarkAt,
+    ) {}
+}

--- a/src/Integrity/NullEvidenceIntegrity.php
+++ b/src/Integrity/NullEvidenceIntegrity.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Integrity;
+
+use Fissible\VerdictConsole\Contracts\EvidenceIntegrity;
+use Fissible\VerdictConsole\Contracts\EvidenceSinkPosture;
+use Fissible\VerdictConsole\Evidence\EvidenceRecordingState;
+use Illuminate\Contracts\Config\Repository as Config;
+
+/**
+ * Configuration-only integrity read. It deliberately cannot read chain gaps or verify a chain.
+ * Selection and fixed-chain identity come from EvidenceSinkPosture, the existing writer-precedence
+ * boundary, rather than a second interpretation of Verdict configuration.
+ */
+final readonly class NullEvidenceIntegrity implements EvidenceIntegrity
+{
+    public function __construct(
+        private EvidenceSinkPosture $posture,
+        private ChainVerificationStore $store,
+        private Config $config,
+    ) {}
+
+    /** @return list<ChainIntegrityView> */
+    public function chains(): array
+    {
+        $posture = $this->posture->read();
+        if ($posture->state !== EvidenceRecordingState::Chained) {
+            return [];
+        }
+
+        $chain = $posture->recordedBy;
+        $hasChain = $posture->configuredChain !== null
+            || ($posture->chainConfigured && $chain !== null && $posture->chainResolver === null);
+        $hasResolver = $posture->chainResolver !== null;
+        if ($hasChain && $hasResolver || ! $hasChain && ! $hasResolver) {
+            return [$this->unnameable(UnnameableReason::InvalidTopology)];
+        }
+
+        if ($hasChain && $chain !== null) {
+            return [$this->view($chain)];
+        }
+
+        $chains = $this->namedChains();
+        if ($chains === []) {
+            return [$this->unnameable(UnnameableReason::NoNamedChains)];
+        }
+
+        return array_map($this->view(...), $chains);
+    }
+
+    /** @return list<string> */
+    private function namedChains(): array
+    {
+        $chains = $this->config->get('verdict-console.integrity.chains', []);
+
+        if (! is_array($chains)) {
+            return [];
+        }
+
+        return array_values(array_filter($chains, fn (mixed $chain): bool => is_string($chain) && $chain !== ''));
+    }
+
+    private function unnameable(UnnameableReason $reason): ChainIntegrityView
+    {
+        return new ChainIntegrityView('', ChainIntegrityState::Unnameable, $reason, null, null, null);
+    }
+
+    private function view(string $chainId): ChainIntegrityView
+    {
+        $latest = $this->store->latestFor($chainId);
+        $completed = $latest?->lastCompleted;
+        $attempt = $latest?->lastAttempt;
+        $state = match ($completed?->outcome) {
+            'verified' => ChainIntegrityState::Verified,
+            'failed' => ChainIntegrityState::Failed,
+            default => ChainIntegrityState::Unverified,
+        };
+
+        return new ChainIntegrityView($chainId, $state, null, $completed, $attempt, null);
+    }
+}

--- a/src/Integrity/RecordedVerification.php
+++ b/src/Integrity/RecordedVerification.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Integrity;
+
+use DateTimeImmutable;
+
+final readonly class RecordedVerification
+{
+    /** @param array<string, string> $verifierVersions */
+    public function __construct(
+        public string $outcome,
+        public DateTimeImmutable $ranAt,
+        public string $ranBy,
+        public int $fromSeq,
+        public ?int $toSeqRequested,
+        public ?int $verifiedThroughSeq,
+        public ?int $brokenAtSeq,
+        public ?string $attestOutcome,
+        public string $policyFingerprint,
+        public string $source,
+        public ?string $outputDigest,
+        public ?string $errorClass,
+        public array $verifierVersions,
+    ) {}
+}

--- a/src/Integrity/UnnameableReason.php
+++ b/src/Integrity/UnnameableReason.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\Integrity;
+
+enum UnnameableReason: string
+{
+    case NoNamedChains = 'no_named_chains';
+    case InvalidTopology = 'invalid_topology';
+}

--- a/src/VerdictConsoleServiceProvider.php
+++ b/src/VerdictConsoleServiceProvider.php
@@ -26,6 +26,7 @@ use Fissible\VerdictConsole\Chat\ChatService;
 use Fissible\VerdictConsole\Chat\ConfiguredChatEntry;
 use Fissible\VerdictConsole\Configuration\VerdictConfigurationInspection;
 use Fissible\VerdictConsole\Console\Commands\DoctorCommand;
+use Fissible\VerdictConsole\Console\Commands\RecordVerificationCommand;
 use Fissible\VerdictConsole\Contracts\ApprovalNotificationRecipients;
 use Fissible\VerdictConsole\Contracts\ApprovalPresenter;
 use Fissible\VerdictConsole\Contracts\ApprovalScope;
@@ -34,6 +35,7 @@ use Fissible\VerdictConsole\Contracts\ChatEntry;
 use Fissible\VerdictConsole\Contracts\ConfigurationDriftQuery;
 use Fissible\VerdictConsole\Contracts\ConfigurationInspection;
 use Fissible\VerdictConsole\Contracts\ConversationParticipants;
+use Fissible\VerdictConsole\Contracts\EvidenceIntegrity;
 use Fissible\VerdictConsole\Contracts\EvidenceQuery;
 use Fissible\VerdictConsole\Contracts\EvidenceSinkPosture;
 use Fissible\VerdictConsole\Contracts\ExecutionClaimAuthority;
@@ -46,6 +48,7 @@ use Fissible\VerdictConsole\Evidence\DatabaseEvidenceQuery;
 use Fissible\VerdictConsole\ExecutionClaims\GateExecutionClaimAuthority;
 use Fissible\VerdictConsole\Http\VerdictConsoleRoutes;
 use Fissible\VerdictConsole\Incidents\IncidentStore;
+use Fissible\VerdictConsole\Integrity\NullEvidenceIntegrity;
 use Fissible\VerdictConsole\Listeners\IngestToolApprovalRequests;
 use Fissible\VerdictConsole\Listeners\LogApprovalIngestionIncident;
 use Fissible\VerdictConsole\Listeners\NotifyApprovalReceiptTransition;
@@ -114,6 +117,8 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
         $this->app->singleton(ConfigurationDriftQuery::class, DatabaseConfigurationDriftQuery::class);
 
         $this->app->singleton(EvidenceSinkPosture::class, ConfigurationSinkPosture::class);
+
+        $this->app->singleton(EvidenceIntegrity::class, NullEvidenceIntegrity::class);
 
         $this->app->singleton(ConfigurationInspection::class, VerdictConfigurationInspection::class);
 
@@ -213,7 +218,7 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
             return;
         }
 
-        $this->commands([DoctorCommand::class]);
+        $this->commands([DoctorCommand::class, RecordVerificationCommand::class]);
 
         $this->publishes([
             __DIR__.'/../config/verdict-console.php' => config_path('verdict-console.php'),
@@ -253,6 +258,9 @@ final class VerdictConsoleServiceProvider extends ServiceProvider
             ),
             __DIR__.'/../database/migrations/add_approval_context_to_verdict_console_pending_approvals_table.php.stub' => database_path(
                 'migrations/2026_08_30_000001_add_approval_context_to_verdict_console_pending_approvals_table.php',
+            ),
+            __DIR__.'/../database/migrations/create_verdict_console_chain_verifications_table.php.stub' => database_path(
+                'migrations/2026_09_02_000001_create_verdict_console_chain_verifications_table.php',
             ),
         ], ['verdict-console', 'verdict-console-migrations']);
     }

--- a/src/View/Components/Integrity.php
+++ b/src/View/Components/Integrity.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\VerdictConsole\View\Components;
+
+use Fissible\VerdictConsole\Contracts\EvidenceIntegrity;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+final class Integrity extends Component
+{
+    public function __construct(private EvidenceIntegrity $integrity) {}
+
+    public function render(): View
+    {
+        return view('verdict-console::components.integrity', ['chains' => $this->integrity->chains()]);
+    }
+}

--- a/tests/Feature/EvidenceIntegrityTest.php
+++ b/tests/Feature/EvidenceIntegrityTest.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\VerdictConsole\Contracts\EvidenceIntegrity;
+use Fissible\VerdictConsole\Contracts\EvidenceSinkPosture;
+use Fissible\VerdictConsole\Evidence\EvidenceRecordingState;
+use Fissible\VerdictConsole\Evidence\SinkPosture;
+use Fissible\VerdictConsole\Integrity\ChainIntegrityState;
+use Fissible\VerdictConsole\Integrity\ChainVerificationStore;
+use Fissible\VerdictConsole\Integrity\NullEvidenceIntegrity;
+use Fissible\VerdictConsole\Integrity\RecordedVerification;
+use Fissible\VerdictConsole\Integrity\UnnameableReason;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ADR 0002 §§1–4: the integrity boundary beside the evidence state boundary. States derive from
+ * the effective sink through the posture contract and from the console's own two-group
+ * verification record; nothing here reads an evidence table, and an errored attempt never
+ * disturbs a standing claim.
+ */
+const ATTEST_RECORDER = 'Fissible\\Verdict\\Evidence\\AttestEvidenceRecorder';
+
+function recordedRun(
+    string $outcome = 'verified',
+    string $source = 'automated',
+    ?int $verifiedThrough = 120,
+    ?int $brokenAt = null,
+): RecordedVerification {
+    return new RecordedVerification(
+        outcome: $outcome,
+        ranAt: new DateTimeImmutable('2026-09-01T12:00:00+00:00'),
+        ranBy: 'scheduler-1',
+        fromSeq: 1,
+        toSeqRequested: null,
+        verifiedThroughSeq: $verifiedThrough,
+        brokenAtSeq: $brokenAt,
+        attestOutcome: $outcome === 'errored' ? null : 'ok',
+        policyFingerprint: hash('sha256', 'policy'),
+        source: $source,
+        outputDigest: null,
+        errorClass: null,
+        verifierVersions: ['attest-laravel' => '1.1.0', 'attest' => '1.3.0', 'verdict' => '0.15.0'],
+    );
+}
+
+beforeEach(function (): void {
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_chain_verifications_table.php.stub')->up();
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists('verdict_console_chain_verifications');
+});
+
+it('binds a null default a host may replace', function (): void {
+    expect(app(EvidenceIntegrity::class))->toBeInstanceOf(NullEvidenceIntegrity::class);
+
+    $replacement = new class implements EvidenceIntegrity
+    {
+        public function chains(): array
+        {
+            return [];
+        }
+    };
+    app()->instance(EvidenceIntegrity::class, $replacement);
+
+    expect(app(EvidenceIntegrity::class))->toBe($replacement);
+});
+
+it('reports nothing when the effective sink is not chained, whatever chain keys say', function (): void {
+    // Chain settings beside a non-attest effective writer are inert (ADR 0002 §2).
+    config()->set('verdict.evidence.recorder', 'Fissible\\Verdict\\Evidence\\DatabaseEvidenceRecorder');
+    config()->set('verdict.evidence.attest.chain', 'orders-chain');
+
+    expect(app(EvidenceIntegrity::class)->chains())->toBe([]);
+});
+
+it('reports a fixed chain with no recorded verification as unverified', function (): void {
+    config()->set('verdict.evidence.recorder', ATTEST_RECORDER);
+    config()->set('verdict.evidence.attest.chain', 'orders-chain');
+
+    $views = app(EvidenceIntegrity::class)->chains();
+
+    expect($views)->toHaveCount(1)
+        ->and($views[0]->chainId)->toBe('orders-chain')
+        ->and($views[0]->state)->toBe(ChainIntegrityState::Unverified)
+        ->and($views[0]->lastCompleted)->toBeNull()
+        ->and($views[0]->lastAttempt)->toBeNull()
+        // The null default cannot read gap marks: no information, never zero (ADR 0002 §6).
+        ->and($views[0]->gaps)->toBeNull();
+});
+
+it('reports a resolver topology with no named chains as unnameable', function (): void {
+    config()->set('verdict.evidence.recorder', ATTEST_RECORDER);
+    config()->set('verdict.evidence.attest.chain_resolver', 'App\\Attest\\TenantChains');
+
+    $views = app(EvidenceIntegrity::class)->chains();
+
+    expect($views)->toHaveCount(1)
+        ->and($views[0]->state)->toBe(ChainIntegrityState::Unnameable)
+        ->and($views[0]->unnameableReason)->toBe(UnnameableReason::NoNamedChains);
+});
+
+it('reports host-named chains in the named order under a resolver topology', function (): void {
+    config()->set('verdict.evidence.recorder', ATTEST_RECORDER);
+    config()->set('verdict.evidence.attest.chain_resolver', 'App\\Attest\\TenantChains');
+    config()->set('verdict-console.integrity.chains', ['tenant-b', 'tenant-a']);
+
+    $views = app(EvidenceIntegrity::class)->chains();
+
+    expect(array_map(fn ($view) => $view->chainId, $views))->toBe(['tenant-b', 'tenant-a'])
+        ->and($views[0]->state)->toBe(ChainIntegrityState::Unverified);
+});
+
+it('fails closed to unnameable when verdict itself rejects the topology', function (): void {
+    // Exactly one of chain / chain_resolver may be set upstream; both set is not a topology to
+    // report on (ADR 0002 §3).
+    config()->set('verdict.evidence.recorder', ATTEST_RECORDER);
+    config()->set('verdict.evidence.attest.chain', 'orders-chain');
+    config()->set('verdict.evidence.attest.chain_resolver', 'App\\Attest\\TenantChains');
+
+    $views = app(EvidenceIntegrity::class)->chains();
+
+    expect($views)->toHaveCount(1)
+        ->and($views[0]->state)->toBe(ChainIntegrityState::Unnameable)
+        ->and($views[0]->unnameableReason)->toBe(UnnameableReason::InvalidTopology);
+});
+
+it('treats an attest sink with neither chain nor resolver as the same invalid topology', function (): void {
+    config()->set('verdict.evidence.recorder', ATTEST_RECORDER);
+
+    $views = app(EvidenceIntegrity::class)->chains();
+
+    expect($views)->toHaveCount(1)
+        ->and($views[0]->state)->toBe(ChainIntegrityState::Unnameable)
+        ->and($views[0]->unnameableReason)->toBe(UnnameableReason::InvalidTopology);
+});
+
+it('ignores the host chain list beside a fixed chain: the fixed chain alone reports', function (): void {
+    config()->set('verdict.evidence.recorder', ATTEST_RECORDER);
+    config()->set('verdict.evidence.attest.chain', 'orders-chain');
+    config()->set('verdict-console.integrity.chains', ['other-a', 'other-b']);
+
+    expect(array_map(fn ($view) => $view->chainId, app(EvidenceIntegrity::class)->chains()))->toBe(['orders-chain']);
+});
+
+it('derives the effective sink through the posture boundary, not by re-reading config', function (): void {
+    // Config says nothing is chained; the bound posture says chained. The boundary must follow
+    // the posture contract — the one source every sink-answering surface shares (#105).
+    // Every config signal disagrees with the double — writer precedence included — so identity
+    // or applicability re-read from config, rather than the posture's recordedBy, fails here.
+    config()->set('verdict.evidence.recorder', 'Fissible\\Verdict\\Evidence\\NullEvidenceRecorder');
+    config()->set('verdict.evidence.writer', 'Fissible\\Verdict\\Evidence\\DatabaseEvidenceRecorder');
+    config()->set('verdict.evidence.attest.chain', 'config-chain');
+    app()->instance(EvidenceSinkPosture::class, new class implements EvidenceSinkPosture
+    {
+        public function read(): SinkPosture
+        {
+            return new SinkPosture(
+                state: EvidenceRecordingState::Chained,
+                effectiveWriter: ATTEST_RECORDER,
+                recordedBy: 'posture-chain',
+                table: null,
+                connection: null,
+                chainConfigured: true,
+            );
+        }
+    });
+
+    $views = app(EvidenceIntegrity::class)->chains();
+
+    expect($views)->toHaveCount(1)
+        ->and($views[0]->chainId)->toBe('posture-chain');
+});
+
+// --- the two-group record ------------------------------------------------------------------------
+
+it('derives the standing state from the last completed verification', function (): void {
+    config()->set('verdict.evidence.recorder', ATTEST_RECORDER);
+    config()->set('verdict.evidence.attest.chain', 'orders-chain');
+
+    app(ChainVerificationStore::class)->record('orders-chain', recordedRun());
+
+    $view = app(EvidenceIntegrity::class)->chains()[0];
+
+    expect($view->state)->toBe(ChainIntegrityState::Verified)
+        ->and($view->lastCompleted?->verifiedThroughSeq)->toBe(120)
+        ->and($view->lastCompleted?->verifierVersions)->toBe(['attest-laravel' => '1.1.0', 'attest' => '1.3.0', 'verdict' => '0.15.0']);
+});
+
+it('keeps the standing claim when a newer attempt errors', function (): void {
+    config()->set('verdict.evidence.recorder', ATTEST_RECORDER);
+    config()->set('verdict.evidence.attest.chain', 'orders-chain');
+
+    $store = app(ChainVerificationStore::class);
+    $store->record('orders-chain', recordedRun());
+    $store->record('orders-chain', new RecordedVerification(
+        outcome: 'errored',
+        ranAt: new DateTimeImmutable('2026-09-02T08:00:00+00:00'),
+        ranBy: 'scheduler-1',
+        fromSeq: 1,
+        toSeqRequested: null,
+        verifiedThroughSeq: null,
+        brokenAtSeq: null,
+        attestOutcome: null,
+        policyFingerprint: hash('sha256', 'policy'),
+        source: 'automated',
+        outputDigest: null,
+        errorClass: 'RuntimeException',
+        verifierVersions: ['attest-laravel' => '1.1.0'],
+    ));
+
+    $view = app(EvidenceIntegrity::class)->chains()[0];
+
+    // ADR 0002 §4: an errored attempt never erases the standing claim.
+    expect($view->state)->toBe(ChainIntegrityState::Verified)
+        ->and($view->lastCompleted?->outcome)->toBe('verified')
+        ->and($view->lastAttempt?->outcome)->toBe('errored')
+        ->and($view->lastAttempt?->ranAt->format(DATE_ATOM))->toBe('2026-09-02T08:00:00+00:00');
+});
+
+it('preserves a failed standing claim through an errored attempt, and lets a completed run replace both groups', function (): void {
+    config()->set('verdict.evidence.recorder', ATTEST_RECORDER);
+    config()->set('verdict.evidence.attest.chain', 'orders-chain');
+
+    $store = app(ChainVerificationStore::class);
+    $store->record('orders-chain', recordedRun(outcome: 'failed', verifiedThrough: null, brokenAt: 87));
+    $store->record('orders-chain', new RecordedVerification(
+        outcome: 'errored',
+        ranAt: new DateTimeImmutable('2026-09-02T08:00:00+00:00'),
+        ranBy: 'scheduler-1',
+        fromSeq: 1,
+        toSeqRequested: null,
+        verifiedThroughSeq: null,
+        brokenAtSeq: null,
+        attestOutcome: null,
+        policyFingerprint: hash('sha256', 'policy'),
+        source: 'automated',
+        outputDigest: null,
+        errorClass: 'RuntimeException',
+        verifierVersions: [],
+    ));
+
+    $view = app(EvidenceIntegrity::class)->chains()[0];
+
+    expect($view->state)->toBe(ChainIntegrityState::Failed)
+        ->and($view->lastAttempt?->errorClass)->toBe('RuntimeException');
+
+    // A later completed run replaces both groups.
+    $store->record('orders-chain', recordedRun());
+
+    $view = app(EvidenceIntegrity::class)->chains()[0];
+
+    expect($view->state)->toBe(ChainIntegrityState::Verified)
+        ->and($view->lastAttempt?->outcome)->toBe('verified');
+});
+
+it('reports a failed completed verification as failed, one row per chain', function (): void {
+    config()->set('verdict.evidence.recorder', ATTEST_RECORDER);
+    config()->set('verdict.evidence.attest.chain', 'orders-chain');
+
+    $store = app(ChainVerificationStore::class);
+    $store->record('orders-chain', recordedRun());
+    $store->record('orders-chain', recordedRun(outcome: 'failed', verifiedThrough: null, brokenAt: 87));
+
+    $view = app(EvidenceIntegrity::class)->chains()[0];
+
+    expect($view->state)->toBe(ChainIntegrityState::Failed)
+        ->and($view->lastCompleted?->brokenAtSeq)->toBe(87)
+        ->and(DB::table('verdict_console_chain_verifications')->count())->toBe(1);
+});

--- a/tests/Feature/IntegrityPageComponentTest.php
+++ b/tests/Feature/IntegrityPageComponentTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\VerdictConsole\Contracts\EvidenceIntegrity;
+use Fissible\VerdictConsole\Integrity\ChainIntegrityState;
+use Fissible\VerdictConsole\Integrity\ChainIntegrityView;
+use Fissible\VerdictConsole\Integrity\GapTrace;
+use Fissible\VerdictConsole\Integrity\RecordedVerification;
+use Fissible\VerdictConsole\Integrity\UnnameableReason;
+
+/**
+ * ADR 0002 §2/§6, rendered: every state's copy verbatim, the recorded-source attribution variant,
+ * the errored attempt beside — never instead of — the standing claim, gap marks in their own
+ * words, and nothing at all for a sink that is not chained.
+ */
+function integrityRun(
+    string $outcome = 'verified',
+    string $source = 'automated',
+    string $ranAt = '2026-09-01T12:00:00+00:00',
+    ?int $verifiedThrough = 120,
+    ?int $brokenAt = null,
+    ?string $attestOutcome = 'ok',
+    ?string $outputDigest = null,
+    string $ranBy = 'scheduler-1',
+): RecordedVerification {
+    return new RecordedVerification(
+        outcome: $outcome,
+        ranAt: new DateTimeImmutable($ranAt),
+        ranBy: $ranBy,
+        fromSeq: 1,
+        toSeqRequested: null,
+        verifiedThroughSeq: $verifiedThrough,
+        brokenAtSeq: $brokenAt,
+        attestOutcome: $attestOutcome,
+        policyFingerprint: hash('sha256', 'policy'),
+        source: $source,
+        outputDigest: $outputDigest,
+        errorClass: null,
+        verifierVersions: ['attest-laravel' => '1.1.0'],
+    );
+}
+
+function integrityView(
+    ChainIntegrityState $state,
+    ?RecordedVerification $completed = null,
+    ?RecordedVerification $attempt = null,
+    ?GapTrace $gaps = null,
+    string $chainId = 'orders-chain',
+    ?UnnameableReason $unnameableReason = null,
+): ChainIntegrityView {
+    return new ChainIntegrityView(
+        chainId: $chainId,
+        state: $state,
+        unnameableReason: $unnameableReason,
+        lastCompleted: $completed,
+        lastAttempt: $attempt ?? $completed,
+        gaps: $gaps,
+    );
+}
+
+/** @param list<ChainIntegrityView> $views */
+function bindIntegrity(array $views): void
+{
+    app()->instance(EvidenceIntegrity::class, new class($views) implements EvidenceIntegrity
+    {
+        /** @param list<ChainIntegrityView> $views */
+        public function __construct(private readonly array $views) {}
+
+        public function chains(): array
+        {
+            return $this->views;
+        }
+    });
+}
+
+function renderIntegrity(): string
+{
+    return (string) test()->blade('<x-verdict-console::integrity />');
+}
+
+it('renders nothing at all when there is no chain to report on', function (): void {
+    bindIntegrity([]);
+
+    // NotApplicable renders nothing: the evidence surfaces' states already speak (ADR 0002 §2).
+    expect(renderIntegrity())->not->toContain('chain')
+        ->not->toContain('Verified')
+        ->not->toContain('verification');
+});
+
+it('renders each states copy verbatim, from the record rather than from the state', function (): void {
+    // Every value below is deliberately distinct so a component rendering state-shaped constants
+    // — instead of the record's own sequence, instant, and actor — fails on the exact string.
+    bindIntegrity([
+        integrityView(ChainIntegrityState::Unnameable, chainId: 'resolver', unnameableReason: UnnameableReason::NoNamedChains),
+        integrityView(ChainIntegrityState::Unnameable, chainId: 'broken-config', unnameableReason: UnnameableReason::InvalidTopology),
+        integrityView(ChainIntegrityState::Unverified, chainId: 'fresh-chain'),
+        integrityView(ChainIntegrityState::Verified, completed: integrityRun(verifiedThrough: 205, ranAt: '2026-09-03T05:00:00+00:00', ranBy: 'auditor-2'), chainId: 'good-chain'),
+        integrityView(ChainIntegrityState::Failed, completed: integrityRun(outcome: 'failed', verifiedThrough: null, brokenAt: 87, attestOutcome: 'broken_link', ranAt: '2026-09-03T06:30:00+00:00'), chainId: 'bad-chain'),
+    ]);
+
+    $html = renderIntegrity();
+
+    expect($html)->toContain('Chained through a resolver; no chains are named for integrity reporting.')
+        ->toContain('Chain configuration is invalid; integrity cannot be reported.')
+        ->toContain('Not yet verified.')
+        ->toContain('Verified through sequence 205 at 2026-09-03T05:00:00+00:00 by auditor-2.')
+        ->toContain('Verification failed at sequence 87 (broken_link) at 2026-09-03T06:30:00+00:00.')
+        ->not->toContain('the chain is verified')
+        ->not->toContain('tampered');
+});
+
+it('attributes a recorded-source claim as recorded, never as independently verified', function (): void {
+    bindIntegrity([
+        integrityView(ChainIntegrityState::Verified, completed: integrityRun(source: 'recorded')),
+    ]);
+
+    $html = renderIntegrity();
+
+    expect($html)->toContain('Verified through sequence 120 at 2026-09-01T12:00:00+00:00, as recorded by scheduler-1.')
+        ->not->toContain('independently');
+});
+
+it('renders byte-identical output for a recorded claim with and without an output digest', function (): void {
+    // Same chain id, same record, separately bound and rendered: the only difference is the
+    // digest, and ADR 0002 §4 says it changes nothing rendered — not a word, not a marker.
+    bindIntegrity([integrityView(ChainIntegrityState::Verified, completed: integrityRun(source: 'recorded'))]);
+    $plain = renderIntegrity();
+
+    bindIntegrity([integrityView(ChainIntegrityState::Verified, completed: integrityRun(source: 'recorded', outputDigest: hash('sha256', 'artifact')))]);
+    $digested = renderIntegrity();
+
+    expect($digested)->toBe($plain)
+        ->and($digested)->not->toContain(hash('sha256', 'artifact'));
+});
+
+it('renders a newer errored attempt beside the standing claim, not instead of it', function (): void {
+    bindIntegrity([
+        integrityView(
+            ChainIntegrityState::Verified,
+            completed: integrityRun(),
+            attempt: integrityRun(outcome: 'errored', ranAt: '2026-09-02T08:00:00+00:00', verifiedThrough: null, attestOutcome: null),
+        ),
+    ]);
+
+    $html = renderIntegrity();
+
+    expect($html)->toContain('Verified through sequence 120 at 2026-09-01T12:00:00+00:00 by scheduler-1.')
+        ->toContain('Last verification attempt errored at 2026-09-02T08:00:00+00:00.');
+});
+
+it('renders gap marks in their own words, and their absence as no information', function (): void {
+    bindIntegrity([
+        integrityView(ChainIntegrityState::Verified, completed: integrityRun(), gaps: new GapTrace(3, new DateTimeImmutable('2026-09-01T07:00:00+00:00')), chainId: 'gappy'),
+        integrityView(ChainIntegrityState::Verified, completed: integrityRun(), chainId: 'unknown-gaps'),
+    ]);
+
+    $html = renderIntegrity();
+
+    // §6's copy — never merged into a verification outcome; and gaps: null renders as no gap
+    // information, never as zero gaps.
+    expect($html)->toContain('3 chain-write gap marks (latest 2026-09-01T07:00:00+00:00)')
+        ->not->toContain('0 chain-write gap marks');
+});

--- a/tests/Feature/MigrationPublishingTest.php
+++ b/tests/Feature/MigrationPublishingTest.php
@@ -49,7 +49,7 @@ it('publishes every migration, in an order that can actually run', function (): 
         ->sort()
         ->values();
 
-    expect($published)->toHaveCount(7);
+    expect($published)->toHaveCount(8);
 
     $position = fn (string $fragment): int => $published->search(fn (string $name): bool => str_contains($name, $fragment));
 

--- a/tests/Feature/RecordVerificationCommandTest.php
+++ b/tests/Feature/RecordVerificationCommandTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+use Fissible\VerdictConsole\Integrity\ChainVerificationStore;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Symfony\Component\Console\Exception\InvalidOptionException;
+
+/**
+ * ADR 0002 §4/§7: the recording command is a claim intake, not a verifier. Its instant and actor
+ * derive from execution — never from inputs — every record is source 'recorded', and the optional
+ * output digest is an audit breadcrumb with no effect on anything rendered.
+ */
+beforeEach(function (): void {
+    (require dirname(__DIR__, 2).'/database/migrations/create_verdict_console_chain_verifications_table.php.stub')->up();
+    Carbon::setTestNow(Carbon::parse('2026-09-02 09:30:00', 'UTC'));
+});
+
+afterEach(function (): void {
+    Carbon::setTestNow();
+    Schema::dropIfExists('verdict_console_chain_verifications');
+});
+
+it('records a verified claim with execution-derived instant and actor, as a recorded source', function (): void {
+    $this->artisan('verdict-console:record-verification', [
+        'chain' => 'orders-chain',
+        'outcome' => 'verified',
+        '--from' => 1,
+        '--verified-through' => 240,
+        '--attest-outcome' => 'ok',
+        '--policy-fingerprint' => hash('sha256', 'policy'),
+        '--component-version' => ['attest-laravel=1.1.0', 'attest=1.3.0'],
+    ])->assertSuccessful();
+
+    $record = app(ChainVerificationStore::class)->latestFor('orders-chain');
+
+    expect($record->lastCompleted?->outcome)->toBe('verified')
+        ->and($record->lastCompleted?->verifiedThroughSeq)->toBe(240)
+        // Derived at execution: the clock, not an input (ADR 0002 §4).
+        ->and($record->lastCompleted?->ranAt->format(DATE_ATOM))->toBe('2026-09-02T09:30:00+00:00')
+        ->and($record->lastCompleted?->ranBy)->not->toBe('')
+        ->and($record->lastCompleted?->source)->toBe('recorded')
+        ->and($record->lastCompleted?->verifierVersions)->toBe(['attest-laravel' => '1.1.0', 'attest' => '1.3.0']);
+});
+
+it('refuses caller-supplied instants and actors by not defining such inputs at all', function (): void {
+    // The trust contract is structural: there is nothing to pass. An unknown option is an error.
+    expect(fn () => $this->artisan('verdict-console:record-verification', [
+        'chain' => 'orders-chain',
+        'outcome' => 'verified',
+        '--ran-at' => '2020-01-01T00:00:00+00:00',
+    ]))->toThrow(InvalidOptionException::class);
+
+    expect(DB::table('verdict_console_chain_verifications')->count())->toBe(0);
+});
+
+it('records an errored attempt without touching a standing completed claim', function (): void {
+    $this->artisan('verdict-console:record-verification', [
+        'chain' => 'orders-chain',
+        'outcome' => 'verified',
+        '--from' => 1,
+        '--verified-through' => 240,
+        '--attest-outcome' => 'ok',
+        '--policy-fingerprint' => hash('sha256', 'policy'),
+    ])->assertSuccessful();
+
+    Carbon::setTestNow(Carbon::parse('2026-09-02 10:00:00', 'UTC'));
+
+    $this->artisan('verdict-console:record-verification', [
+        'chain' => 'orders-chain',
+        'outcome' => 'errored',
+        '--from' => 1,
+        '--policy-fingerprint' => hash('sha256', 'policy'),
+        '--error-class' => 'RuntimeException',
+    ])->assertSuccessful();
+
+    $record = app(ChainVerificationStore::class)->latestFor('orders-chain');
+
+    expect($record->lastCompleted?->outcome)->toBe('verified')
+        ->and($record->lastCompleted?->ranAt->format(DATE_ATOM))->toBe('2026-09-02T09:30:00+00:00')
+        ->and($record->lastAttempt?->outcome)->toBe('errored')
+        ->and($record->lastAttempt?->errorClass)->toBe('RuntimeException')
+        ->and($record->lastAttempt?->ranAt->format(DATE_ATOM))->toBe('2026-09-02T10:00:00+00:00')
+        // One row per chain through the command path too — never a second row.
+        ->and(DB::table('verdict_console_chain_verifications')->count())->toBe(1);
+});
+
+it('refuses a digest that is not sha256-shaped', function (string $digest): void {
+    $this->artisan('verdict-console:record-verification', [
+        'chain' => 'orders-chain',
+        'outcome' => 'verified',
+        '--from' => 1,
+        '--verified-through' => 10,
+        '--attest-outcome' => 'ok',
+        '--policy-fingerprint' => hash('sha256', 'policy'),
+        '--output-digest' => $digest,
+    ])->assertFailed();
+
+    expect(DB::table('verdict_console_chain_verifications')->count())->toBe(0);
+})->with([
+    'wrong length' => ['not-a-digest'],
+    // 64 characters of non-hex: a length-only validator passes this and fails here.
+    'right length, not hex' => [str_repeat('g', 64)],
+]);
+
+it('confines the error class to errored outcomes and to class-shaped values', function (array $arguments): void {
+    $this->artisan('verdict-console:record-verification', array_merge([
+        'chain' => 'orders-chain',
+        '--from' => 1,
+        '--policy-fingerprint' => hash('sha256', 'policy'),
+    ], $arguments))->assertFailed();
+
+    expect(DB::table('verdict_console_chain_verifications')->count())->toBe(0);
+})->with([
+    // errorClass is the errored outcome's datum only (ADR 0002 §4).
+    'error class on a verified outcome' => [[
+        'outcome' => 'verified', '--verified-through' => 10, '--attest-outcome' => 'ok',
+        '--error-class' => 'RuntimeException',
+    ]],
+    // A class, never a message: message-shaped values commonly carry paths and configuration.
+    'message-shaped value' => [[
+        'outcome' => 'errored',
+        '--error-class' => 'RuntimeException: something broke at /app/Handler.php',
+    ]],
+]);
+
+it('persists an output digest verbatim as an audit breadcrumb', function (): void {
+    $digest = hash('sha256', 'the run output');
+
+    $this->artisan('verdict-console:record-verification', [
+        'chain' => 'orders-chain',
+        'outcome' => 'verified',
+        '--from' => 1,
+        '--verified-through' => 10,
+        '--attest-outcome' => 'ok',
+        '--policy-fingerprint' => hash('sha256', 'policy'),
+        '--output-digest' => $digest,
+    ])->assertSuccessful();
+
+    expect(app(ChainVerificationStore::class)->latestFor('orders-chain')->lastCompleted?->outputDigest)->toBe($digest);
+});
+
+it('refuses an outcome outside the vocabulary', function (): void {
+    $this->artisan('verdict-console:record-verification', [
+        'chain' => 'orders-chain',
+        'outcome' => 'tampered',
+        '--policy-fingerprint' => hash('sha256', 'policy'),
+    ])->assertFailed();
+
+    expect(DB::table('verdict_console_chain_verifications')->count())->toBe(0);
+});

--- a/tests/Integration/DoctorTest.php
+++ b/tests/Integration/DoctorTest.php
@@ -814,3 +814,33 @@ it('ships the acknowledgement default as false so a fresh install is nagged', fu
 
     expect(in_array(FindingCode::EvidenceRecordingUnacknowledged, $codes, true))->toBeTrue();
 });
+
+/** ADR 0002 §3: a fixed chain and a resolver both set is a configuration Verdict rejects. */
+it('flags an invalid chain topology as its own error finding', function (): void {
+    config()->set('verdict.evidence.recorder', 'Fissible\\Verdict\\Evidence\\AttestEvidenceRecorder');
+    config()->set('verdict.evidence.attest.chain', 'orders-chain');
+    config()->set('verdict.evidence.attest.chain_resolver', 'App\\Attest\\TenantChains');
+
+    $findings = doctorFor()->run();
+    $finding = current(array_filter($findings, fn ($f) => $f->code === FindingCode::ChainTopologyInvalid));
+
+    expect($finding)->not->toBeFalse()
+        ->and($finding->severity)->toBe(Severity::Error)
+        ->and($finding->summary)->toContain('exactly one')
+        ->and($finding->fix)->toContain('chain_resolver');
+});
+
+it('flags an attest sink with neither chain source set as the same invalid topology', function (): void {
+    config()->set('verdict.evidence.recorder', 'Fissible\\Verdict\\Evidence\\AttestEvidenceRecorder');
+
+    expect(array_map(fn ($finding) => $finding->code, doctorFor()->run()))
+        ->toContain(FindingCode::ChainTopologyInvalid);
+});
+
+it('raises no topology finding when exactly one chain source is set', function (): void {
+    config()->set('verdict.evidence.recorder', 'Fissible\\Verdict\\Evidence\\AttestEvidenceRecorder');
+    config()->set('verdict.evidence.attest.chain', 'orders-chain');
+
+    expect(array_map(fn ($finding) => $finding->code, doctorFor()->run()))
+        ->not->toContain(FindingCode::ChainTopologyInvalid);
+});


### PR DESCRIPTION
Closes #119 — ADR 0002's core slice, ungated, with the bridge (#120) still waiting only on its own repo work now that attest-laravel v1.1.0 shipped the seam.

What ships: the `EvidenceIntegrity` contract and null default (one `ChainIntegrityView` per named chain); the five states with the ADR's copy rendered verbatim — including the two distinct `Unnameable` refusals and the errored-attempt line beside a standing claim; the two-group one-row-per-chain verification record (completed replaced only by completed runs); the `verdict-console:record-verification` claim intake under the pinned trust contract (execution-derived `ranAt`/`ranBy` with no such inputs to abuse, sha256-shaped digests as audit-only breadcrumbs that change nothing rendered, errored-only class-shaped `--error-class`); the `chain_topology_invalid` Doctor finding for both invalid topologies (both chain sources set, or an attest sink with neither); and the published `chain_verifications` migration.

Two ADR amendments ride along, dated: `unnameableReason` (the original field set could not render §3's own copy variant) and `errorClass` (§4's 'exception class only' datum had no field), plus two §3 clarifications — neither-source-set is the same invalid topology, and `verdict-console.integrity.chains` is a resolver-topology affordance, ignored beside a fixed chain.

**For the #105 author's visibility:** `SinkPosture` gains two additive, defaulted fields — `configuredChain` and `chainResolver`, normalized — so the integrity derivation stays on the posture seam instead of re-reading attest configuration. Every existing posture pin passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)